### PR TITLE
refactor(model): replace traced artifact with public source

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,29 @@ Instant NuRec leverages the following foundational technologies:
 
 ## Pipeline Overview
 
-NCore V4 Sequence ─► Frame Batching ─► Forward Pass (JIT) ─► 3D Gaussians ─► PLY (per-chunk or merged)
+NCore V4 Sequence ─► Frame Batching ─► Eager PyTorch Model ─► 3D Gaussians ─► PLY (per-chunk or merged)
+
+## Model Architecture
+
+The released model is implemented entirely in this repository. Its
+pixel-aligned pipeline consists of:
+
+1. a multi-view vision-transformer encoder with alternating local and
+   global attention;
+2. DPT heads for depth, RGB, normals, semantics, Gaussian parameters,
+   and motion;
+3. a cubemap sky decoder; and
+4. per-camera affine color post-processing.
+
+The reusable attention, embedding, DPT, and camera-encoding layers live
+under [`instant_nurec/model/blocks`](instant_nurec/model/blocks), the
+encoder/decoder definitions under
+[`instant_nurec/model/backbone`](instant_nurec/model/backbone), and the
+complete model composition in
+[`instant_nurec/model/kelvin.py`](instant_nurec/model/kelvin.py).
+Inference runs the PLY-relevant heads directly from source via
+[`static_core.py`](instant_nurec/model/static_core.py); the downloaded
+checkpoint contains weights only.
 
 ## User Guide
 
@@ -85,7 +107,7 @@ image as a generic CUDA environment.
 
 #### Download Model Checkpoints [optional]
 
-> **Note:** `instant_nurec.pt` is auto-downloaded into the Hugging Face
+> **Note:** `pth/instant_nurec_pa_front_1.1.0.pth` is auto-downloaded into the Hugging Face
 > hub cache on the first inference run.
 
 However, you can also manually download the model into a directory of
@@ -100,12 +122,13 @@ hf download nvidia/instant-nurec --local-dir checkpoints
 This places the following file in `checkpoints/`:
 
     checkpoints/
-    └── instant_nurec.pt
+    └── pth/
+        └── instant_nurec_pa_front_1.1.0.pth
 
 Point the pipeline at this local copy by exporting:
 
 ```bash
-export INSTANT_NUREC_FULL_PT="$(pwd)/checkpoints/instant_nurec.pt"
+export INSTANT_NUREC_FULL_PT="$(pwd)/checkpoints/pth/instant_nurec_pa_front_1.1.0.pth"
 ```
 
 </details>
@@ -113,8 +136,8 @@ export INSTANT_NUREC_FULL_PT="$(pwd)/checkpoints/instant_nurec.pt"
 <details>
 <summary><b>Inference</b></summary>
 
-> **Note:** The pretrained model `instant_nurec.pt` (a TorchScript
-> archive) is fetched on first inference run from the Hugging Face
+> **Note:** The pretrained weights `pth/instant_nurec_pa_front_1.1.0.pth` are fetched
+> on first inference run from the Hugging Face
 > repo `nvidia/instant-nurec` and cached locally; subsequent runs read
 > it from the cache. Set `INSTANT_NUREC_FULL_PT` to a local path to
 > override the auto-download.
@@ -218,7 +241,7 @@ Output layout: PLYs only, under `out_dir/<run_id>/ply/<sequence_id>/...ply`.
 
 | variable | purpose |
 | --- | --- |
-| `INSTANT_NUREC_FULL_PT` | Absolute path to a local `instant_nurec.pt`. Takes priority over the auto-downloaded copy. |
+| `INSTANT_NUREC_FULL_PT` | Absolute path to a local `instant_nurec_pa_front_1.1.0.pth`. Takes priority over the auto-downloaded copy. |
 | `INSTANT_NUREC_RUN_ID` | Override the per-run shortuuid; useful when scripting reproducible output paths. |
 
 </details>
@@ -230,13 +253,16 @@ Output layout: PLYs only, under `out_dir/<run_id>/ply/<sequence_id>/...ply`.
 instant-nurec/
 ├── instant_nurec/                  # main package (what ships in the wheel)
 │   ├── cli.py                      # argparse entrypoint
-│   ├── pretrained.py               # auto-downloads instant_nurec.pt from HF on first run
-│   ├── config_schema/              # pydantic schemas + defaults (post-JIT runtime knobs only)
+│   ├── pretrained.py               # auto-downloads weight checkpoint from HF on first run
+│   ├── config_schema/              # pydantic schemas + public architecture defaults
 │   ├── datasets/                   # ncorev4 ingest + cuboid-track helpers
 │   ├── model/
-│   │   ├── __init__.py             # make() — torch.jit.load + JITKelvinAdapter wiring
-│   │   ├── jit_adapter.py          # KelvinInstantNuRec-shaped wrapper around the JIT module
-│   │   └── system.py               # GaussiansInstantNuRecSystem (predict-loop harness)
+│   │   ├── backbone/               # multi-view encoder, DPT decoder, sky decoder
+│   │   ├── blocks/                 # attention, embeddings, DPT, camera encoding
+│   │   ├── kelvin.py               # complete source model composition
+│   │   ├── static_core.py          # eager PLY-reconstruction heads
+│   │   ├── inference.py            # masking + primitive packaging
+│   │   └── system.py               # predict-loop harness
 │   ├── predict/                    # predict loop + PLY export + merge
 │   ├── primitives/                 # KelvinInstantNuRecPrimitive
 │   └── utils/                      # batch / geometry / sensors / nn-extensions

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -2,7 +2,8 @@
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
-| `PretrainedModelError: Could not download nvidia/instant-nurec/instant_nurec.pt` | No network / proxy blocks `huggingface.co` or `*.cloudfront.net` | Set `HTTPS_PROXY`, or copy `instant_nurec.pt` locally and `export INSTANT_NUREC_FULL_PT=/abs/path/to/instant_nurec.pt`. |
+| `PretrainedModelError: Could not download nvidia/instant-nurec/pth/instant_nurec_pa_front_1.1.0.pth` | No network / proxy blocks `huggingface.co` or `*.cloudfront.net` | Set `HTTPS_PROXY`, or copy `instant_nurec_pa_front_1.1.0.pth` locally and set `INSTANT_NUREC_FULL_PT` to its absolute path. |
+| `ModelCheckpointError: ... is a legacy traced-model archive` | `INSTANT_NUREC_FULL_PT` points at the retired artifact | Download `pth/instant_nurec_pa_front_1.1.0.pth` and update the environment variable. |
 | `PretrainedModelError: huggingface_hub is required` | Dependency missing | `uv sync --frozen`. |
 | `ValueError: --ncore-path ...: not an existing JSON/LST file` | Path doesn't resolve | Check the resolved path; `.lst` entries resolve relative to the LST file's dir, not `$PWD`. |
 | `ValueError: --ncore-path must end in .json or .lst` | Wrong suffix | Pass a single `.json` or a `.lst` manifest. |

--- a/instant_nurec/config_schema/dataset.py
+++ b/instant_nurec/config_schema/dataset.py
@@ -42,8 +42,14 @@ class NCoreInstantNuRecCuboidTracksParamsConfig(BaseConfigSchema):
 class AdaptiveSequentialFrameBatchSamplerConfig(BaseConfigSchema):
     """Adaptive sequential frame-batch sampler config.
 
-    ``n_frames_per_sample`` is sourced by the runtime, not via this config.
+    The released checkpoint was trained with 18 input frames per sample.
     """
+
+    n_frames_per_sample: int = Field(
+        default=18,
+        gt=0,
+        description="Number of frames in each model input sample.",
+    )
 
     n_samples_per_sequence: int = Field(
         default=8,
@@ -62,6 +68,21 @@ class AdaptiveSequentialFrameBatchSamplerConfig(BaseConfigSchema):
             "n_frames_per_sample, this sets each chunk's max timespan; tighter values "
             "mean more chunks needed to cover a clip."
         ),
+    )
+
+
+class CameraSubsamplerConfig(BaseConfigSchema):
+    """Image dimensions expected by the released model."""
+
+    frame_width: int = Field(
+        default=784,
+        gt=0,
+        description="Width after aspect-preserving resize and center crop.",
+    )
+    frame_height: int = Field(
+        default=448,
+        gt=0,
+        description="Height after aspect-preserving resize and center crop.",
     )
 
 
@@ -85,6 +106,11 @@ class NCoreInstantNuRecDatasetConfig(BaseConfigSchema):
         "max_angle = min(max_fov / 2, camera_model.max_angle). This will make boundary pixels classified as invalid",
     )
     n_camera_mask_dilation_iterations: int = Field(default=10)
+
+    camera_subsampler: CameraSubsamplerConfig = Field(
+        default_factory=CameraSubsamplerConfig,
+        description="Image resize and crop applied before model inference.",
+    )
 
     context_camera_ids: list[str] = Field(
         default_factory=lambda: ["camera_front_wide_120fov"],

--- a/instant_nurec/config_schema/models.py
+++ b/instant_nurec/config_schema/models.py
@@ -13,24 +13,103 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Public model configs."""
-
 from __future__ import annotations
+
+from typing import List, Literal, Tuple
 
 from instant_nurec.config_schema.base_schema import BaseConfigSchema, Field
 
 
 class PrimitiveExportPreprocessConfig(BaseConfigSchema):
-    """Per-chunk primitive preprocessing applied before export and
-    (optionally) chunk merge."""
+    """
+    Config for per-chunk primitive preprocessing before export (and before merge).
+    Used by preprocess_for_export(); not part of merge logic.
+    """
 
     density_prune_threshold: float = Field(
         default=0.01, description="Density threshold for pruning Gaussians in each chunk."
     )
 
 
+class GaussiansActivationConfig(BaseConfigSchema):
+    """
+    Configuration for activation functions used in neural reconstruction models.
+    """
+
+    # Opacity activation parameters
+    opacity_shift: float = Field(default=-2.0, description="Shift parameter for opacity sigmoid activation")
+
+    # Scale activation parameters
+    scale_shift_log_ratio: float = Field(default=-2.9, description="Shift parameter for scale activation")
+    scale_max: float = Field(default=0.045, description="Maximum scale value")
+    scale_min: float = Field(
+        default=0.0,
+        description="Minimum scale value (clamp applied after exp). Use 0.01 when using 3DGUT renderer to avoid NaN gradients.",
+    )
+
+
+
+
+class KelvinDAv3EncoderConfig(BaseConfigSchema):
+    depth: int = Field(default=12)
+    n_heads: int = Field(default=12)
+    embed_dim: int = Field(default=1536)
+    take_block_indices: List[int] = Field(default_factory=lambda: [5, 7, 9, 11])
+    aa_start_block_idx: int = Field(default=4)
+    checkpointing: Literal["all", "local", "none"] = Field(
+        default="all", description="Whether to checkpoint the encoder"
+    )
+
+
+class KelvinDPTDecoderConfig(BaseConfigSchema):
+    dpt_dim: int = Field(default=128)
+    dpt_reassemble_hidden_dims: List[int] = Field(default_factory=lambda: [96, 192, 384, 768])
+
+    checkpointing: bool = Field(default=True, description="Whether to use checkpointing for the DPT decoder")
+    dpt_chunk_size: int = Field(
+        default=4, description="Chunk size for the DPT decoder. Used for saving memory. -1 to disable."
+    )
+
+    # Motion-related:
+    time_encoding_dim: int = Field(default=256, description="Dimension of the time sinusoidal encoding")
+    motion_depth: int = Field(default=1, description="Depth of the motion head (V-DPM setup is equivalent to 8)")
+
+    def model_post_init(self, __context) -> None:
+        assert self.dpt_dim > 0, "DPT dimension must be positive"
+
+
+class KelvinSkyCubemapDecoderConfig(BaseConfigSchema):
+    cubemap_size: int = Field(default=448)
+    embed_dim: int = Field(default=384)
+    depth: int = Field(default=1)
+    checkpointing: bool = Field(default=True, description="Whether to use checkpointing for the cubemap decoder")
+
+
 class KelvinModelConfig(BaseConfigSchema):
-    """Slim runtime config; only ``export_preprocess`` is user-exposed."""
+    """
+    Configuration for the Kelvin model.
+    """
+
+    track_padding_m: List[float] = Field(
+        default_factory=lambda: [1.0, 1.0, 1.0],
+        description=(
+            "Padding in meters for cuboid track bounding boxes when warping world points for motion supervision "
+            "(x, y, z)."
+        ),
+        min_length=3,
+        max_length=3,
+    )
+
+    scene_rescale: float = Field(default=0.15, description="Rescale scenes for model input and output")
+    sky: KelvinSkyCubemapDecoderConfig = Field(default_factory=KelvinSkyCubemapDecoderConfig)
+
+    patch_shape: Tuple[int, int] = Field(default=(14, 14))
+
+    encoder: KelvinDAv3EncoderConfig = Field(default_factory=KelvinDAv3EncoderConfig)
+    decoder: KelvinDPTDecoderConfig = Field(default_factory=KelvinDPTDecoderConfig)
+    activations: GaussiansActivationConfig = Field(
+        default_factory=GaussiansActivationConfig, description="Activation functions configuration."
+    )
 
     export_preprocess: PrimitiveExportPreprocessConfig = Field(
         default_factory=PrimitiveExportPreprocessConfig,

--- a/instant_nurec/datasets/datamodule.py
+++ b/instant_nurec/datasets/datamodule.py
@@ -21,22 +21,10 @@ from instant_nurec.utils.batch import InstantNuRecDataBatch
 
 
 class InstantNuRecDataModule:
-    """``frame_width`` / ``frame_height`` / ``n_frames_per_sample`` are
-    passed in by the caller; ``instant_nurec.model.make`` is the
-    canonical caller."""
+    """Predict datamodule configured from the public input schema."""
 
-    def __init__(
-        self,
-        instantnurec_config: InstantNuRecConfig,
-        *,
-        frame_width: int,
-        frame_height: int,
-        n_frames_per_sample: int,
-    ) -> None:
+    def __init__(self, instantnurec_config: InstantNuRecConfig) -> None:
         self.instantnurec_config = instantnurec_config
-        self._frame_width = frame_width
-        self._frame_height = frame_height
-        self._n_frames_per_sample = n_frames_per_sample
         self.predict_dataset: NCoreInstantNuRecDataset | None = None
 
     def predict_dataloader(self) -> DataLoader:
@@ -45,9 +33,9 @@ class InstantNuRecDataModule:
 
         self.predict_dataset = NCoreInstantNuRecDataset(
             dataset_config,
-            frame_width=self._frame_width,
-            frame_height=self._frame_height,
-            n_frames_per_sample=self._n_frames_per_sample,
+            frame_width=dataset_config.camera_subsampler.frame_width,
+            frame_height=dataset_config.camera_subsampler.frame_height,
+            n_frames_per_sample=dataset_config.frame_batch_sampler.n_frames_per_sample,
         )
         return DataLoader(
             self.predict_dataset,

--- a/instant_nurec/model/__init__.py
+++ b/instant_nurec/model/__init__.py
@@ -15,15 +15,15 @@
 
 import logging
 import os
+import zipfile
 
 from typing import TYPE_CHECKING, Optional
 
 import torch
 
-from torch import nn
-
 from instant_nurec import pretrained
-from instant_nurec.model.jit_adapter import JITKelvinAdapter
+from instant_nurec.model.inference import KelvinInferenceModel
+from instant_nurec.model.static_core import KelvinStaticCore
 from instant_nurec.model.system import GaussiansInstantNuRecSystem
 
 
@@ -35,11 +35,15 @@ logger = logging.getLogger(__name__)
 
 
 class ModelNotFoundError(RuntimeError):
-    """``instant_nurec.pt`` couldn't be resolved (no HF download, no env override)."""
+    """The pretrained weight checkpoint could not be resolved."""
+
+
+class ModelCheckpointError(RuntimeError):
+    """The resolved file is not a source-model state dictionary."""
 
 
 def _resolve_model_pt_path() -> Optional[str]:
-    """Return the local path to ``instant_nurec.pt`` or ``None`` on failure."""
+    """Return the local path to the weight checkpoint or ``None`` on failure."""
     try:
         return pretrained.download_instant_nurec_pt()
     except pretrained.PretrainedModelError:
@@ -111,55 +115,56 @@ def _preflight_validate_camera_ids(config: "InstantNuRecConfig") -> None:
     )
 
 
+def _load_model_state_dict(path: str) -> dict[str, torch.Tensor]:
+    """Load a weights-only checkpoint and reject legacy traced archives."""
+    if zipfile.is_zipfile(path):
+        with zipfile.ZipFile(path) as archive:
+            if any(name.endswith("/constants.pkl") for name in archive.namelist()):
+                raise ModelCheckpointError(
+                    f"{path} is a legacy traced-model archive. Download "
+                    f"{pretrained.MODEL_FILENAME} or point INSTANT_NUREC_FULL_PT "
+                    "at the released weights-only checkpoint."
+                )
+
+    state_dict = torch.load(path, map_location="cpu", weights_only=True)
+    if not isinstance(state_dict, dict) or not all(
+        isinstance(key, str) and isinstance(value, torch.Tensor)
+        for key, value in state_dict.items()
+    ):
+        raise ModelCheckpointError(
+            f"{path} must contain a plain state dictionary of string keys and tensors."
+        )
+    return state_dict
+
+
 def make(config: "InstantNuRecConfig") -> GaussiansInstantNuRecSystem:
-    """Load ``instant_nurec.pt`` and build a ``GaussiansInstantNuRecSystem``.
+    """Build the eager source model and load its pretrained weights.
 
     Resolution: ``INSTANT_NUREC_FULL_PT`` env var takes priority; otherwise
     the artifact is fetched from Hugging Face.
-
-    The full ``GaussiansInstantNuRecSystem.__init__`` is bypassed via
-    ``__new__`` + manual attribute assignment.
     """
     full_pt_path = _resolve_model_pt_path()
     if not full_pt_path or not os.path.exists(full_pt_path):
         raise ModelNotFoundError(
-            f"instant_nurec.pt not found. Either set INSTANT_NUREC_FULL_PT to a "
+            f"{pretrained.MODEL_FILENAME} not found. Either set INSTANT_NUREC_FULL_PT to a "
             f"local .pt path or ensure {pretrained.MODEL_REPO_ID!r} is reachable."
         )
 
-    from instant_nurec.datasets.datamodule import InstantNuRecDataModule
-
     _preflight_validate_camera_ids(config)
+    logger.info("Loading source-model weights from %s.", full_pt_path)
+    static_core = KelvinStaticCore(config.model)
+    static_core.load_state_dict(_load_model_state_dict(full_pt_path), strict=True)
 
-    logger.info("Loading JIT system from %s.", full_pt_path)
-    torch.jit.set_fusion_strategy([("STATIC", 0), ("DYNAMIC", 0)])
-    jit_module = torch.jit.load(full_pt_path, map_location="cpu")
-    adapter = JITKelvinAdapter(jit_module=jit_module)
-
-    n_context_cams = len(config.dataset.predict.context_camera_ids)
-    if adapter.expected_v % n_context_cams != 0:
-        raise ModelNotFoundError(
-            f"Model expects {adapter.expected_v} input frames; "
-            f"len(context_camera_ids)={n_context_cams} doesn't divide it. "
-            f"Update context_camera_ids so its length divides "
-            f"{adapter.expected_v}."
-        )
-    n_frames_per_sample = adapter.expected_v // n_context_cams
-
-    system: GaussiansInstantNuRecSystem = GaussiansInstantNuRecSystem.__new__(
-        GaussiansInstantNuRecSystem
+    dataset_config = config.dataset.predict
+    assert dataset_config is not None, "dataset.predict must be configured for inference"
+    model = KelvinInferenceModel(
+        static_core,
+        scene_rescale=config.model.scene_rescale,
+        expected_frames=(
+            len(dataset_config.context_camera_ids)
+            * dataset_config.frame_batch_sampler.n_frames_per_sample
+        ),
+        expected_height=dataset_config.camera_subsampler.frame_height,
+        expected_width=dataset_config.camera_subsampler.frame_width,
     )
-    nn.Module.__init__(system)
-    system.out_dir = config.out_dir
-    system.run_id = config.run_id
-    system.config = config.system
-    system.predict_config = config.predict
-    system.export_preprocess = config.model.export_preprocess
-    system.datamodule = InstantNuRecDataModule(
-        config,
-        frame_width=adapter.expected_w,
-        frame_height=adapter.expected_h,
-        n_frames_per_sample=n_frames_per_sample,
-    )
-    system.model = adapter
-    return system
+    return GaussiansInstantNuRecSystem(config, model)

--- a/instant_nurec/model/activations.py
+++ b/instant_nurec/model/activations.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+from dataclasses import dataclass
+from typing import Self
+
+import torch
+import torch.nn as nn
+
+from torch import Tensor
+
+from instant_nurec.config_schema.models import GaussiansActivationConfig
+
+
+class OpacityActivation(nn.Module):
+    """Activation function for opacity values using sigmoid with configurable shift."""
+
+    def __init__(self, config: GaussiansActivationConfig):
+        super().__init__()
+        self.opacity_shift = config.opacity_shift
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Apply sigmoid activation with shift to opacity values."""
+        return torch.sigmoid(x + self.opacity_shift)
+
+
+class ScaleActivation(nn.Module):
+    """Activation function for scale values with exponential activation and clamping."""
+
+    def __init__(self, config: GaussiansActivationConfig):
+        super().__init__()
+        self.scale_shift_log_ratio = config.scale_shift_log_ratio
+        self.scale_max = config.scale_max
+        self.scale_min = config.scale_min
+
+        # Apply a shift so that the scale is scale_max * exp(scale_shift_log_ratio) when x is 0
+        # This is adapted from GS-LRM where the scale_shift is 0.23 and the scale_max is 0.3
+        # GS-LRM uses 0.23 because exp(0.23) = 0.1, i.e., scale_max / 3
+        # When scale_shift_log_ratio = -1, the scale is scale_max / e when x is 0
+        self._scale_shift = math.log(self.scale_max) + self.scale_shift_log_ratio
+
+    def forward(self, x: Tensor, scene_rescale: float = 1.0) -> Tensor:
+        """
+        Apply exponential activation to scale values with clamping.
+        Uses exponential activation to ensure positive scales, with maximum clamping
+        to prevent numerical instability in 3D Gaussian splatting backpropagation.
+        """
+        scale = torch.exp(x + self._scale_shift)
+        scale = scale.clamp(max=self.scale_max)
+        # Default scale_min=0 is a no-op for exp(); use 0.01 with 3DGUT renderer to avoid NaN gradients.
+        scale = scale.clamp(min=self.scale_min)
+        scale = scale / scene_rescale
+        return scale
+
+
+class RotationActivation(nn.Module):
+    """Activation function for rotation quaternions using L2 normalization."""
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Normalize rotation quaternions to unit length."""
+        return torch.nn.functional.normalize(x, dim=-1)
+
+
+class RgbActivation(nn.Module):
+    """Activation function for RGB color values using sigmoid."""
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Apply sigmoid activation to map RGB values to [0, 1] range."""
+        return torch.sigmoid(2 * x)
+
+
+@dataclass(kw_only=True, slots=True)
+class GaussianParams:
+    """
+    Parameters for 3D Gaussian primitives. The decoder always emits
+    activated parameters in the predict pipeline.
+    All the gaussian attributes should have the same prefix shape (if not None),
+    and the rest dimension should be matching the corresponding attributes.
+    - rgb: (*, 3)
+    - scale: (*, 3)
+    - rotation: (*, 4)
+    - opacity: (*, 1)
+    - xyz: (*, 3)
+    """
+
+    rgb: Tensor
+    scale: Tensor
+    rotation: Tensor
+    opacity: Tensor
+    xyz: Tensor
+
+    def __getitem__(self, key: torch.Tensor | slice | int) -> Self:
+        return type(self)(
+            rgb=self.rgb[key],
+            scale=self.scale[key],
+            rotation=self.rotation[key],
+            opacity=self.opacity[key],
+            xyz=self.xyz[key],
+        )
+
+    def flatten(self) -> Self:
+        return type(self)(
+            rgb=self.rgb.reshape(-1, 3),
+            scale=self.scale.reshape(-1, 3),
+            rotation=self.rotation.reshape(-1, 4),
+            opacity=self.opacity.reshape(-1, 1),
+            xyz=self.xyz.reshape(-1, 3),
+        )
+
+    def __post_init__(self):
+        prefix_shape = self.scale.shape[:-1]
+        assert self.rgb.shape[:-1] == prefix_shape, "RGB shape must match prefix shape"
+        assert self.rotation.shape[:-1] == prefix_shape, "Rotation shape must match prefix shape"
+        assert self.opacity.shape[:-1] == prefix_shape, "Opacity shape must match prefix shape"
+        assert self.xyz.shape[:-1] == prefix_shape, "XYZ shape must match prefix shape"
+
+
+class GaussianActivations(nn.Module):
+    """Combined activation functions for Gaussian parameters.
+
+    Predict-only calls the per-attribute submodules directly
+    (`self.gaussian_activations.{rgb,scale,opacity,rotation}` from the
+    decoder); `forward` was unused, so the `xyz` / `distance` activation
+    classes that fed it are gone
+    """
+
+    def __init__(self, config: GaussiansActivationConfig):
+        super().__init__()
+        self.rgb = RgbActivation()
+        self.scale = ScaleActivation(config)
+        self.rotation = RotationActivation()
+        self.opacity = OpacityActivation(config)

--- a/instant_nurec/model/backbone/__init__.py
+++ b/instant_nurec/model/backbone/__init__.py
@@ -12,17 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# pytest auto-loads this before collection so the in-tree package resolves
-# without an editable install.
-
-import sys
-
-from pathlib import Path
-
-
-_REPO_ROOT = Path(__file__).resolve().parent
-
-_repo_root = str(_REPO_ROOT)
-if _repo_root not in sys.path:
-    sys.path.insert(0, _repo_root)

--- a/instant_nurec/model/backbone/base.py
+++ b/instant_nurec/model/backbone/base.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(kw_only=True, slots=True)
+class KelvinLatent(ABC):
+    @property
+    @abstractmethod
+    def batch_size(self) -> int:
+        """
+        Get the batch size of the latent.
+        """
+
+    @property
+    @abstractmethod
+    def device(self) -> torch.device:
+        """
+        Get the device of the latent.
+        """
+
+    @property
+    @abstractmethod
+    def deepest(self) -> torch.Tensor:
+        """
+        Get the deepest feature of the latent.
+        Note this is not necessarily normalized via layer norm.
+        Size will be (B, V, h, w, C)
+        """
+
+
+@dataclass(kw_only=True, slots=True)
+class KelvinMultiscaleFeaturesLatent(KelvinLatent):
+    """
+    Features means transformed queries (i.e. output of the attention block).
+    """
+
+    # (B, V, h, w, C)
+    features: list[torch.Tensor]
+
+    # (B, V, n_cls_tokens, C)
+    cls_tokens: list[torch.Tensor] | None = None
+
+    @property
+    def batch_size(self) -> int:
+        return self.features[0].shape[0]
+
+    @property
+    def device(self) -> torch.device:
+        return self.features[0].device
+
+    @property
+    def deepest(self) -> torch.Tensor:
+        return self.features[-1]

--- a/instant_nurec/model/backbone/decoders.py
+++ b/instant_nurec/model/backbone/decoders.py
@@ -1,0 +1,478 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import math
+
+from dataclasses import dataclass
+
+import torch
+import torch.utils.checkpoint
+
+from einops import rearrange
+from torch import nn
+
+from instant_nurec.datasets.tracks import CuboidTracks, TrackFlags
+from instant_nurec.config_schema.models import (
+    KelvinDAv3EncoderConfig,
+    KelvinDPTDecoderConfig,
+    KelvinModelConfig,
+)
+from instant_nurec.model.activations import GaussianActivations, GaussianParams
+from instant_nurec.model.blocks.aa_vit import AlternateAttentionVisionTransformer
+from instant_nurec.model.blocks.dpt import DPTFullHead
+from instant_nurec.model.blocks.embeds import ContinuousTimeEmbed
+from instant_nurec.model.backbone.base import (
+    KelvinLatent,
+    KelvinMultiscaleFeaturesLatent,
+)
+from instant_nurec.primitives.kelvin_primitive import (
+    KelvinDynamicLayer,
+    KelvinSemanticClass,
+    KelvinStaticLayer,
+)
+from instant_nurec.utils.motion import TimeRemapping, warp_points_with_cuboid_tracks
+from instant_nurec.utils.batch import DataAndRenderingBatch
+from instant_nurec.utils.misc import unpack_optional
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(kw_only=True, slots=True)
+class KelvinDecoderReturn:
+    # Allowing all dynamic layers
+    static_layer: KelvinStaticLayer | None
+    dynamic_layers: list[KelvinDynamicLayer]
+
+
+class KelvinDPTDecoder(nn.Module):
+    """
+    DPT Head (compared to corresponding encoder this is ~5-10% of parameters & FLOPS)
+    """
+
+    class TimeModulatedMotionHead(nn.Module):
+        """
+        Takes in image tokens, source time, and target time, output motion offset from each frame to the target time.
+        """
+
+        def __init__(self, config: KelvinDPTDecoderConfig, model_config: KelvinModelConfig):
+            super().__init__()
+            self.embed_dim = model_config.encoder.embed_dim // 2
+            self.vit = AlternateAttentionVisionTransformer(
+                depth=config.motion_depth,
+                embed_dim=self.embed_dim,  # Match encoder ViT
+                n_heads=model_config.encoder.n_heads,
+                mlp_ratio=4.0,
+                aa_start_block_idx=0,
+                img_pos_embed_shape=518 // model_config.patch_shape[0],
+                n_cls_tokens=0,
+                with_default_global_cls_tokens=False,
+                rope_frequency=100.0,
+                checkpointing="all" if config.checkpointing else "none",
+                n_cls_tokens_aa=2,  # [CLS + SRC-Time]
+                use_modulated_attention=True,
+            )
+            self.source_time_embed = ContinuousTimeEmbed(
+                patch_shape=(1, 1),
+                embed_dim=self.embed_dim,
+                frequency_embedding_dim=config.time_encoding_dim,
+                max_period=500.0,
+            )
+            self.source_time_norm = nn.LayerNorm(self.embed_dim)
+            self.target_time_embed = ContinuousTimeEmbed(
+                patch_shape=(1, 1),
+                embed_dim=self.embed_dim // 2,
+                frequency_embedding_dim=config.time_encoding_dim,
+                max_period=500.0,
+            )
+            self.final_motion_head = DPTFullHead(
+                input_dim=self.embed_dim * 2,
+                reassemble_hidden_dims=tuple(config.dpt_reassemble_hidden_dims),
+                reassemble_dim=config.dpt_dim,
+                output_dim=3 + 3,
+                n_blocks=len(config.dpt_reassemble_hidden_dims),
+                head_before_conv="1-layer",
+                head_after_conv="2-layers",
+                head_after_conv_dim=32,
+                pos_embed_strength=0.1,
+                checkpointing=config.checkpointing,
+            )
+            self.cls_token_norm = nn.LayerNorm(self.embed_dim)
+
+        def _encode_timestamps_us(
+            self, time_remappings: list[TimeRemapping], timestamps_us: torch.Tensor, embed_block: ContinuousTimeEmbed
+        ) -> torch.Tensor:
+            """
+            Encode timestamps into continuous time embeddings.
+            Input:
+                time_remappings: (B, )
+                timestamps_us: (B, V, H, W, 1)
+                embed_block: ContinuousTimeEmbed
+            Output:
+                t_embed: (B, V, C)
+            """
+            B, V, H, W, _ = timestamps_us.shape
+            frame_timestamp_us = timestamps_us[:, :, H // 2, W // 2, 0]
+            t_float = torch.stack(
+                [
+                    time_remappings[bidx].timestamps_us_to_continuous_times(frame_timestamp_us[bidx])
+                    for bidx in range(B)
+                ],
+                dim=0,
+            )  # (B, V)
+            t_embed = embed_block(rearrange(t_float, "B V -> (B V) 1 1"))
+            t_embed = rearrange(t_embed, "(B V) 1 1 C -> B V C", B=B, V=V)
+            return t_embed
+
+        def forward(
+            self,
+            encoded_latent: KelvinMultiscaleFeaturesLatent,
+            output_shape: tuple[int, int],
+            fusion_features: torch.Tensor | None,
+            chunk_size: int,
+            *,  # Force keyword-only for timing to be clear
+            time_remappings: list[TimeRemapping],
+            source_timestamps_us: torch.Tensor,
+            prev_target_timestamps_us: torch.Tensor,
+            next_target_timestamps_us: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            """
+            Input:
+                encoded_latent: (B, V, h, w, C) & (B, V, n_cls_tokens, C)
+                time_remappings: (B, )
+                source_timestamps_us: (B, V, H, W, 1)
+                prev_target_timestamps_us: (B, V, H, W, 1)
+                next_target_timestamps_us: (B, V, H, W, 1)
+            Output:
+                Flow to be added on XYZ to reach prev timestamp: (B, V, H, W, 3)
+                Flow to be added on XYZ to reach next timestamp: (B, V, H, W, 3)
+            """
+            H, W = output_shape
+            B, V, _, _, _ = prev_target_timestamps_us.shape
+            assert prev_target_timestamps_us.shape == (B, V, H, W, 1), (
+                f"Expected (B, V, H, W, 1), got {prev_target_timestamps_us.shape}"
+            )
+            assert prev_target_timestamps_us.shape == next_target_timestamps_us.shape
+
+            prev_target_t_embed = self._encode_timestamps_us(
+                time_remappings, prev_target_timestamps_us, self.target_time_embed
+            )
+            next_target_t_embed = self._encode_timestamps_us(
+                time_remappings, next_target_timestamps_us, self.target_time_embed
+            )
+            source_t_embed = self._encode_timestamps_us(time_remappings, source_timestamps_us, self.source_time_embed)
+            source_t_embed = self.source_time_norm(source_t_embed)
+
+            multiscale_features: list[torch.Tensor] = []
+            for feat, src_cls_token in zip(encoded_latent.features, unpack_optional(encoded_latent.cls_tokens)):
+                with torch.autocast("cuda", enabled=True):
+                    src_cls_token = self.cls_token_norm(src_cls_token[..., self.embed_dim :])
+                    img_feat, _ = self.vit.get_intermediate_features(
+                        # Last the last half (x) and remove local_x part.
+                        img_tokens=feat[..., self.embed_dim :],
+                        block_indices=[len(self.vit.blocks) - 1],
+                        global_cls_token=torch.cat([src_cls_token, source_t_embed.unsqueeze(-2)], dim=-2),
+                        modulation_cond=torch.cat([prev_target_t_embed, next_target_t_embed], dim=-1),
+                    )
+                multiscale_features.append(rearrange(img_feat[-1], "B V h w C -> (B V) h w C"))
+
+            x = self.final_motion_head(
+                multiscale_features, output_shape=output_shape, fusion_features=fusion_features, chunk_size=chunk_size
+            )
+            x = rearrange(x, "(B V) C H W -> B V H W C", B=B, V=V)
+            flow_prev, flow_next = x.split([3, 3], dim=-1)
+            return flow_prev, flow_next
+
+    def __init__(self, config: KelvinDPTDecoderConfig, model_config: KelvinModelConfig):
+        super().__init__()
+        self.config = config
+        embed_dim = model_config.encoder.embed_dim
+        self.n_blocks = 1
+        if isinstance(model_config.encoder, KelvinDAv3EncoderConfig):
+            self.n_blocks = len(model_config.encoder.take_block_indices)
+        assert self.n_blocks == len(config.dpt_reassemble_hidden_dims), "Number of blocks must match"
+
+        # Pre-training heads.
+        # Output depth and depth confidence
+        # or alternatively, world-points and its confidence (need the 5-layers before-conv setting)
+        self.depth_head = DPTFullHead(
+            input_dim=embed_dim,
+            reassemble_hidden_dims=tuple(config.dpt_reassemble_hidden_dims),
+            reassemble_dim=config.dpt_dim,
+            output_dim=1 + 1,
+            n_blocks=self.n_blocks,
+            head_before_conv="1-layer",
+            head_after_conv="2-layers",
+            head_after_conv_dim=32,
+            pos_embed_strength=0.1,
+            checkpointing=config.checkpointing,
+        )
+
+        # Up-scale RGB features for fusion (helps with HD output).
+        rgb_fusion_dim = config.dpt_dim // 2
+        self.rgb_fusion = nn.Sequential(
+            nn.Conv2d(3, rgb_fusion_dim // 4, 3, 1, 1),
+            nn.GELU(),
+            nn.Conv2d(rgb_fusion_dim // 4, rgb_fusion_dim // 2, 3, 1, 1),
+            nn.GELU(),
+            nn.Conv2d(rgb_fusion_dim // 2, rgb_fusion_dim, 3, 1, 1),
+            nn.GELU(),
+        )
+
+        # Context-training heads (RGB, world-normal, semantic-Logits).
+        self.n_semantic_classes = len(KelvinSemanticClass)
+        self.context_head = DPTFullHead(
+            input_dim=embed_dim,
+            reassemble_hidden_dims=tuple(config.dpt_reassemble_hidden_dims),
+            reassemble_dim=config.dpt_dim,
+            output_dim=3 + 3 + self.n_semantic_classes,
+            n_blocks=self.n_blocks,
+            head_before_conv="1-layer",
+            head_after_conv="2-layers",
+            head_after_conv_dim=32,
+            pos_embed_strength=0.1,
+            checkpointing=config.checkpointing,
+        )
+        # Time-conditioned motion-offset head.
+        self.context_motion_head = self.TimeModulatedMotionHead(config, model_config)
+
+        # GS-training heads: predict (scale[3], world-quaternion[4], opacity[1]).
+        gs_output_dim = 3 + 4 + 1
+        self.gaussians_head = DPTFullHead(
+            input_dim=embed_dim,
+            reassemble_hidden_dims=tuple(config.dpt_reassemble_hidden_dims),
+            reassemble_dim=config.dpt_dim,
+            output_dim=gs_output_dim,
+            n_blocks=self.n_blocks,
+            head_before_conv="1-layer",
+            head_after_conv="2-layers",
+            head_after_conv_dim=32,
+            pos_embed_strength=0.1,
+            checkpointing=config.checkpointing,
+        )
+
+        self.cuboids_dims_padding = nn.Buffer(torch.tensor(model_config.track_padding_m, dtype=torch.float32))
+        self.gaussian_activations = GaussianActivations(model_config.activations)
+
+    @torch.autocast("cuda", enabled=False)
+    def decode(
+        self,
+        encoded_latent: KelvinLatent,
+        batches: list[DataAndRenderingBatch],
+        cuboid_tracks: list[CuboidTracks] | None,
+        time_remappings: list[TimeRemapping],
+        scene_rescale: float = 1.0,
+    ) -> list[KelvinDecoderReturn]:
+        """
+        The returned GaussianParams will have shape (B, V, H, W, C)
+        """
+        assert isinstance(encoded_latent, KelvinMultiscaleFeaturesLatent), (
+            "Encoded latent must be a KelvinMultiscaleFeaturesLatent"
+        )
+        renderings = [unpack_optional(unpack_optional(batch.rendering).camera) for batch in batches]
+        data = [unpack_optional(batch.data.camera) for batch in batches]
+
+        img_rgb = torch.stack([unpack_optional(d.labels.rgb) for d in data], dim=0)
+        B, V, H, W, _ = img_rgb.shape
+        img_feats = [rearrange(feat, "B V h w C -> (B V) h w C") for feat in encoded_latent.features]
+
+        # Forward and activate depth
+        depth_and_dconf = self.depth_head(img_feats, output_shape=(H, W), chunk_size=self.config.dpt_chunk_size)
+        depth_and_dconf = rearrange(depth_and_dconf, "(B V) C H W -> B V C H W", B=B, V=V)
+        pred_depth = torch.exp(depth_and_dconf[:, :, 0].unsqueeze(-1) - math.log(scene_rescale))  # (B, V, H, W, 1)
+
+        # Forward and activate context
+        img_rgb = rearrange(img_rgb, "B V H W C -> (B V) C H W")
+        if self.config.checkpointing:
+            rgb_fusion_features = torch.utils.checkpoint.checkpoint(self.rgb_fusion, img_rgb, use_reentrant=False)
+        else:
+            rgb_fusion_features = self.rgb_fusion(img_rgb)
+        context_features_tensor = self.context_head(
+            img_feats, output_shape=(H, W), fusion_features=rgb_fusion_features, chunk_size=self.config.dpt_chunk_size
+        )
+        context_features_tensor = rearrange(context_features_tensor, "(B V) C H W -> B V H W C", B=B, V=V)
+        (
+            context_rgb,
+            context_world_normal,
+            context_semantic_logits,
+        ) = context_features_tensor.split(
+            [3, 3, self.n_semantic_classes],
+            dim=-1,
+        )
+        context_rgb = self.gaussian_activations.rgb(context_rgb)
+        context_world_normal = torch.nn.functional.normalize(context_world_normal, dim=-1)
+
+        # For motion, determine the gap based on the time remappings for now
+        source_timestamps_us = torch.stack(
+            [unpack_optional(renderings[bidx].rays_timestamps_us) for bidx in range(B)], dim=0
+        )
+        frame_gap_timestamps_us = torch.stack(
+            [time_remappings[bidx].frame_gap_timestamps_us for bidx in range(B)], dim=0
+        ).to(img_rgb.device)
+        prev_target_timestamps_us = source_timestamps_us - frame_gap_timestamps_us[..., 0][..., None, None, None]
+        next_target_timestamps_us = source_timestamps_us + frame_gap_timestamps_us[..., 1][..., None, None, None]
+        # This typically gives sharp motion boundary.
+        context_dynamic_mask = torch.argmax(context_semantic_logits, dim=-1) == KelvinSemanticClass.MOVABLE.value
+
+        context_prev_flow, context_next_flow = self.context_motion_head.forward(
+            encoded_latent,
+            output_shape=(H, W),
+            fusion_features=None,
+            chunk_size=self.config.dpt_chunk_size,
+            time_remappings=time_remappings,
+            source_timestamps_us=source_timestamps_us,
+            prev_target_timestamps_us=prev_target_timestamps_us,
+            next_target_timestamps_us=next_target_timestamps_us,
+        )
+        context_prev_flow = context_prev_flow / scene_rescale
+        context_next_flow = context_next_flow / scene_rescale
+
+        # If cuboid tracks are provided, use them instead.
+        if cuboid_tracks is not None:
+            # No need to re-scale points here since both cuboids and pred_depth are already scaled.
+            context_prev_flow_list: list[torch.Tensor] = []
+            context_next_flow_list: list[torch.Tensor] = []
+            context_dynamic_mask_list: list[torch.Tensor] = []
+            for bidx in range(B):
+                dynamic_track = CuboidTracks.Ops.subset_from_mask(
+                    cuboid_tracks[bidx], cuboid_tracks[bidx].tracks_flags & TrackFlags.DYNAMIC != 0
+                )
+                context_xyz = (
+                    pred_depth[bidx].detach()
+                    / renderings[bidx].distance_to_depth_scale
+                    * renderings[bidx].rays[..., 3:]
+                    + renderings[bidx].rays[..., :3]
+                )
+                # Auxiliary association via car-ray-cuboid intersection on movable rays. This serves
+                # as a fallback when point-cuboid intersection misses (e.g. due to inaccurate depth).
+                # Rays with multiple intersections are deemed ambiguous (-1).
+                movable_mask = context_dynamic_mask[bidx]
+                aux_ray_intersection_result = dynamic_track.ray_intersection(
+                    renderings[bidx].rays[..., :3][movable_mask],
+                    renderings[bidx].rays[..., 3:][movable_mask],
+                    source_timestamps_us[bidx, ..., 0][movable_mask],
+                    max_intersections_per_ray=2,
+                )
+                aux_movable_tracks_idx = aux_ray_intersection_result.intersections_tracks_idx[..., 0]
+                aux_movable_tracks_idx[aux_ray_intersection_result.intersections_cnt != 1] = -1
+                aux_tracks_idx = torch.full_like(movable_mask, -1, dtype=aux_movable_tracks_idx.dtype)
+                aux_tracks_idx[movable_mask] = aux_movable_tracks_idx
+
+                dynamic_mask, (prev_world_points, next_world_points) = warp_points_with_cuboid_tracks(
+                    points=context_xyz,
+                    source_timestamps_us=source_timestamps_us[bidx],
+                    target_timestamps_us_list=[prev_target_timestamps_us[bidx], next_target_timestamps_us[bidx]],
+                    dynamic_tracks=dynamic_track,
+                    aux_tracks_idx=aux_tracks_idx,
+                    cuboids_dims_padding=self.cuboids_dims_padding,
+                )
+                context_prev_flow_list.append(prev_world_points - context_xyz)
+                context_next_flow_list.append(next_world_points - context_xyz)
+                context_dynamic_mask_list.append(dynamic_mask)
+
+            # Replace with ones from gt cuboids.
+            context_prev_flow = torch.stack(context_prev_flow_list, dim=0)
+            context_next_flow = torch.stack(context_next_flow_list, dim=0)
+            context_dynamic_mask = torch.stack(context_dynamic_mask_list, dim=0)
+
+        # Forward and activate gaussian parameters
+        gs_params_tensor = self.gaussians_head(
+            img_feats,
+            output_shape=(H, W),
+            fusion_features=None,
+            chunk_size=self.config.dpt_chunk_size,
+        )
+        gs_params_tensor = rearrange(gs_params_tensor, "(B V) C H W -> B V H W C", B=B, V=V)
+        gs_scale, gs_world_quaternion, gs_opacity = gs_params_tensor.split([3, 4, 1], dim=-1)
+        gs_distance = torch.stack([pred_depth[bidx] / renderings[bidx].distance_to_depth_scale for bidx in range(B)])
+
+        gs_scale = self.gaussian_activations.scale(gs_scale, scene_rescale=scene_rescale)
+        gs_valid_mask = KelvinSemanticClass.opacity_mask_from_semantic_probs(
+            torch.softmax(context_semantic_logits, dim=-1)
+        )  # (B, V, H, W, 1)
+        gs_opacity = self.gaussian_activations.opacity(gs_opacity) * (gs_valid_mask > 0.5).float().detach()
+        gs_world_quaternion = self.gaussian_activations.rotation(gs_world_quaternion)
+        gs_xyz = torch.stack(
+            [renderings[bidx].rays[..., :3] + renderings[bidx].rays[..., 3:] * gs_distance[bidx] for bidx in range(B)]
+        )
+
+        gs_params = GaussianParams(
+            rgb=context_rgb,
+            scale=gs_scale,
+            rotation=gs_world_quaternion,
+            opacity=gs_opacity,
+            xyz=gs_xyz,
+        )
+
+        # Build up the primitive
+        return_values: list[KelvinDecoderReturn] = []
+        for bidx in range(B):
+            gs_bidx = gs_params[bidx].flatten()
+            world_points = unpack_optional(gs_bidx.xyz)
+            prev_world_points = world_points + context_prev_flow[bidx].reshape(-1, 3)
+            next_world_points = world_points + context_next_flow[bidx].reshape(-1, 3)
+
+            dynamic_mask = context_dynamic_mask[bidx].reshape(-1)
+            static_mask = torch.where(~dynamic_mask)[0]
+            dynamic_mask = torch.where(dynamic_mask)[0]
+
+            # Derive per-gaussian semantic class from logits (argmax) for the static layer
+            sem_class = torch.argmax(context_semantic_logits[bidx], dim=-1).reshape(-1)  # (V*H*W,)
+            semantic_class_static = sem_class[static_mask].unsqueeze(-1).to(torch.uint8)  # (n_static, 1)
+            normals_static = context_world_normal[bidx].reshape(-1, 3)[static_mask]  # (n_static, 3)
+
+            static_layer = KelvinStaticLayer(
+                positions=world_points[static_mask],
+                rotations=gs_bidx.rotation[static_mask],
+                scales=gs_bidx.scale[static_mask],
+                densities=gs_bidx.opacity[static_mask],
+                rgb=gs_bidx.rgb[static_mask],
+                semantic_class=semantic_class_static,
+                normals=normals_static,
+            )
+
+            dynamic_layer = KelvinDynamicLayer(
+                keyframe_positions=torch.stack(
+                    [
+                        prev_world_points[dynamic_mask],
+                        world_points[dynamic_mask],
+                        next_world_points[dynamic_mask],
+                    ],
+                    dim=1,
+                ),
+                keyframe_timestamps_us=torch.stack(
+                    [
+                        prev_target_timestamps_us[bidx].reshape(-1)[dynamic_mask],
+                        source_timestamps_us[bidx].reshape(-1)[dynamic_mask],
+                        next_target_timestamps_us[bidx].reshape(-1)[dynamic_mask],
+                    ],
+                    dim=1,
+                ),
+                max_densities=gs_bidx.opacity[dynamic_mask],
+                rotations=gs_bidx.rotation[dynamic_mask],
+                scales=gs_bidx.scale[dynamic_mask],
+                rgb=gs_bidx.rgb[dynamic_mask],
+            )
+            # Dynamic layers have a typical smaller timespan so their presence should be guaranteed.
+            dynamic_layer = dynamic_layer.ensure_minimum_density(0.75)
+            return_values.append(
+                KelvinDecoderReturn(
+                    static_layer=static_layer,
+                    dynamic_layers=[dynamic_layer],
+                )
+            )
+
+        return return_values

--- a/instant_nurec/model/backbone/encoders.py
+++ b/instant_nurec/model/backbone/encoders.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from typing import cast
+
+import numpy as np
+import torch
+import torch.nn as _nn
+
+from einops import rearrange
+from torch import nn
+
+from ncore.data import ConcreteCameraModelParametersUnion, OpenCVPinholeCameraModelParameters
+from instant_nurec.config_schema.models import (
+    KelvinDAv3EncoderConfig,
+    KelvinModelConfig,
+)
+from instant_nurec.model.blocks.aa_vit import AlternateAttentionVisionTransformer
+from instant_nurec.model.blocks.dav3 import CameraEncoder
+from instant_nurec.model.blocks.embeds import PatchEmbed
+from instant_nurec.model.backbone.base import (
+    KelvinLatent,
+    KelvinMultiscaleFeaturesLatent,
+)
+from instant_nurec.utils.sensor import to_simple_pinhole_model_parameters
+from instant_nurec.utils.batch import DataAndRenderingBatch
+from instant_nurec.utils.geometry import tquat_to_se3_matrix
+from instant_nurec.utils.misc import unpack_optional
+
+
+class _RGBNormalize(_nn.Module):
+    """Wraps ``torchvision.transforms.v2.Normalize`` for tensors of shape
+    ``(..., C, H, W)``. The mean/std are stored as non-persistent buffers
+    so they don't appear in ``state_dict()``.
+    """
+
+    def __init__(self, mean, std):
+        super().__init__()
+        self.register_buffer("_mean", torch.tensor(mean).view(1, -1, 1, 1), persistent=False)
+        self.register_buffer("_std", torch.tensor(std).view(1, -1, 1, 1), persistent=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        import torchvision.transforms.functional as TF
+
+        return TF.normalize(
+            x,
+            mean=self._mean.flatten().tolist(),
+            std=self._std.flatten().tolist(),
+        )
+
+
+logger = logging.getLogger(__name__)
+
+
+class KelvinDAv3Encoder(nn.Module):
+    def __init__(self, config: KelvinDAv3EncoderConfig, model_config: KelvinModelConfig):
+        super().__init__()
+        self.rgb_normalize = _RGBNormalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
+
+        embed_dim = config.embed_dim // 2
+        patch_shape = model_config.patch_shape
+
+        self.patch_embed_img = PatchEmbed(
+            patch_shape=patch_shape,
+            input_dim=3,
+            embed_dim=embed_dim,
+            norm=False,
+        )
+        self.embed_camera = CameraEncoder(input_dim=9, output_dim=embed_dim)
+
+        self.vit = AlternateAttentionVisionTransformer(
+            depth=config.depth,
+            embed_dim=embed_dim,
+            n_heads=config.n_heads,
+            mlp_ratio=4.0,
+            aa_start_block_idx=config.aa_start_block_idx,
+            img_pos_embed_shape=518 // patch_shape[0],
+            n_cls_tokens=1,
+            with_default_global_cls_tokens=False,
+            rope_frequency=100.0,
+            checkpointing=config.checkpointing,
+        )
+        self.take_block_indices = config.take_block_indices
+
+    @staticmethod
+    def _fov_wh_from_pinhole(pinhole_parameters: OpenCVPinholeCameraModelParameters) -> torch.Tensor:
+        """
+        Computes the fov and width/height from the pinhole parameters.
+        """
+        fov_w = 2 * np.arctan2(pinhole_parameters.resolution[0] / 2, pinhole_parameters.focal_length[0])
+        fov_h = 2 * np.arctan2(pinhole_parameters.resolution[1] / 2, pinhole_parameters.focal_length[1])
+        return torch.tensor([fov_w, fov_h]).float()
+
+    @torch.autocast("cuda", enabled=False)
+    def encode(
+        self,
+        batches: list[DataAndRenderingBatch],
+        scene_rescale: float = 1.0,
+    ) -> KelvinLatent:
+        batch_rgbs: list[torch.Tensor] = []
+        batch_c2ws: list[torch.Tensor] = []
+        batch_fovs: list[torch.Tensor] = []
+
+        for batch in batches:
+            data = unpack_optional(batch.data.camera)
+            rendering = unpack_optional(unpack_optional(batch.rendering).camera)
+
+            rgb = unpack_optional(data.labels.rgb)
+            num_imgs, _, _ = rgb.shape[:3]
+            batch_rgbs.append(rgb)
+
+            # Use end of frame pose for c2w approximation
+            c2w_frame_end = tquat_to_se3_matrix(rendering.poses_tquat_startend[:, 1, :], unbatch=False)
+            c2w_frame_end[:, :3, 3] *= scene_rescale
+            batch_c2ws.append(c2w_frame_end)
+
+            # Use simple pinhole model for fov approximation (TODO: Investigate?)
+            # Since prediction is depth so we should probably hint rays as accurate as possible.
+            pinhole_parameters = [
+                to_simple_pinhole_model_parameters(
+                    cast(ConcreteCameraModelParametersUnion, rendering.sensor_model_parameters[vidx]),
+                )
+                for vidx in range(num_imgs)
+            ]
+            fov_wh = torch.stack([self._fov_wh_from_pinhole(pinhole_parameters[vidx]) for vidx in range(num_imgs)]).to(
+                rgb.device
+            )
+            batch_fovs.append(fov_wh)
+
+        # Assertions about shapes should come with the stack function
+        rgbs_in = torch.stack(batch_rgbs, dim=0)
+        B, V, H, W, _ = rgbs_in.shape
+
+        x = self.patch_embed_img(self.rgb_normalize(rearrange(rgbs_in, "B V H W C -> (B V) C H W")))
+        _, h, w, _ = x.shape  # h and w is the number of patches
+        x = rearrange(x, "(B V) h w C -> B V h w C", B=B, V=V)
+
+        # Compute camera encoding
+        c2w_in, fov_in = torch.stack(batch_c2ws, dim=0), torch.stack(batch_fovs, dim=0)
+        camera_encodings = self.embed_camera.forward(c2w_in, fov_in)
+
+        with torch.autocast("cuda", enabled=True):
+            img_feats, cls_tokens = self.vit.get_intermediate_features(
+                x, block_indices=self.take_block_indices, global_cls_token=camera_encodings.unsqueeze(2)
+            )
+
+        return KelvinMultiscaleFeaturesLatent(features=img_feats, cls_tokens=cls_tokens)

--- a/instant_nurec/model/backbone/sky.py
+++ b/instant_nurec/model/backbone/sky.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import torch.nn as _nn
+
+from einops import rearrange, repeat
+from torch import nn
+
+from instant_nurec.utils.nn_extensions import TypedModuleList
+from instant_nurec.config_schema.models import (
+    KelvinModelConfig,
+    KelvinSkyCubemapDecoderConfig,
+)
+from instant_nurec.model.blocks.attention import CrossAttentionBlock, KVProjector
+from instant_nurec.model.blocks.dpt import DPTFusionHead, DPTReassembleBlock
+from instant_nurec.model.blocks.embeds import PatchEmbed, PositionalEmbed
+from instant_nurec.model.backbone.base import KelvinLatent
+from instant_nurec.utils.cubemap import cubemap_ray_directions
+from instant_nurec.utils.batch import DataAndRenderingBatch
+from instant_nurec.utils.misc import unpack_optional
+
+
+class _RGBNormalize(_nn.Module):
+    """Wraps ``torchvision.transforms.v2.Normalize`` for tensors of shape
+    ``(..., C, H, W)``. The mean/std are stored as non-persistent buffers
+    so they don't appear in ``state_dict()``.
+    """
+
+    def __init__(self, mean, std):
+        super().__init__()
+        self.register_buffer("_mean", torch.tensor(mean).view(1, -1, 1, 1), persistent=False)
+        self.register_buffer("_std", torch.tensor(std).view(1, -1, 1, 1), persistent=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        import torchvision.transforms.functional as TF
+
+        return TF.normalize(
+            x,
+            mean=self._mean.flatten().tolist(),
+            std=self._std.flatten().tolist(),
+        )
+
+
+class CubemapDecoderSky(nn.Module):
+    """
+    Let's start with brute force decoding.
+    """
+
+    class DPTFusionUpsampler(nn.Module):
+        """Upsampler from patches to RGB values."""
+
+        def __init__(self, embed_dim: int, dpt_dim: int, sky_cubemap_size: int):
+            super().__init__()
+            self.reassemble = DPTReassembleBlock(
+                input_dim=embed_dim,
+                output_dim=dpt_dim,
+                n_blocks=4,
+                hidden_dims=(embed_dim // 8, embed_dim // 4, embed_dim // 2, embed_dim),
+                pos_embed_strength=0.1,
+            )
+            self.decode_head = DPTFusionHead(
+                input_dim=dpt_dim,
+                output_dim=3,
+                n_blocks=4,
+                before_conv="1-layer",
+                after_conv="2-layers",
+                after_conv_dim=32,
+                pos_embed_strength=0.1,
+            )
+            self.sky_cubemap_size = sky_cubemap_size
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            x_list = self.reassemble([x] * self.reassemble.n_blocks)
+            return self.decode_head(x_list, output_shape=(self.sky_cubemap_size, self.sky_cubemap_size))
+
+    class RayPatchEmbed(nn.Module):
+        def __init__(self, embed_dim: int, pe_dim: int, patch_shape: tuple[int, int]):
+            super().__init__()
+            assert pe_dim % 3 == 0, "Embedding dimension must be divisible by 3."
+            self.pe_dim = pe_dim
+            self.ray_embed = PatchEmbed(
+                patch_shape=patch_shape,
+                input_dim=pe_dim,
+                embed_dim=embed_dim,
+                norm=True,
+            )
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            rx, ry, rz = x[:, 0], x[:, 1], x[:, 2]
+            rx = PositionalEmbed.get_1d_sincos_nerf_embed(rx, self.pe_dim // 3)
+            ry = PositionalEmbed.get_1d_sincos_nerf_embed(ry, self.pe_dim // 3)
+            rz = PositionalEmbed.get_1d_sincos_nerf_embed(rz, self.pe_dim // 3)
+            x = torch.cat([rx, ry, rz], dim=-1)
+            return self.ray_embed(rearrange(x, "B h w C -> B C h w"))
+
+    def __init__(self, config: KelvinSkyCubemapDecoderConfig, model_config: KelvinModelConfig):
+        super().__init__()
+        self.config = config
+        self.patch_shape = model_config.patch_shape
+        self.sky_cubemap_size = config.cubemap_size
+        assert self.sky_cubemap_size % self.patch_shape[0] == 0, "Sky cubemap size must be divisible by patch shape"
+
+        self.num_latent_heads = model_config.encoder.n_heads
+        self.embed_dim = config.embed_dim
+        self.depth = config.depth
+
+        # Down-project and normalize the backbone features
+        self.feature_transform = nn.Sequential(
+            nn.Linear(model_config.encoder.embed_dim, self.embed_dim),
+            nn.LayerNorm(self.embed_dim),
+        )
+
+        # Skip connections for RGB information
+        self.rgb_normalize = _RGBNormalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
+        self.patch_embed_img = PatchEmbed(
+            patch_shape=self.patch_shape,
+            input_dim=3,
+            embed_dim=self.embed_dim,
+            norm=True,
+        )
+
+        # Ray directional embeddings to build img-cubemap connections
+        self.patch_embed_ray = self.RayPatchEmbed(self.embed_dim, 3 * 16, self.patch_shape)
+
+        # Query rays for cross-attention
+        self.token = nn.Parameter(torch.randn(self.embed_dim) * 0.02)
+        self.query_rays = nn.Buffer(cubemap_ray_directions(self.sky_cubemap_size, device=torch.device("cuda")))
+
+        self.blocks = TypedModuleList(
+            [
+                CrossAttentionBlock(
+                    self.embed_dim,
+                    self.num_latent_heads,
+                    qkv_bias=True,
+                    attn_drop=0.0,
+                    proj_drop=0.0,
+                    qk_norm=True,
+                    mlp_ratio=4.0,
+                    dropout=0.0,
+                    layer_scale_init_values=1.0,
+                    kv_projector=None,
+                )
+                for _ in range(self.depth)
+            ]
+        )
+        self.kv_projector = KVProjector(
+            dim=self.embed_dim,
+            n_heads=self.num_latent_heads,
+            kv_bias=True,
+            k_norm=True,
+        )
+
+        self.upsample = self.DPTFusionUpsampler(self.embed_dim, 128, self.sky_cubemap_size)
+
+    def decode(self, encoded_latent: KelvinLatent, batches: list[DataAndRenderingBatch]) -> torch.Tensor:
+        """
+        Args:
+            encoded_latent: KelvinMultiscaleFeaturesLatent
+            batches: list[DataAndRenderingBatch]
+
+        Returns:
+            torch.Tensor: (B, 6, S, S, 3)
+        """
+        batch_size = encoded_latent.batch_size
+
+        batch_rgbs: list[torch.Tensor] = []
+        batch_rays: list[torch.Tensor] = []
+        for batch in batches:
+            data = unpack_optional(batch.data.camera)
+            rendering = unpack_optional(unpack_optional(batch.rendering).camera)
+            rgb = unpack_optional(data.labels.rgb)
+            batch_rgbs.append(rgb)
+            batch_rays.append(rendering.rays[..., 3:])
+
+        # KV = backbone + RGB + Ray
+        rgbs_in = torch.stack(batch_rgbs, dim=0)
+        rgbs_in = self.patch_embed_img(self.rgb_normalize(rearrange(rgbs_in, "B V H W C -> (B V) C H W")))
+        rgbs_in = rearrange(rgbs_in, "(B V) h w C -> B (V h w) C", B=batch_size)
+        rays_in = torch.stack(batch_rays, dim=0)
+        rays_in = self.patch_embed_ray(rearrange(rays_in, "B V H W C -> (B V) C H W"))
+        rays_in = rearrange(rays_in, "(B V) h w C -> B (V h w) C", B=batch_size)
+        features_in = self.feature_transform(encoded_latent.deepest)  # This contains normalization after proj.
+        features_in = features_in.reshape(batch_size, -1, self.embed_dim) + rgbs_in + rays_in
+        k, v = self.kv_projector(k=features_in, v=features_in)
+
+        # Q = Ray
+        queries = self.patch_embed_ray(rearrange(self.query_rays, "F SH SW C -> F C SH SW"))
+        _, s, _, _ = queries.shape
+        queries = repeat(queries, "F h w C -> B (F h w) C", B=batch_size) + self.token
+
+        for block in self.blocks:
+            queries = block(queries, k, v)
+
+        with torch.autocast("cuda", enabled=False):
+            queries = rearrange(queries.float(), "B (F h w) C -> (B F) h w C", F=6, h=s, w=s)
+            if self.config.checkpointing:
+                queries = torch.utils.checkpoint.checkpoint(self.upsample, queries, use_reentrant=False)
+            else:
+                queries = self.upsample(queries)
+            queries = rearrange(queries, "(B F) C H W -> B F H W C", F=6)
+            queries = torch.clamp(queries, min=-1.0, max=1.0) * 0.5 + 0.5
+
+        return queries

--- a/instant_nurec/model/blocks/__init__.py
+++ b/instant_nurec/model/blocks/__init__.py
@@ -12,17 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# pytest auto-loads this before collection so the in-tree package resolves
-# without an editable install.
-
-import sys
-
-from pathlib import Path
-
-
-_REPO_ROOT = Path(__file__).resolve().parent
-
-_repo_root = str(_REPO_ROOT)
-if _repo_root not in sys.path:
-    sys.path.insert(0, _repo_root)

--- a/instant_nurec/model/blocks/aa_vit.py
+++ b/instant_nurec/model/blocks/aa_vit.py
@@ -1,0 +1,283 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+
+from typing import Callable, Literal, cast
+
+import torch
+import torch.nn as nn
+import torch.utils.checkpoint
+
+from einops import rearrange, repeat
+
+from instant_nurec.model.blocks.attention import AttentionBlock, ModulatedAttentionBlock
+from instant_nurec.model.blocks.embeds import RotaryPositionEmbed2D
+
+
+class AlternateAttentionVisionTransformer(nn.Module):
+    """
+    DINOv2 ViT network with multi-image inputs, based on Alternate attention (AA) blocks.
+    RoPE is added only for the local per-image attention layers.
+
+    Reference:
+    - https://github.com/ByteDance-Seed/Depth-Anything-3/blob/main/src/depth_anything_3/model/dinov2/vision_transformer.py
+    """
+
+    IMG_POS_EMBED_INTERP_OFFSET: float = 0.1
+
+    def __init__(
+        self,
+        depth: int,
+        embed_dim: int,
+        n_heads: int,
+        mlp_ratio: float,
+        aa_start_block_idx: int,
+        img_pos_embed_shape: int,
+        n_cls_tokens: int,
+        with_default_global_cls_tokens: bool,
+        rope_frequency: float,
+        checkpointing: Literal["all", "local", "none"] = "none",
+        n_cls_tokens_aa: int | None = None,
+        use_modulated_attention: bool = False,
+    ):
+        """
+        Args:
+            [Attention-block-related]
+            depth: int, the number of blocks
+            embed_dim: int, the dimension of the embedding
+            n_heads: int, the number of heads
+            mlp_ratio: float, the ratio of the MLP hidden dimension to the input dimension
+            aa_start_block_idx: int, the index of the block to start the AA blocks
+            checkpointing: whether to checkpoint all blocks, only-local blocks (since global blocks recomputation is compute-heavy), or none
+
+            [Embeddings/CLS tokens-related]
+            img_pos_embed_shape: int, the shape of the positional embedding for the image tokens, side length of the square image
+            n_cls_tokens: int, the number of CLS tokens
+            n_cls_tokens_aa: int | None, the number of CLS tokens for the AA blocks, if None, then n_cls_tokens is used
+            with_default_global_cls_tokens: bool, whether to use the default global CLS tokens
+            rope_frequency: float, the frequency of the RoPE
+
+            use_modulated_attention: if True, use ModulatedAttentionBlock for every layer (pass ``modulation_cond`` in
+                ``get_intermediate_features``; last dim must match ``embed_dim``).
+        """
+        super().__init__()
+        self.cls_tokens = nn.Parameter(torch.zeros(n_cls_tokens, embed_dim))
+        self.cls_pos_embed = nn.Parameter(torch.zeros(n_cls_tokens, embed_dim))
+        self.n_cls_tokens = n_cls_tokens
+        self.n_cls_tokens_aa = n_cls_tokens_aa if n_cls_tokens_aa is not None else n_cls_tokens
+
+        self.img_pos_embed_shape = img_pos_embed_shape
+        self.img_pos_embed = nn.Parameter(torch.zeros(img_pos_embed_shape, img_pos_embed_shape, embed_dim))
+
+        # This is the query camera tokens when not provided by the user (ref view + src views)
+        self.default_global_cls_tokens = (
+            nn.Parameter(torch.randn(2, self.n_cls_tokens_aa, embed_dim)) if with_default_global_cls_tokens else None
+        )
+
+        self.aa_start_block_idx = aa_start_block_idx
+        self.use_modulated_attention = use_modulated_attention
+        self.rope = RotaryPositionEmbed2D(frequency=rope_frequency)
+        self.norm_layer = nn.LayerNorm([embed_dim])
+
+        block_cls = ModulatedAttentionBlock if use_modulated_attention else AttentionBlock
+        self.blocks = nn.ModuleList(
+            [
+                block_cls(
+                    input_dim=embed_dim,
+                    n_heads=n_heads,
+                    mlp_ratio=mlp_ratio,
+                    qkv_bias=True,
+                    layer_norm_eps=1e-6,
+                    layer_scale_init_values=1.0,
+                    qk_norm=i >= aa_start_block_idx,
+                    rope=self.rope if i >= aa_start_block_idx else None,
+                )
+                for i in range(depth)
+            ]
+        )
+        self.checkpointing = checkpointing
+
+    def forward(self, _: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError("Please call get_intermediate_layers() instead to obtain intermediate features.")
+
+    def get_interpolated_img_pos_embed(self, height: int, width: int):
+        """
+        Interpolate the positional embedding for the image tokens to the new height and width.
+        Returns:
+            (height, width, embed_dim) tensor
+        """
+        if (height, width) == (self.img_pos_embed_shape, self.img_pos_embed_shape):
+            return self.img_pos_embed
+
+        dtype = self.img_pos_embed.dtype
+        # Historical kludge: add a small number to avoid floating point error in the
+        # interpolation, see https://github.com/facebookresearch/dino/issues/8
+        sh = float(height + self.IMG_POS_EMBED_INTERP_OFFSET) / self.img_pos_embed_shape
+        sw = float(width + self.IMG_POS_EMBED_INTERP_OFFSET) / self.img_pos_embed_shape
+        patch_pos_embed = nn.functional.interpolate(
+            self.img_pos_embed.float().moveaxis(2, 0)[None],  # (H, W, embed_dim) -> (1, embed_dim, H, W)
+            mode="bicubic",
+            antialias=False,
+            scale_factor=(sh, sw),
+        )
+        assert (height, width) == patch_pos_embed.shape[-2:]
+
+        return patch_pos_embed[0].moveaxis(0, 2).to(dtype)
+
+    def get_rope_positions(self, height: int, width: int, device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Returns the rope positions for the global and local attention.
+        Returns:
+            (n_CLS_aa + hw, 2) tensor, the rope positions for the global attention
+            (n_CLS_aa + hw, 2) tensor, the rope positions for the local attention
+        """
+        rope_pos_local = torch.cartesian_prod(
+            torch.arange(height, device=device), torch.arange(width, device=device)
+        ).reshape(-1, 2)
+        rope_pos_global = torch.zeros_like(rope_pos_local)
+
+        # Arange for CLS tokens
+        rope_pos_cls = repeat(
+            torch.arange(self.n_cls_tokens_aa, device=device, dtype=rope_pos_local.dtype), "n -> n D", D=2
+        )
+        rope_pos_global = torch.cat([rope_pos_cls, rope_pos_global + self.n_cls_tokens_aa], dim=0)
+        rope_pos_local = torch.cat([rope_pos_cls, rope_pos_local + self.n_cls_tokens_aa], dim=0)
+
+        return rope_pos_global, rope_pos_local
+
+    def _forward_attention_block(
+        self,
+        block_fn: Callable,
+        block_type: Literal["global", "local"],
+        x: torch.Tensor,
+        rope_positions: torch.Tensor | None,
+        modulation_cond: torch.Tensor | None,
+    ) -> torch.Tensor:
+        if self.checkpointing == "all" or (self.checkpointing == "local" and block_type == "local"):
+            block_fn = functools.partial(torch.utils.checkpoint.checkpoint, block_fn, use_reentrant=False)
+
+        if self.use_modulated_attention:
+            assert modulation_cond is not None, "modulation_cond is required when use_modulated_attention=True"
+            if block_type == "local":
+                modulation_cond = rearrange(modulation_cond, "B V C -> (B V) 1 C")
+            return cast(torch.Tensor, block_fn(x, modulation_cond, rope_positions=rope_positions))
+
+        else:
+            return cast(torch.Tensor, block_fn(x, rope_positions=rope_positions))
+
+    def get_intermediate_features(
+        self,
+        img_tokens: torch.Tensor,
+        block_indices: list[int],
+        global_cls_token: torch.Tensor | None = None,
+        modulation_cond: torch.Tensor | None = None,
+    ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+        """
+        Returns the features from the intermediate blocks specified by block_indices.
+        Args:
+            img_tokens: (B, V, h, w, C) tensor -- already embedded in token space (positional encodings yet to be added)
+            block_indices: list of integers, the indices of the intermediate blocks to return
+            global_cls_token: (B, V, n_CLS_aa, C) tensor, the global CLS token to use for the AA blocks
+            modulation_cond: (B, V, C) per-view conditioning for ModulatedAttentionBlock; required if
+                ``use_modulated_attention`` is True.
+        Returns:
+            img_features: list of (B, V, h, w, C*2) tensors, the image token features
+            cls_features: list of (B, V, n_CLS_aa, C*2) tensors, the CLS token features
+        """
+        if (last_block_idx := len(self.blocks) - 1) not in block_indices:
+            raise ValueError(
+                f"Last block index {last_block_idx} is not in block_indices {block_indices}. Model is not fully forwarded."
+            )
+        if self.use_modulated_attention and modulation_cond is None:
+            raise ValueError("modulation_cond must be provided when use_modulated_attention=True")
+
+        B, V, h, w, C = img_tokens.shape
+
+        # Prepend CLS and add positional embedding to img tokens -> (B, V, n_CLS + h * w, C)
+        x = torch.cat(
+            [
+                repeat(self.cls_tokens + self.cls_pos_embed, "n C -> B V n C", B=B, V=V),
+                rearrange(img_tokens + self.get_interpolated_img_pos_embed(h, w), "B V h w C -> B V (h w) C"),
+            ],
+            dim=-2,
+        )
+
+        # Prepare rope positions to be used
+        global_rope_pos, local_rope_pos = self.get_rope_positions(h, w, device=x.device)
+        global_rope_pos = repeat(global_rope_pos, "N D -> B (V N) D", B=B, V=V)
+        local_rope_pos = repeat(local_rope_pos, "N D -> (B V) N D", B=B, V=V)
+
+        # Forward pass
+        output_img_features: list[torch.Tensor] = []
+        output_cls_features: list[torch.Tensor] = []
+
+        local_x: torch.Tensor | None = None  # Last x after local attention
+        for block_idx, block in enumerate(self.blocks):
+            # For early blocks, perform only local attention without rope
+            if block_idx < self.aa_start_block_idx:
+                x = rearrange(x, "B V N C -> (B V) N C")
+                x = self._forward_attention_block(block.forward, "local", x, None, modulation_cond)
+                x = rearrange(x, "(B V) N C -> B V N C", B=B, V=V)
+                local_x = x
+
+            # At the transition, swap out local CLS token into global CLS token
+            if block_idx == self.aa_start_block_idx:
+                # Fallback to default ones if not provided by the user
+                if global_cls_token is None:
+                    assert self.default_global_cls_tokens is not None, (
+                        "Please enable with_default_global_cls_tokens for the model"
+                    )
+                    first_img_token = self.default_global_cls_tokens[0:1]  # (1, n_CLS_aa, C)
+                    other_img_tokens = self.default_global_cls_tokens[1:2].repeat(V - 1, 1, 1)
+                    global_cls_token = torch.cat([first_img_token, other_img_tokens], dim=0).repeat(
+                        B, 1, 1, 1
+                    )  # (B, V, n_CLS_aa, C)
+
+                x = torch.cat([global_cls_token, x[:, :, self.n_cls_tokens :]], dim=2)
+
+            # For later odd blocks, perform global attention with rope
+            if (block_idx >= self.aa_start_block_idx) and (block_idx % 2 == 1):
+                x = rearrange(x, "B V N C -> B (V N) C")
+                x = self._forward_attention_block(block.forward, "global", x, global_rope_pos, modulation_cond)
+                x = rearrange(x, "B (V N) C -> B V N C", V=V)
+
+            # For later even blocks, perform local attention without rope
+            if (block_idx >= self.aa_start_block_idx) and (block_idx % 2 == 0):
+                x = rearrange(x, "B V N C -> (B V) N C")
+                x = self._forward_attention_block(block.forward, "local", x, local_rope_pos, modulation_cond)
+                x = rearrange(x, "(B V) N C -> B V N C", B=B, V=V)
+                local_x = x
+
+            # Append the output features
+            if block_idx in block_indices:
+                assert local_x is not None
+                output_cls_features.append(
+                    torch.cat(
+                        [local_x[:, :, : self.n_cls_tokens_aa], x[:, :, : self.n_cls_tokens_aa]],
+                        dim=-1,
+                    )
+                )
+                output_img_features.append(
+                    torch.cat(
+                        [
+                            local_x[:, :, self.n_cls_tokens_aa :],
+                            self.norm_layer(x[:, :, self.n_cls_tokens_aa :]),
+                        ],
+                        dim=-1,
+                    ).reshape(B, V, h, w, -1)
+                )
+
+        return output_img_features, output_cls_features

--- a/instant_nurec/model/blocks/attention.py
+++ b/instant_nurec/model/blocks/attention.py
@@ -1,0 +1,464 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Hierarchy of the modules in this file:
+- [AttentionBlock] = [SelfAttention] + FFN/LN
+  - SelfAttention = QKV-Projector + SDPA
+- [CrossAttentionBlock] = [CrossAttention] + [SelfAttention] + FFN/LN
+  - [CrossAttention] = [KVProjector] + Q-Projector + SDPA
+"""
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+
+from einops import rearrange
+
+from instant_nurec.utils.nn_extensions import module_call_type
+from instant_nurec.model.blocks.embeds import RotaryPositionEmbed2D
+from instant_nurec.model.blocks.layers import FeedForwardMLP, LayerScale
+
+
+class SelfAttention(nn.Module):
+    """
+    A Self-attention module that takes tokens as input and performs SDPA operation.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        n_heads: int = 8,
+        qkv_bias: bool = False,
+        attn_drop: float = 0.0,
+        proj_drop: float = 0.0,
+        qk_norm: bool = False,
+        rope: RotaryPositionEmbed2D | None = None,
+    ) -> None:
+        super().__init__()
+        self.n_heads = n_heads
+
+        assert dim % n_heads == 0, f"dim ({dim}) must be divisible by n_heads ({n_heads})"
+        head_dim = dim // n_heads
+
+        self.dim = dim
+        self.scale = head_dim**-0.5
+
+        self.qkv = nn.Linear(dim, 3 * dim, bias=qkv_bias)
+        self.q_norm = nn.LayerNorm(head_dim) if qk_norm else nn.Identity()
+        self.k_norm = nn.LayerNorm(head_dim) if qk_norm else nn.Identity()
+        self.attn_drop = attn_drop
+        self.proj = nn.Linear(dim, dim)
+        self.proj_drop = nn.Dropout(proj_drop)
+        self.rope = rope
+
+    def forward(self, x: torch.Tensor, rope_positions: torch.Tensor | None = None) -> torch.Tensor:
+        """
+        Input:
+            x: (B, N, dim) tensor
+            rope_positions: (B, N, 2) tensor, the rope positions for the input tokens
+        Output:
+            (B, N, dim) tensor
+        """
+        B, N, C = x.shape
+        assert C == self.dim, f"Input tensor has incorrect dimension. Expected {self.dim}, got {C}."
+
+        # Obtain QKV and apply QK normalization
+        qkv = rearrange(self.qkv(x), "B N (QKV H E) -> QKV B H N E", QKV=3, H=self.n_heads)
+        q, k, v = torch.unbind(qkv, dim=0)
+        q = self.q_norm(q)
+        k = self.k_norm(k)
+
+        # Apply RoPE to QK before computing attention
+        if self.rope is not None:
+            assert rope_positions is not None, "Rope positions must be provided"
+            q = self.rope(q, rope_positions)
+            k = self.rope(k, rope_positions)
+
+        # Attention and projection
+        x = torch.nn.functional.scaled_dot_product_attention(q, k, v, scale=self.scale, dropout_p=self.attn_drop)
+        x = rearrange(x, "B H N E -> B N (H E)")
+        x = self.proj(x)
+        x = self.proj_drop(x)
+        return x
+
+    __call__ = module_call_type(forward)
+
+
+class KVProjector(nn.Module):
+    """
+    This module projects the keys and values to the point right before the SDPA operation.
+    This is a sub-operation of both self-attention and cross-attention.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        n_heads: int = 8,
+        kv_bias: bool = False,
+        k_norm: bool = False,
+    ) -> None:
+        super().__init__()
+        self.n_heads = n_heads
+
+        assert dim % n_heads == 0, f"dim ({dim}) must be divisible by n_heads ({n_heads})"
+
+        self.dim = dim
+        self.head_dim = dim // n_heads
+
+        self.to_k = nn.Linear(dim, dim, bias=kv_bias)
+        self.to_v = nn.Linear(dim, dim, bias=kv_bias)
+        self.k_norm = nn.LayerNorm(self.head_dim) if k_norm else nn.Identity()
+
+    def forward(self, k: torch.Tensor, v: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Input:
+            k: (B, N, dim) tensor
+            v: (B, N, dim) tensor
+        Output:
+            projected_k: (B, H, M, head_dim) tensor (pre-projected and rearranged)
+            projected_v: (B, H, M, head_dim) tensor (pre-projected and rearranged)
+            where head_dim = dim / H
+        """
+        k = self.to_k(k)
+        k = rearrange(k, "B N (H C) -> B H N C", H=self.n_heads)
+        k = self.k_norm(k)
+        v = self.to_v(v)
+        v = rearrange(v, "B N (H C) -> B H N C", H=self.n_heads)
+        return k, v
+
+    __call__ = module_call_type(forward)
+
+
+class CrossAttention(nn.Module):
+    """
+    Standard cross-attention block which can optionally skip projecting the keys and values
+    (assuming they already come in pre-projected) for TokenGS architecture.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        n_heads: int = 8,
+        q_bias: bool = False,
+        attn_drop: float = 0.0,
+        proj_drop: float = 0.0,
+        qk_norm: bool = False,
+        kv_projector: KVProjector | None = None,
+    ) -> None:
+        super().__init__()
+        self.n_heads = n_heads
+        self.kv_projector = kv_projector
+
+        # Consistency check
+        if self.kv_projector is not None:
+            assert self.kv_projector.n_heads == self.n_heads, (
+                f"kv_projector must have the same number of heads as the cross-attention, got {self.kv_projector.n_heads} and {self.n_heads}"
+            )
+            assert self.kv_projector.dim == dim, (
+                f"kv_projector must have the same dimension as the cross-attention, got {self.kv_projector.dim} and {dim}"
+            )
+            assert isinstance(self.kv_projector.k_norm, nn.Identity) != qk_norm, (
+                "kv_projector must have the same QK normalization as the cross-attention"
+            )
+
+        assert dim % n_heads == 0, f"dim ({dim}) must be divisible by n_heads ({n_heads})"
+        head_dim = dim // n_heads
+
+        self.dim = dim
+        self.scale = head_dim**-0.5
+
+        self.to_q = nn.Linear(dim, dim, bias=q_bias)
+        self.q_norm = nn.LayerNorm(head_dim) if qk_norm else nn.Identity()
+
+        self.attn_drop = attn_drop
+        self.proj = nn.Linear(dim, dim, bias=q_bias)
+        self.proj_drop = nn.Dropout(proj_drop)
+
+    def _project_q(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+        # k and v should already be projected and rearranged, check
+        head_c = self.dim // self.n_heads
+        assert k.ndim == 4 and k.shape[1] == self.n_heads and k.shape[3] == head_c, (
+            f"k must have 4 dimensions, [B, {self.n_heads}, M, {head_c}], got {k.shape}"
+        )
+        assert v.ndim == 4 and v.shape[1] == self.n_heads and v.shape[3] == head_c, (
+            f"v must have 4 dimensions, [B, {self.n_heads}, M, {head_c}], got {v.shape}"
+        )
+        assert k.shape == v.shape, f"k and v must have the same shape, got {k.shape} and {v.shape}"
+
+        # project q
+        q = rearrange(self.to_q(q), "B N (H C) -> B H N C", H=self.n_heads)
+        return self.q_norm(q)
+
+    def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+        """
+        Input:
+            When kv_projector is not None:
+                q: (B, N, dim) tensor
+                k: (B, M, dim) tensor
+                v: (B, M, dim) tensor
+            When kv_projector is None:
+                q: (B, N, dim) tensor
+                k: (B, H, M, head_dim) tensor (pre-projected and rearranged)
+                v: (B, H, M, head_dim) tensor (pre-projected and rearranged)
+        Output:
+            (B, N, dim) tensor
+        """
+        if self.kv_projector is not None:
+            k, v = self.kv_projector(k, v)
+        q = self._project_q(q, k, v)
+
+        x = torch.nn.functional.scaled_dot_product_attention(q, k, v, scale=self.scale, dropout_p=self.attn_drop)
+        x = rearrange(x, "B H N C -> B N (H C)")
+        x = self.proj(x)
+        x = self.proj_drop(x)
+        return x
+
+    __call__ = module_call_type(forward)
+
+
+class CrossAttentionWithKVProjector(CrossAttention):
+    """
+    Cross-attention module with a built-in KVProjector.
+    It also supports loading the state dict with the legacy format.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        n_heads: int = 8,
+        bias: bool = False,
+        attn_drop: float = 0.0,
+        proj_drop: float = 0.0,
+        norm: bool = False,
+        allow_legacy_state_dict: bool = False,
+    ) -> None:
+        super().__init__(
+            dim=dim,
+            n_heads=n_heads,
+            q_bias=bias,
+            attn_drop=attn_drop,
+            proj_drop=proj_drop,
+            qk_norm=norm,
+            kv_projector=KVProjector(
+                dim=dim,
+                n_heads=n_heads,
+                kv_bias=bias,
+                k_norm=norm,
+            ),
+        )
+
+        # Previously the CrossAttention module has kv_projector's attributes directly put in the module.
+        # To support those we need to load the state dict with the legacy format.
+        if allow_legacy_state_dict:
+            self.register_load_state_dict_pre_hook(self._pre_load_state_dict_hook)
+
+    @staticmethod
+    def _pre_load_state_dict_hook(
+        module: "CrossAttention", state_dict: dict[str, torch.Tensor], prefix: str, *args, **kwargs
+    ) -> None:
+        if module.kv_projector is not None:
+            for key in list(state_dict.keys()):
+                for attr in ["to_k.", "to_v.", "k_norm.", "v_norm."]:
+                    if key.startswith(prefix + attr):
+                        new_key = key.replace(prefix + attr, prefix + "kv_projector." + attr)
+                        state_dict[new_key] = state_dict.pop(key)
+                        break
+
+
+def _maybe_layer_scale(dim: int, init_values: Optional[float]) -> LayerScale | nn.Identity:
+    """Makes a LayerScale module if init_values is not None, otherwise returns an Identity."""
+    return LayerScale(dim, init_values=init_values) if init_values is not None else nn.Identity()
+
+
+class AttentionBlock(nn.Module):
+    """Standard Transformer block: one self-attention application + an MLP."""
+
+    mlp: FeedForwardMLP
+
+    def __init__(
+        self,
+        input_dim: int,
+        n_heads: int,
+        mlp_ratio: float = 4.0,
+        qkv_bias: bool = False,
+        attn_drop: float = 0.0,
+        proj_drop: float = 0.0,
+        layer_norm_eps: float = 1e-5,
+        layer_scale_init_values: Optional[float] = 1e-5,
+        qk_norm: bool = False,
+        rope: RotaryPositionEmbed2D | None = None,
+    ):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(input_dim, eps=layer_norm_eps)
+        self.attn = SelfAttention(
+            input_dim,
+            n_heads=n_heads,
+            qkv_bias=qkv_bias,
+            attn_drop=attn_drop,
+            proj_drop=proj_drop,
+            qk_norm=qk_norm,
+            rope=rope,
+        )
+        self.ls1 = _maybe_layer_scale(input_dim, layer_scale_init_values)
+        self.norm2 = nn.LayerNorm(input_dim, eps=layer_norm_eps)
+        self.mlp = FeedForwardMLP(
+            input_dim=input_dim,
+            hidden_dim=int(input_dim * mlp_ratio),
+            output_dim=input_dim,
+            dropout=proj_drop,
+        )
+        self.ls2 = _maybe_layer_scale(input_dim, layer_scale_init_values)
+
+    def forward(self, x: torch.Tensor, rope_positions: torch.Tensor | None = None) -> torch.Tensor:
+        """
+        Input:
+            x: (B, N, C) tensor
+            rope_positions: (B, N, 2) tensor, the rope positions for the input tokens
+        Output:
+            (B, N, C) tensor
+        """
+        x = x + self.ls1(self.attn(self.norm1(x), rope_positions=rope_positions))
+        x = x + self.ls2(self.mlp(self.norm2(x)))
+        return x
+
+    __call__ = module_call_type(forward)
+
+
+class ModulatedAttentionBlock(AttentionBlock):
+    """
+    AttentionBlock with AdaLN-style conditioning on a separate cond vector (vdpm ConditionalBlock pattern):
+    (1 + scale) * norm1(x) + shift, attention, then gate * attn_out. Uses affine-free norm1; FFN path unchanged.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        *args,
+        modulation_cond_dim: int | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(input_dim, *args, **kwargs)
+
+        # Re-create norm1 without elementwise_affine (it would otherwise cancel the effect of modulation).
+        self.norm1 = nn.LayerNorm(input_dim, eps=self.norm1.eps, elementwise_affine=False)
+
+        # Allow cond_dim to be specified (defaults to input_dim).
+        cond_dim = input_dim if modulation_cond_dim is None else modulation_cond_dim
+        self.modulation = nn.Linear(cond_dim, 3 * input_dim, bias=True)
+
+    def forward(  # type: ignore[override]
+        self,
+        x: torch.Tensor,
+        cond: torch.Tensor,
+        rope_positions: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """
+        Input:
+            x: (B, N, C) tensor
+            cond: (B, n, cond_dim), if n != 1 then N in x is supposed to be equally divided into n segments, and modulated respectively
+            rope_positions: (B, N, 2) tensor, the rope positions for the input tokens
+        Output:
+            (B, N, C) tensor
+        """
+        _, N, _ = x.shape
+        _, n_segments, _ = cond.shape
+        assert N % n_segments == 0, f"N ({N}) must be divisible by n_segments ({n_segments})"
+        segment_size = N // n_segments
+
+        mod: torch.Tensor = self.modulation(torch.nn.functional.silu(cond))
+        shift, scale, gate = mod.unsqueeze(-2).chunk(3, dim=-1)  # (B, n, 1, C) * 3
+
+        def prepare_before_modulation(value: torch.Tensor) -> torch.Tensor:
+            return rearrange(value, "B (n S) C -> B n S C", n=n_segments, S=segment_size)
+
+        def restore_after_modulation(h: torch.Tensor) -> torch.Tensor:
+            return rearrange(h, "B n S C -> B (n S) C")
+
+        h = restore_after_modulation((1.0 + scale) * prepare_before_modulation(self.norm1(x)) + shift)
+        h = self.attn(h, rope_positions=rope_positions)
+        h = restore_after_modulation(gate * prepare_before_modulation(h))
+
+        x = x + self.ls1(h)
+        x = x + self.ls2(self.mlp(self.norm2(x)))
+        return x
+
+    __call__ = module_call_type(forward)  # type: ignore[assignment]
+
+
+class CrossAttentionBlock(nn.Module):
+    """
+    Transformer decoder block with cross-attention, self-attention, and MLP.
+
+    Can be configured to work with either pre-projected keys/values (kv_projection=False)
+    or to project them internally (kv_projection=True).
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        n_heads: int,
+        qkv_bias: bool = True,
+        attn_drop: float = 0.0,
+        proj_drop: float = 0.0,
+        qk_norm: bool = False,
+        mlp_ratio: float = 4.0,
+        dropout: float = 0.0,
+        layer_scale_init_values: Optional[float] = 1e-5,
+        kv_projector: KVProjector | None = None,
+    ):
+        super().__init__()
+
+        self.ca_norm = nn.LayerNorm(dim)
+        self.ca = CrossAttention(
+            dim=dim,
+            n_heads=n_heads,
+            q_bias=qkv_bias,
+            attn_drop=attn_drop,
+            proj_drop=proj_drop,
+            qk_norm=qk_norm,
+            kv_projector=kv_projector,
+        )
+        self.ls_ca = _maybe_layer_scale(dim, layer_scale_init_values)
+
+        self.sa_norm = nn.LayerNorm(dim)
+        self.sa = SelfAttention(dim, n_heads, qkv_bias, attn_drop, proj_drop, qk_norm)
+        self.ls_sa = _maybe_layer_scale(dim, layer_scale_init_values)
+
+        self.mlp_norm = nn.LayerNorm(dim)
+        self.mlp = FeedForwardMLP(dim, int(dim * mlp_ratio), dim, bias=True, dropout=dropout)
+        self.ls_mlp = _maybe_layer_scale(dim, layer_scale_init_values)
+
+    def forward(self, q_tokens: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+        """
+        Input:
+            When kv_projection=False:
+                q_tokens: (B, N, dim) tensor
+                k: (B, H, M, head_dim) tensor (pre-projected and rearranged)
+                v: (B, H, M, head_dim) tensor (pre-projected and rearranged)
+            When kv_projection=True:
+                q_tokens: (B, N, dim) tensor
+                k: (B, M, dim) tensor
+                v: (B, M, dim) tensor
+        Output:
+            (B, N, dim) tensor
+        """
+        q_tokens = q_tokens + self.ls_ca(self.ca(self.ca_norm(q_tokens), k, v))
+        q_tokens = q_tokens + self.ls_sa(self.sa(self.sa_norm(q_tokens)))
+        q_tokens = q_tokens + self.ls_mlp(self.mlp(self.mlp_norm(q_tokens)))
+        return q_tokens
+
+    __call__ = module_call_type(forward)

--- a/instant_nurec/model/blocks/dav3.py
+++ b/instant_nurec/model/blocks/dav3.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import torch.nn as nn
+
+from instant_nurec.model.blocks.attention import AttentionBlock
+from instant_nurec.model.blocks.layers import FeedForwardMLP
+from instant_nurec.utils.geometry import so3_matrix_to_quat
+
+
+class CameraEncoder(nn.Module):
+    """
+    Encode extrinsics and intrinsics to pose encoding (to be used as CLS tokens)
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        depth: int = 4,
+        n_heads: int = 16,
+        mlp_ratio: float = 4.0,
+        layer_scale_init_values: float = 0.01,
+    ):
+        super().__init__()
+        self.pose_branch = FeedForwardMLP(
+            input_dim=input_dim,
+            hidden_dim=output_dim // 2,
+            output_dim=output_dim,
+        )
+        self.token_norm = nn.LayerNorm([output_dim])
+        self.trunk = nn.Sequential(
+            *[
+                AttentionBlock(
+                    input_dim=output_dim,
+                    n_heads=n_heads,
+                    mlp_ratio=mlp_ratio,
+                    qkv_bias=True,
+                    layer_scale_init_values=layer_scale_init_values,
+                )
+                for _ in range(depth)
+            ]
+        )
+        self.trunk_norm = nn.LayerNorm([output_dim])
+
+    # Always operate in high-precision mode
+    @torch.autocast("cuda", enabled=False)
+    def forward(self, T_camera_world: torch.Tensor, fov_wh: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            T_camera_world: (B, V, 4, 4) camera-to-world transformation matrices
+            fov_wh: (B, V, 2) field of view (fov_w, fov_h)
+
+        Returns:
+            pose_tokens: (B, V, D) pose tokens
+        """
+        B, V, _, _ = T_camera_world.shape
+        quaternion = so3_matrix_to_quat(T_camera_world[..., :3, :3].float()).reshape(B, V, 4)
+        quaternion = torch.where(quaternion[..., 3:4] < 0, -quaternion, quaternion)
+        translation = T_camera_world[..., :3, 3].float()
+        pose_encoding = torch.cat([translation, quaternion, fov_wh[..., [1, 0]].float()], dim=-1)  # (B, V, 9)
+        pose_tokens = self.pose_branch(pose_encoding)
+        pose_tokens = self.token_norm(pose_tokens)
+        pose_tokens = self.trunk(pose_tokens)
+        pose_tokens = self.trunk_norm(pose_tokens)
+        return pose_tokens

--- a/instant_nurec/model/blocks/dpt.py
+++ b/instant_nurec/model/blocks/dpt.py
@@ -1,0 +1,359 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+from typing import Literal, cast
+
+import torch
+import torch.nn as nn
+import torch.utils.checkpoint
+
+from einops import rearrange, repeat
+
+from instant_nurec.model.blocks.embeds import NormalizedPositionalEmbed
+from instant_nurec.model.blocks.layers import LayerNorm2d
+from instant_nurec.utils.misc import unpack_optional
+
+
+class DPTReassembleBlock(nn.Module):
+    """
+    Obtain features extracted from intermediate blocks of the ViT backbone, and resize
+    (re-assemble as in DPT https://arxiv.org/pdf/2103.13413 terminology) them to multiple
+    scales for the later fusion stage.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        n_blocks: int,
+        hidden_dims: tuple[int, ...],
+        pos_embed_strength: float | None,
+    ):
+        super().__init__()
+        self.input_dim = input_dim
+        self.output_dim = output_dim
+        self.n_blocks = n_blocks
+        self.hidden_dims = hidden_dims
+
+        assert n_blocks >= 2, "At least 2 blocks are required to re-assemble features."
+        assert len(hidden_dims) == n_blocks, "Number of output dimensions must match number of blocks."
+
+        self.norm_layer = nn.LayerNorm([input_dim])
+        self.proj_layers = nn.ModuleList(
+            [nn.Conv2d(input_dim, hd, kernel_size=1, stride=1, padding=0) for hd in hidden_dims]
+        )
+
+        self.resize_layers = nn.ModuleList()
+        # For the first D-2 blocks, we use conv-transpose to expand their sizes to 4x, 2x...
+        for i in range(self.n_blocks - 2):
+            stride = 2 ** (self.n_blocks - 2 - i)
+            self.resize_layers.append(
+                nn.ConvTranspose2d(hidden_dims[i], hidden_dims[i], kernel_size=stride, stride=stride, padding=0)
+            )
+        self.resize_layers.extend(
+            [
+                # For the 2nd-last block, the size is kept unchanged.
+                nn.Identity(),
+                # For the last block, we downsample to 1/2x with 3x3 conv.
+                nn.Conv2d(hidden_dims[-1], hidden_dims[-1], kernel_size=3, stride=2, padding=1),
+            ]
+        )
+
+        self.output_layers = nn.ModuleList(
+            [nn.Conv2d(hd, output_dim, kernel_size=3, stride=1, padding=1, bias=False) for hd in hidden_dims]
+        )
+
+        self.pos_embed_strength = pos_embed_strength
+        self.pos_embed = NormalizedPositionalEmbed(T=100.0) if pos_embed_strength is not None else None
+
+    def forward(self, x_list: list[torch.Tensor]) -> list[torch.Tensor]:
+        """
+        Args:
+            x_list: list of (B, h, w, input_dim) tensors, the features extracted from the intermediate blocks of the ViT backbone.
+            (from early layers to deeper layers)
+        Returns:
+            list of (B, C', H', W') tensors, the re-assembled features at multiple scales (H' and W' are different for each scale)
+            (from fine to coarse scales)
+        """
+        x_out: list[torch.Tensor] = []
+
+        for x, proj_layer, resize_layer, output_layer in zip(
+            x_list, self.proj_layers, self.resize_layers, self.output_layers, strict=True
+        ):
+            x = self.norm_layer(x)
+            x = proj_layer(rearrange(x, "B h w C -> B C h w"))
+            if self.pos_embed is not None and self.pos_embed_strength is not None:
+                pos_embed = self.pos_embed(rearrange(x, "B C h w -> B h w C")) * self.pos_embed_strength
+                x = x + repeat(pos_embed, "1 h w C -> B C h w", B=x.shape[0])
+            x = resize_layer(x)
+            x = output_layer(x)
+            x_out.append(x)
+
+        return x_out
+
+
+class DPTFusionBlock(nn.Module):
+    """
+    Building block for one level of the fusion head.
+    """
+
+    def __init__(self, input_dim: int, output_dim: int, with_residual: bool):
+        super().__init__()
+        self.input_dim = input_dim
+
+        self.main_block = nn.Sequential(
+            nn.ReLU(),
+            nn.Conv2d(input_dim, input_dim, kernel_size=3, stride=1, padding=1, bias=True),
+            nn.ReLU(),
+            nn.Conv2d(input_dim, input_dim, kernel_size=3, stride=1, padding=1, bias=True),
+        )
+
+        self.res_block: nn.Sequential | None = None
+        if with_residual:
+            self.res_block = nn.Sequential(
+                nn.ReLU(),
+                nn.Conv2d(input_dim, input_dim, kernel_size=3, stride=1, padding=1, bias=True),
+                nn.ReLU(),
+                nn.Conv2d(input_dim, input_dim, kernel_size=3, stride=1, padding=1, bias=True),
+            )
+
+        self.out_conv = nn.Conv2d(input_dim, output_dim, 1, 1, 0, bias=True)
+
+    def forward(
+        self, x: torch.Tensor, x_res: torch.Tensor | None = None, resize: tuple[int, int] | None = None
+    ) -> torch.Tensor:
+        if self.res_block is not None:
+            assert x_res is not None, "Residual connection requires a residual input."
+            x_res = self.res_block(x_res) + x_res
+            x = x + unpack_optional(x_res)
+
+        x = self.main_block(x) + x
+
+        if resize is not None:
+            x = nn.functional.interpolate(x, size=resize, mode="bilinear", align_corners=True)
+
+        x = self.out_conv(x)
+        return x
+
+
+class DPTFusionHead(nn.Module):
+    """
+    Fuses resized features from the re-assemble blocks into a final map required by downstream tasks.
+    One can use multiple heads on top of the features for multiple different tasks.
+    """
+
+    before_conv: nn.Module
+    after_conv: nn.Sequential
+
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        n_blocks: int,
+        before_conv: Literal["1-layer", "5-layers"],
+        after_conv: Literal["2-layers", "2-layers-w-norm"],
+        after_conv_dim: int,
+        pos_embed_strength: float | None,
+    ):
+        super().__init__()
+
+        self.refinement_blocks = nn.ModuleList(
+            [
+                DPTFusionBlock(input_dim, input_dim, with_residual=block_idx < n_blocks - 1)
+                for block_idx in range(n_blocks)
+            ]
+        )
+
+        # Before conv is the layer before resizing to desired final shape.
+        if before_conv == "1-layer":
+            self.before_conv = nn.Conv2d(input_dim, input_dim // 2, kernel_size=3, stride=1, padding=1, bias=True)
+        elif before_conv == "5-layers":
+            self.before_conv = nn.Sequential(
+                nn.Conv2d(input_dim, input_dim // 2, kernel_size=3, stride=1, padding=1, bias=True),
+                nn.Conv2d(input_dim // 2, input_dim, kernel_size=3, stride=1, padding=1, bias=True),
+                nn.Conv2d(input_dim, input_dim // 2, kernel_size=3, stride=1, padding=1, bias=True),
+                nn.Conv2d(input_dim // 2, input_dim, kernel_size=3, stride=1, padding=1, bias=True),
+                nn.Conv2d(input_dim, input_dim // 2, kernel_size=3, stride=1, padding=1, bias=True),
+            )
+        else:
+            raise ValueError(f"Invalid before_conv: {before_conv}")
+
+        # After conv is after resizing.
+        if after_conv == "2-layers":
+            self.after_conv = nn.Sequential(
+                nn.Conv2d(input_dim // 2, after_conv_dim, kernel_size=3, stride=1, padding=1, bias=True),
+                nn.ReLU(inplace=True),
+                nn.Conv2d(after_conv_dim, output_dim, kernel_size=1, stride=1, padding=0, bias=True),
+            )
+        elif after_conv == "2-layers-w-norm":
+            self.after_conv = nn.Sequential(
+                nn.Conv2d(input_dim // 2, after_conv_dim, kernel_size=3, stride=1, padding=1, bias=True),
+                LayerNorm2d(after_conv_dim, eps=1e-5),  # eps to be aligned with nn.LayerNorm
+                nn.ReLU(inplace=True),
+                nn.Conv2d(after_conv_dim, output_dim, kernel_size=1, stride=1, padding=0, bias=True),
+            )
+        else:
+            raise ValueError(f"Invalid after_conv: {after_conv}")
+
+        self.pos_embed_strength = pos_embed_strength
+        self.pos_embed = NormalizedPositionalEmbed(T=100.0) if pos_embed_strength is not None else None
+
+    def zero_init(self, init_values: list[float]):
+        """Initialize so that output is zero regardless of input"""
+        assert isinstance(last_conv := self.after_conv[-1], nn.Conv2d)
+        assert last_conv.bias is not None, "Bias should not be None for zero_init"
+        weight_data = last_conv.weight.data
+        bias_data = last_conv.bias.data
+        assert bias_data.shape[0] == len(init_values), "Bias shape must match init_values length"
+
+        last_conv.reset_parameters()
+        for i, value in enumerate(init_values):
+            if not math.isnan(value):
+                bias_data[i] = value
+                weight_data[i] = 0.0
+
+    def forward(
+        self,
+        x_list: list[torch.Tensor],
+        output_shape: tuple[int, int] | None = None,
+        fusion_features: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """
+        Args:
+            x_list: list of (B, C', H, W) tensors, the resized features from the re-assemble blocks (H and W are different for each scale)
+            (from early/high-res layers to deeper/low-res layers)
+            fusion_features: (B, C' // 2, H, W) tensor, HD features desired to be fused into the final output.
+        Returns:
+            (B, C, H, W) tensor, the final fused feature map.
+        """
+
+        assert len(x_list) == len(self.refinement_blocks), "Number of features and refinement blocks must match."
+
+        # Iterative refinement reversely
+        x = x_list[-1]
+        for block_idx in reversed(range(len(x_list))):
+            # For blocks D-1,...,1, use next block's shape, for block 0, upsample to 2x.
+            if block_idx > 0:
+                resize = (x_list[block_idx - 1].shape[2], x_list[block_idx - 1].shape[3])
+            else:
+                resize = (x.shape[2] * 2, x.shape[3] * 2)
+            # Residual x_input is fed in only for block D-2,...,0.
+            x = self.refinement_blocks[block_idx](
+                x, x_list[block_idx] if block_idx < len(x_list) - 1 else None, resize=resize
+            )
+
+        # Before conv
+        x = self.before_conv(x)
+
+        # Resize + After conv
+        if output_shape is not None:
+            x = nn.functional.interpolate(x, size=output_shape, mode="bilinear", align_corners=True)
+
+        # Fusion of HD features if available
+        if fusion_features is not None:
+            x = x + fusion_features
+
+        if self.pos_embed is not None and self.pos_embed_strength is not None:
+            pos_embed = self.pos_embed(rearrange(x, "B C h w -> B h w C")) * self.pos_embed_strength
+            x = x + repeat(pos_embed, "1 h w C -> B C h w", B=x.shape[0])
+
+        x = self.after_conv(x)
+        return x
+
+
+class DPTFullHead(nn.Module):
+    """
+    A full head implementation that directly takes multi-scale features as input and outputs re-scaled final feature.
+    It is a simple stack of Re-assemble + Fusion head.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        reassemble_hidden_dims: tuple[int, ...],
+        reassemble_dim: int,
+        output_dim: int,
+        n_blocks: int,
+        head_before_conv: Literal["1-layer", "5-layers"],
+        head_after_conv: Literal["2-layers", "2-layers-w-norm"],
+        head_after_conv_dim: int,
+        pos_embed_strength: float | None,
+        checkpointing: bool = False,
+    ):
+        super().__init__()
+        self.reassemble = DPTReassembleBlock(
+            input_dim=input_dim,
+            output_dim=reassemble_dim,
+            n_blocks=n_blocks,
+            hidden_dims=reassemble_hidden_dims,
+            pos_embed_strength=pos_embed_strength,
+        )
+        self.fusion_head = DPTFusionHead(
+            input_dim=reassemble_dim,
+            output_dim=output_dim,
+            n_blocks=n_blocks,
+            before_conv=head_before_conv,
+            after_conv=head_after_conv,
+            after_conv_dim=head_after_conv_dim,
+            pos_embed_strength=pos_embed_strength,
+        )
+        self.checkpointing = checkpointing
+
+    def zero_init(self, init_values: list[float] | None = None):
+        """Initialize so that output is zero regardless of input"""
+        if init_values is not None:
+            self.fusion_head.zero_init(init_values)
+
+    def _raw_forward(
+        self,
+        x_list: list[torch.Tensor],
+        output_shape: tuple[int, int] | None = None,
+        fusion_features: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        x = self.reassemble(x_list)
+        x = self.fusion_head(x, output_shape=output_shape, fusion_features=fusion_features)
+        return x
+
+    def forward(
+        self,
+        x_list: list[torch.Tensor],
+        output_shape: tuple[int, int] | None = None,
+        fusion_features: torch.Tensor | None = None,
+        chunk_size: int | None = None,
+    ) -> torch.Tensor:
+        batch_size: int = x_list[0].shape[0]
+        chunk_size = min(chunk_size, batch_size) if chunk_size is not None and chunk_size > 0 else batch_size
+        n_chunks = math.ceil(batch_size / chunk_size)
+        output_list: list[torch.Tensor] = []
+        for i in range(n_chunks):
+            x_list_chunk = [x[i * chunk_size : (i + 1) * chunk_size] for x in x_list]
+            # Also chunk the fusion features if provided.
+            if fusion_features is not None:
+                fusion_features_chunk = fusion_features[i * chunk_size : (i + 1) * chunk_size]
+            else:
+                fusion_features_chunk = None
+            if self.checkpointing:
+                x = cast(
+                    torch.Tensor,
+                    torch.utils.checkpoint.checkpoint(
+                        self._raw_forward, x_list_chunk, output_shape, fusion_features_chunk, use_reentrant=False
+                    ),
+                )
+            else:
+                x = self._raw_forward(x_list_chunk, output_shape, fusion_features_chunk)
+            output_list.append(x)
+        return torch.cat(output_list, dim=0)

--- a/instant_nurec/model/blocks/embeds.py
+++ b/instant_nurec/model/blocks/embeds.py
@@ -1,0 +1,344 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from einops import rearrange
+
+
+class PatchEmbed(nn.Module):
+    """Split the input into patches, and use a 2D convolution layer to embed the patches."""
+
+    def __init__(
+        self,
+        patch_shape: tuple[int, int],
+        input_dim: int,
+        embed_dim: int,
+        norm: bool = True,
+    ):
+        super().__init__()
+        self.patch_shape = patch_shape
+        self.input_dim = input_dim
+        self.embed_dim = embed_dim
+
+        self.proj = nn.Conv2d(self.input_dim, self.embed_dim, kernel_size=self.patch_shape, stride=self.patch_shape)
+        self.norm = nn.LayerNorm(self.embed_dim) if norm else nn.Identity()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            x: (B, input_dim, H, W) input image tensor
+        Returns:
+            (B, h, w, embed_dim) flattened image features
+        """
+        _, _, H, W = x.shape
+        assert H % (ph := self.patch_shape[0]) == 0, f"Input image height ({H}) is not a multiple of patch size ({ph})."
+        assert W % (pw := self.patch_shape[1]) == 0, f"Input image width ({W}) is not a multiple of patch size ({pw})."
+
+        x = self.proj(x)
+        x = rearrange(x, "B C h w -> B h w C")
+        # Normalization applied to the last dimension (embed_dim)
+        x = self.norm(x)
+        return x
+
+
+class PositionalEmbed(nn.Module):
+    """Adds positional embeddings to the input tensor."""
+
+    @staticmethod
+    def get_2d_sincos_grid_embed(w: torch.Tensor, h: torch.Tensor, embed_dim: int, T: float) -> torch.Tensor:
+        """
+        Args:
+            w: (width,) tensor
+            h: (height,) tensor
+            embed_dim: int
+            T: float, controls the minimum frequency of the embeddings.
+        Returns:
+            (height, width, embed_dim) tensor
+        """
+        height, width = h.shape[0], w.shape[0]
+        grid_w, grid_h = torch.meshgrid(w, h, indexing="xy")  # (H, W)
+        emb_w = PositionalEmbed.get_1d_sincos_pos_embed(grid_w.float().flatten(), embed_dim // 2, T=T)  # (H*W, D//2)
+        emb_h = PositionalEmbed.get_1d_sincos_pos_embed(grid_h.float().flatten(), embed_dim // 2, T=T)  # (H*W, D//2)
+        return torch.cat([emb_w, emb_h], dim=-1).reshape(height, width, embed_dim)  # (H, W, D)
+
+    @staticmethod
+    def get_1d_sincos_pos_embed(x: torch.Tensor, embed_dim: int, T: float) -> torch.Tensor:
+        """
+        This is the same as the timestep embedding in openai model:
+            Embedding(x, l) = [sin(x * T^(-l/L)), cos(x * T^(-l/L))], l=0..L-1
+        Args:
+            x: (...,) tensor
+            embed_dim: int
+            T: float, controls the minimum frequency of the embeddings.
+                If x are input pixel locations, T is recommended to be 10000.0.
+                If x are input view indices, T is recommended to be 32.0.
+        Returns:
+            (..., D) tensor
+        """
+        assert embed_dim % 2 == 0, "Embedding dimension must be even."
+        omega = torch.arange(embed_dim // 2, dtype=x.dtype, device=x.device) / (embed_dim // 2)
+        omega = torch.exp(-math.log(T) * omega)
+        x = x[..., None] * omega  # (..., D//2)
+        x = torch.cat([torch.sin(x), torch.cos(x)], dim=-1)  # (..., D)
+        return x
+
+    @staticmethod
+    def get_1d_sincos_nerf_embed(x: torch.Tensor, embed_dim: int) -> torch.Tensor:
+        """
+        This is the same as the positional embedding in NeRF (x should be normalized to [-1, 1]).
+            Embedding(x, l) = [sin(x * 2^l * pi), cos(x * 2^l * pi)], l=0..L-1
+        Args:
+            x: (..., D) tensor
+            embed_dim: int
+        Returns:
+            (..., D) tensor
+        """
+        return PositionalEmbed.get_1d_sincos_pos_embed(x * math.pi, embed_dim, 2 ** (-embed_dim / 2))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Compute positional embedding for x (you have to add it back to x yourself!)
+        """
+        raise NotImplementedError("Please use child-classes instead.")
+
+
+
+class NormalizedPositionalEmbed(PositionalEmbed):
+    """
+    Normalized positional embedding as used in MoGE DPT.
+    It first normalizes the uv coordinates into 0-1 normalized space before embed them.
+
+    The grid spans horizontally and vertically according to an aspect ratio,
+    ensuring the top-left corner is at (-x_span, -y_span) and the bottom-right
+    corner is at (x_span, y_span), normalized by the diagonal of the plane.
+    """
+
+    def __init__(self, T: float):
+        super().__init__()
+
+        self.T = T
+
+    @staticmethod
+    def get_normalized_uv(
+        w: int, h: int, device: torch.device, dtype: torch.dtype
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # Compute normalized spans for X and Y
+        aspect_ratio: float = w / h
+        diag_factor = (aspect_ratio**2 + 1.0) ** 0.5
+        span_x = aspect_ratio / diag_factor
+        span_y = 1.0 / diag_factor
+
+        # Establish the linspace boundaries
+        left_x = -span_x * (w - 1) / w
+        right_x = span_x * (w - 1) / w
+        top_y = -span_y * (h - 1) / h
+        bottom_y = span_y * (h - 1) / h
+
+        # Generate 1D coordinates
+        x_coords = torch.linspace(left_x, right_x, steps=w, dtype=dtype, device=device)
+        y_coords = torch.linspace(top_y, bottom_y, steps=h, dtype=dtype, device=device)
+        return x_coords, y_coords
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            x: (B, h, w, embed_dim) input image features
+        Returns:
+            (1, h, w, embed_dim) image features with positional embeddings
+        """
+        _, emb_height, emb_width, embed_dim = x.shape
+        return self.forward_shape_only(emb_height, emb_width, embed_dim, x.device, x.dtype)
+
+    def forward_shape_only(
+        self,
+        emb_height: int,
+        emb_width: int,
+        embed_dim: int,
+        device: torch.device = torch.device("cpu"),
+        dtype: torch.dtype = torch.float32,
+    ) -> torch.Tensor:
+        """
+        Returns:
+            (1, h, w, embed_dim) image features with positional embeddings
+        """
+        x_coords, y_coords = self.get_normalized_uv(emb_width, emb_height, device, dtype)
+        embed = self.get_2d_sincos_grid_embed(x_coords, y_coords, embed_dim, self.T)
+        return embed[None]
+
+
+class ContinuousTimeEmbed(nn.Module):
+    """
+    Embeds scalar timesteps (preferrably within range 0-1) into vector representations.
+    Reference: https://github.com/openai/glide-text2im/blob/main/glide_text2im/nn.py
+    """
+
+    def __init__(
+        self, patch_shape: tuple[int, int], embed_dim: int, frequency_embedding_dim: int, max_period: float = 10000.0
+    ):
+        super().__init__()
+        self.patch_shape = patch_shape
+        self.mlp = nn.Sequential(
+            nn.Linear(frequency_embedding_dim, embed_dim, bias=True),
+            nn.SiLU(inplace=True),
+            nn.Linear(embed_dim, embed_dim, bias=True),
+        )
+        self.frequency_embedding_dim = frequency_embedding_dim
+        self.max_period = max_period
+
+    @classmethod
+    def timestep_embedding(cls, t: torch.Tensor, dim: int, max_period: float) -> torch.Tensor:
+        """
+        Create sinusoidal timestep embeddings.
+
+        Args:
+            t: (N,) 1-D Tensor of timestep, one per batch element. These may be fractional.
+            dim: int, the dimension of the output.
+            max_period: float, controls the minimum frequency of the embeddings.
+
+        Returns:
+            torch.Tensor: (N, D) Tensor of time embeddings.
+        """
+        half = dim // 2
+        freqs = torch.exp(-math.log(max_period) * torch.arange(start=0, end=half, dtype=torch.float32) / half).to(
+            device=t.device
+        )
+        args = t[:, None].float() * freqs[None]
+        embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        if dim % 2:
+            embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], dim=-1)
+        return embedding
+
+    def zero_init(self):
+        """Initialize so that output is zero regardless of input"""
+        if isinstance(last_linear := self.mlp[-1], nn.Linear):
+            last_linear.weight.data.zero_()
+            last_linear.bias.data.zero_()
+
+    def forward(self, t: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            t: (B, H, W) 3-D Tensor of continuous time.
+        Returns:
+            torch.Tensor: (B, h, w, embed_dim) Tensor of time embeddings.
+        """
+        B, H, W = t.shape
+        assert H % (ph := self.patch_shape[0]) == 0, f"Input image height ({H}) is not a multiple of patch size ({ph})."
+        assert W % (pw := self.patch_shape[1]) == 0, f"Input image width ({W}) is not a multiple of patch size ({pw})."
+
+        # Compute mean of the patches
+        t = nn.functional.avg_pool2d(t[:, None], kernel_size=self.patch_shape, stride=self.patch_shape)
+        _, _, h, w = t.shape
+
+        t_freq = self.timestep_embedding(t.view(-1), self.frequency_embedding_dim, max_period=self.max_period)
+        t_emb = self.mlp(t_freq)
+        return rearrange(t_emb, "(B h w) D -> B h w D", h=h, w=w, B=B)
+
+
+class RotaryPositionEmbed2D(nn.Module):
+    """
+    2D Rotary Position Embedding implementation. This module applies rotary position
+    embeddings to input tokens based on their 2D spatial positions.
+    It handles the position-dependent rotation of features separately for vertical
+    and horizontal dimensions.
+    """
+
+    def __init__(self, frequency: float = 100.0, scaling_factor: float = 1.0):
+        """
+        Args:
+            frequency: Base frequency for the position embeddings.
+            scaling_factor: Scaling factor for frequency computation.
+        """
+        super().__init__()
+        self.base_frequency = frequency
+        self.scaling_factor = scaling_factor
+
+    def _compute_frequency_components(
+        self, dim: int, seq_len: int, device: torch.device, dtype: torch.dtype
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Computes frequency components for rotary embeddings.
+
+        Args:
+            dim: Feature dimension (must be even).
+            seq_len: Maximum sequence length.
+
+        Returns:
+            Tuple of (cosine, sine) tensors for frequency components.
+        """
+        # Compute frequency bands and generate position-dependent frequencies
+        exponents = torch.arange(0, dim, 2, device=device).float() / dim
+        inv_freq = 1.0 / (self.base_frequency**exponents)
+        positions = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+        angles = torch.einsum("i,j->ij", positions, inv_freq)
+
+        # Compute and cache frequency components
+        angles = angles.to(dtype)
+        angles = torch.cat((angles, angles), dim=-1)
+        cos_components = angles.cos().to(dtype)
+        sin_components = angles.sin().to(dtype)
+
+        return cos_components, sin_components
+
+    def _apply_1d_rope(
+        self, tokens: torch.Tensor, positions: torch.Tensor, cos_comp: torch.Tensor, sin_comp: torch.Tensor
+    ) -> torch.Tensor:
+        # Helper function to rotate features
+        def _rotate_features(x: torch.Tensor) -> torch.Tensor:
+            feature_dim = x.shape[-1]
+            x1, x2 = x[..., : feature_dim // 2], x[..., feature_dim // 2 :]
+            return torch.cat((-x2, x1), dim=-1)
+
+        # Embed positions with frequency components
+        cos = F.embedding(positions, cos_comp)[:, None, :, :]
+        sin = F.embedding(positions, sin_comp)[:, None, :, :]
+        # Apply rotation
+        return (tokens * cos) + (_rotate_features(tokens) * sin)
+
+    def forward(self, tokens: torch.Tensor, positions: torch.Tensor) -> torch.Tensor:
+        """
+        Applies 2D rotary position embeddings to input tokens.
+
+        Args:
+            tokens: Input tensor of shape (B, H, N, dim).
+                   The dimension (dim) must be divisible by 4.
+            positions: Position tensor of shape (B, N, 2) containing
+                      the y and x coordinates for each token.
+
+        Returns:
+            (B, H, N, dim) tensor, the tokens with applied 2D rotary position embeddings.
+        """
+        assert tokens.size(-1) % 4 == 0, "Feature dimension must be divisible by 4."
+        assert positions.ndim == 3 and positions.shape[-1] == 2, "Positions must have shape (B, N, 2)."
+
+        # Compute feature dimension for each spatial direction
+        feature_dim = tokens.size(-1) // 2
+
+        # Get frequency components
+        max_position = int(positions.max()) + 1
+        cos_comp, sin_comp = self._compute_frequency_components(feature_dim, max_position, tokens.device, tokens.dtype)
+
+        # Split features for vertical and horizontal processing
+        vertical_features, horizontal_features = tokens.chunk(2, dim=-1)
+
+        # Apply RoPE separately for each dimension
+        vertical_features = self._apply_1d_rope(vertical_features, positions[..., 0], cos_comp, sin_comp)
+        horizontal_features = self._apply_1d_rope(horizontal_features, positions[..., 1], cos_comp, sin_comp)
+
+        # Combine processed features
+        return torch.cat((vertical_features, horizontal_features), dim=-1)

--- a/instant_nurec/model/blocks/layers.py
+++ b/instant_nurec/model/blocks/layers.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import torch.nn as nn
+
+
+class LayerScale(nn.Module):
+    def __init__(self, dim: int, init_values: float = 1e-5, inplace: bool = False) -> None:
+        super().__init__()
+        self.inplace = inplace
+        self.gamma = nn.Parameter(init_values * torch.ones(dim))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x.mul_(self.gamma) if self.inplace else x * self.gamma
+
+
+class FeedForwardMLP(nn.Module):
+    """MLP as used in Vision Transformer, MLP-Mixer and related networks."""
+
+    def __init__(self, input_dim: int, hidden_dim: int, output_dim: int, bias: bool = True, dropout: float = 0.0):
+        super().__init__()
+        self.fc1 = nn.Linear(input_dim, hidden_dim, bias=bias)
+        self.act = nn.GELU()
+        self.drop1 = nn.Dropout(dropout)
+        self.fc2 = nn.Linear(hidden_dim, output_dim, bias=bias)
+        self.drop2 = nn.Dropout(dropout)
+
+    def zero_init(self):
+        """Initialize so that output is zero regardless of input"""
+        self.fc2.weight.data.zero_()
+        if self.fc2.bias is not None:
+            self.fc2.bias.data.zero_()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Input:
+            x: (..., dim) tensor
+        Output:
+            (..., dim) tensor
+        """
+        x = self.fc1(x)
+        x = self.act(x)
+        x = self.drop1(x)
+        x = self.fc2(x)
+        x = self.drop2(x)
+        return x
+
+
+class LayerNorm2d(nn.Module):
+    """
+    Perform Layer Norm on 2D input tensor.
+    """
+
+    def __init__(self, n_dim: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(n_dim))
+        self.bias = nn.Parameter(torch.zeros(n_dim))
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            x: (B, C, H, W) tensor
+        Returns:
+            (B, C, H, W) tensor
+        """
+        u = x.mean(1, keepdim=True)
+        s = (x - u).pow(2).mean(1, keepdim=True)
+        x = (x - u) / torch.sqrt(s + self.eps)
+        x = self.weight[:, None, None] * x + self.bias[:, None, None]
+        return x

--- a/instant_nurec/model/inference.py
+++ b/instant_nurec/model/inference.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""``JITKelvinAdapter``: thin Python wrapper around the loaded model.
+"""Public eager-mode InstantNuRec inference model.
 
 Applies semantic + optional cuboid-track-based dynamic-mask refinement
 to the per-pixel outputs and packages them into
@@ -32,6 +32,7 @@ import torch
 from torch import nn
 
 from instant_nurec.datasets.tracks import CuboidTracks
+from instant_nurec.model.static_core import KelvinStaticCore
 from instant_nurec.primitives.kelvin_primitive import (
     KelvinDynamicLayer,
     KelvinInstantNuRecPrimitive,
@@ -53,24 +54,36 @@ from instant_nurec.utils.types import TrackFlags
 _PLACEHOLDER_SKY_CUBEMAP_SIZE = 16
 
 
-class JITKelvinAdapter(nn.Module):
-    """Adapter wrapping a ``torch.jit.load`` output.
+class KelvinInferenceModel(nn.Module):
+    """Wrap the eager model core and package its tensor outputs.
 
     Args:
-        jit_module: Output of ``torch.jit.load(instant_nurec.pt)``.
+        static_core: Source-defined encoder, decoder, and post-processing core.
+        scene_rescale: Scale factor used by the released model.
+        expected_frames: Number of input frames per inference sample.
+        expected_height: Input image height after preprocessing.
+        expected_width: Input image width after preprocessing.
     """
 
-    def __init__(self, jit_module: torch.jit.ScriptModule):
+    def __init__(
+        self,
+        static_core: KelvinStaticCore,
+        *,
+        scene_rescale: float,
+        expected_frames: int,
+        expected_height: int,
+        expected_width: int,
+    ) -> None:
         super().__init__()
-        self.jit_module = jit_module
-        self.scene_rescale = float(jit_module.static_core.scene_rescale_buffer.item())
-        self.expected_b = int(jit_module.static_core.expected_b.item())
-        self.expected_v = int(jit_module.static_core.expected_v.item())
-        self.expected_h = int(jit_module.static_core.expected_h.item())
-        self.expected_w = int(jit_module.static_core.expected_w.item())
+        self.static_core = static_core
+        self.scene_rescale = scene_rescale
+        self.expected_b = 1
+        self.expected_v = expected_frames
+        self.expected_h = expected_height
+        self.expected_w = expected_width
         self.register_buffer(
             "cuboids_dims_padding",
-            jit_module.static_core.decoder.cuboids_dims_padding.detach().clone(),
+            static_core.decoder.cuboids_dims_padding.detach().clone(),
             persistent=False,
         )
 
@@ -93,7 +106,7 @@ class JITKelvinAdapter(nn.Module):
         return context
 
     # ------------------------------------------------------------------
-    # reconstruct: tensor-extraction adapter
+    # reconstruct: tensor extraction and primitive packaging
     # ------------------------------------------------------------------
 
     def _extract_tensors(self, batch: DataAndRenderingBatch):
@@ -221,7 +234,7 @@ class JITKelvinAdapter(nn.Module):
                 semantic_argmax,
                 normals,
                 affine,
-            ) = self.jit_module(*tensors)
+            ) = self.static_core(*tensors)
 
             rendering_camera = unpack_optional(unpack_optional(batch.rendering).camera)
             cuboid_tracks_b = cuboid_tracks[bidx] if cuboid_tracks is not None else None
@@ -253,4 +266,3 @@ class JITKelvinAdapter(nn.Module):
                 )
             )
         return primitives
-

--- a/instant_nurec/model/kelvin.py
+++ b/instant_nurec/model/kelvin.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copyright (c) 2024-2026 NVIDIA CORPORATION.  All rights reserved.
+
+from __future__ import annotations
+
+import logging
+
+import torch
+import torch.nn as nn
+
+from einops import rearrange
+
+from instant_nurec.datasets.tracks import CuboidTracks
+from instant_nurec.config_schema.models import KelvinModelConfig
+from instant_nurec.model.backbone.decoders import KelvinDPTDecoder
+from instant_nurec.model.backbone.encoders import KelvinDAv3Encoder
+from instant_nurec.model.backbone.sky import CubemapDecoderSky
+from instant_nurec.model.post_processing import PerCameraAffinePostProcessing
+from instant_nurec.primitives.kelvin_primitive import KelvinInstantNuRecPrimitive
+from instant_nurec.utils.motion import TimeRemapping
+from instant_nurec.utils.batch import DataAndRenderingBatch
+from instant_nurec.utils.misc import unpack_optional
+
+
+logger = logging.getLogger(__name__)
+
+
+class KelvinInstantNuRec(nn.Module):
+    """
+    Please refer to the [Kelvin Model](../docs/KELVIN_MODEL.md) for more details.
+    """
+
+    config: KelvinModelConfig
+
+    def __init__(self, config: KelvinModelConfig):
+        super().__init__()
+        self.config = config
+        self.encoder = KelvinDAv3Encoder(config.encoder, config)
+        self.decoder = KelvinDPTDecoder(config.decoder, config)
+        self.sky = CubemapDecoderSky(config.sky, config)
+        self.post_processing = PerCameraAffinePostProcessing(
+            embed_dim=config.encoder.embed_dim, init_token_scale=0.02
+        )
+        self.scene_rescale = self.config.scene_rescale
+        self.cuboids_dims_padding = torch.nn.Buffer(torch.tensor(self.config.track_padding_m, dtype=torch.float32))
+
+    def prepare_context(
+        self,
+        context: list[DataAndRenderingBatch],
+    ) -> list[DataAndRenderingBatch]:
+        return context
+
+    @staticmethod
+    def _grab_metainfo(
+        context: list[DataAndRenderingBatch],
+    ) -> tuple[int, int, torch.Tensor, list[TimeRemapping]]:
+        first_context_data = unpack_optional(context[0].data.camera)
+        num_imgs = first_context_data.b
+        num_views = len(set([meta.unique_sensor_idx for meta in first_context_data.meta]))
+
+        batch_camera_idxs: list[torch.Tensor] = []
+        time_remappings: list[TimeRemapping] = []
+        for batch in context:
+            context_data = unpack_optional(batch.data.camera)
+            unique_sensor_idx = torch.tensor([meta.unique_sensor_idx for meta in context_data.meta], dtype=torch.int64)
+            num_views_bidx = len(unique_sensor_idx.unique())
+            assert context_data.b == num_imgs, "All context batches must have the same number of images"
+            assert num_views_bidx == num_views, "All context batches must have the same number of views"
+            batch_camera_idxs.append(unique_sensor_idx)
+
+            rendering = unpack_optional(batch.rendering)
+            camera = unpack_optional(rendering.camera)
+            time_remappings.append(
+                TimeRemapping.from_timestamps_startend_us(camera.timestamps_startend_us_cpu, unique_sensor_idx)
+            )
+
+        return num_imgs, num_views, torch.stack(batch_camera_idxs, dim=0), time_remappings
+
+    def _compute_affine_matrix(
+        self,
+        encoded_latent,
+        camera_idxs: torch.Tensor,
+    ) -> torch.Tensor:
+        # This affine transform is also used by the static PLY inference path.
+        _, affine_latents = self.post_processing.transform_tokens(
+            rearrange(encoded_latent.deepest, "B V h w C -> B (V h w) C"), camera_idxs
+        )
+        affine_matrix_3, affine_bias = self.post_processing.decode_affine(affine_latents)
+        return torch.cat([affine_matrix_3, affine_bias[..., None]], dim=-1)
+
+    @staticmethod
+    def _build_primitives(
+        context: list[DataAndRenderingBatch],
+        decoder_returns,
+        sky_cubemaps: torch.Tensor,
+        affine_matrix: torch.Tensor,
+    ) -> list[KelvinInstantNuRecPrimitive]:
+        primitives: list[KelvinInstantNuRecPrimitive] = []
+        for bidx in range(len(context)):
+            primitive = KelvinInstantNuRecPrimitive(
+                static_layer=unpack_optional(decoder_returns[bidx].static_layer),
+                dynamic_layers=decoder_returns[bidx].dynamic_layers,
+                sky_cubemap=sky_cubemaps[bidx],
+                affine_matrix=affine_matrix[bidx],
+            )
+            primitives.append(primitive)
+        return primitives
+
+    def reconstruct(
+        self,
+        context: list[DataAndRenderingBatch],
+        cuboid_tracks: list[CuboidTracks] | None,
+    ) -> list[KelvinInstantNuRecPrimitive]:
+        # Add assertions about input context -- num_images and num_views should match
+        num_imgs, num_views, camera_idxs, time_remappings = self._grab_metainfo(context)
+
+        encoded_latent = self.encoder.encode(context, self.scene_rescale)
+
+        decoder_returns = self.decoder.decode(
+            encoded_latent,
+            context,
+            cuboid_tracks,
+            time_remappings,
+            self.scene_rescale,
+        )
+
+        # Decode the non-static sky head for full-model callers.
+        sky_cubemaps = self.sky.decode(encoded_latent, context).contiguous()
+
+        affine_matrix = self._compute_affine_matrix(encoded_latent, camera_idxs)
+
+        return self._build_primitives(context, decoder_returns, sky_cubemaps, affine_matrix)

--- a/instant_nurec/model/post_processing.py
+++ b/instant_nurec/model/post_processing.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import torch.nn as nn
+
+from einops import rearrange, repeat
+
+from instant_nurec.model.blocks.attention import CrossAttention, CrossAttentionWithKVProjector
+
+
+class PerCameraAffinePostProcessing(nn.Module):
+    """
+    This post processing module is a special case of BilateralGrid with configuration:
+        - num_grids = number of cameras
+        - width = height = depth (sampled via luminance) = 1
+    There are two main methods within this module:
+        - transform_tokens: cross attention between affine tokens and x.
+        - decode_affine: This will decode the affine tokens into a 3x3 matrix and a 3x1 bias vector.
+    """
+
+    affine_attention: CrossAttention
+
+    def __init__(
+        self,
+        embed_dim: int,
+        init_token_scale: float,
+    ):
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.init_token_scale = init_token_scale
+
+        self.kv_norm = nn.LayerNorm(self.embed_dim)
+        self.affine_linear = nn.Linear(self.embed_dim, 3 * 4)
+        self.affine_attention = CrossAttentionWithKVProjector(
+            dim=self.embed_dim,
+            n_heads=16,
+            bias=True,
+            norm=False,
+            allow_legacy_state_dict=True,
+        )
+        self.affine_token = nn.Parameter(torch.randn(self.embed_dim) * self.init_token_scale)
+
+    def _transform_tokens_cross_attention(
+        self, x: torch.Tensor, camera_idxs: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Input:
+            x: (B, v * t * hw, C)
+            camera_idxs: (B, v * t)
+        Output:
+            embedded_x: (B, v * t * hw, C)
+            affine_token: (B, n_affine_tokens, C)
+        """
+        # Permute affine tokens to apply cross attention
+        # Cross attend tokens with input embeddings to inform affine_tokens with image info.
+        inferred_v: int = torch.unique(camera_idxs).shape[0]
+        original_camera_idxs = camera_idxs = rearrange(camera_idxs, "B (v t) -> B v t", v=inferred_v)
+        camera_idxs = camera_idxs.median(2).values  # (B, v)
+        assert torch.all(camera_idxs[..., None] == original_camera_idxs), (
+            f"Camera idxs must be the same for each divided view. Got {original_camera_idxs}."
+        )
+
+        B, v = camera_idxs.shape
+        kv = rearrange(x, "B (v thw) C -> (B v) (thw) C", v=v)
+        affine_token = repeat(self.affine_token, "C -> (B v) 1 C", B=B, v=v)
+        affine_token = self.affine_attention(affine_token, kv, kv).squeeze(1)
+        affine_token = rearrange(affine_token, "(B v) C -> B v C", B=B, v=v)
+        # original x is kept unchanged
+        return x, affine_token
+
+    def transform_tokens(self, x: torch.Tensor, camera_idxs: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Input:
+            x: (B, v * t * hw, C)
+            camera_idxs: (B, v * t)
+        Output:
+            embedded_x: (B, v * t * hw, C)
+            affine_token: (B, n_affine_tokens, C)
+        """
+        return self._transform_tokens_cross_attention(self.kv_norm(x), camera_idxs)
+
+    @torch.autocast("cuda", enabled=False)
+    def decode_affine(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Input:
+            x: (B, n_affine_tokens, C)
+        Output:
+            affine_matrix: (B, n_affine_tokens, 3, 3)
+            affine_bias: (B, n_affine_tokens, 3)
+        """
+        affine: torch.Tensor = self.affine_linear(x.float())  # (B, n_affine_tokens, 3 * 4)
+        affine_matrix, affine_bias = affine.split([3 * 3, 3], dim=-1)
+        affine_matrix = (
+            rearrange(affine_matrix, "B n (a b) -> B n a b", a=3, b=3)
+            + torch.eye(3, device=x.device, dtype=x.dtype)[None, None]
+        )
+        return affine_matrix, affine_bias
+
+    def forward(self, *args, **kwargs):
+        raise NotImplementedError("Please use transform_tokens or decode_affine instead.")

--- a/instant_nurec/model/static_core.py
+++ b/instant_nurec/model/static_core.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Eager source implementation of the pretrained static reconstruction core.
+
+The PLY exporter consumes the static Gaussian layer and per-camera affine
+matrix. This module therefore runs the released encoder, the static decoder
+heads, and affine post-processing directly from Python source. Variable-length
+cuboid-track masking remains in :mod:`instant_nurec.model.inference`.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+from einops import rearrange
+from torch import nn
+
+from instant_nurec.model.backbone.decoders import KelvinDPTDecoder
+from instant_nurec.model.backbone.encoders import KelvinDAv3Encoder
+from instant_nurec.model.post_processing import PerCameraAffinePostProcessing
+from instant_nurec.config_schema.models import KelvinModelConfig
+
+
+class KelvinStaticCore(nn.Module):
+    """Static Gaussian reconstruction heads used by public inference."""
+
+    # Class indices for KelvinSemanticClass.{EGO,SKY,MOVABLE}.
+    _SEMANTIC_EGO: int = 1
+    _SEMANTIC_SKY: int = 2
+    _SEMANTIC_MOVABLE: int = 4
+
+    def __init__(self, config: KelvinModelConfig) -> None:
+        super().__init__()
+        inference_config = config.model_copy(deep=True)
+        inference_config.encoder.checkpointing = "none"
+        inference_config.decoder.checkpointing = False
+        self.encoder = KelvinDAv3Encoder(inference_config.encoder, inference_config)
+        self.decoder = KelvinDPTDecoder(inference_config.decoder, inference_config)
+        self.post_processing = PerCameraAffinePostProcessing(
+            embed_dim=inference_config.encoder.embed_dim,
+            init_token_scale=0.02,
+        )
+        self.scene_rescale = inference_config.scene_rescale
+
+    def forward(
+        self,
+        rgb: torch.Tensor,
+        c2w: torch.Tensor,
+        fov: torch.Tensor,
+        rays: torch.Tensor,
+        distance_to_depth_scale: torch.Tensor,
+        camera_idxs: torch.Tensor,
+    ) -> tuple[
+        torch.Tensor,  # gs_xyz             (B, V, H, W, 3)
+        torch.Tensor,  # gs_rotations       (B, V, H, W, 4)
+        torch.Tensor,  # gs_scales          (B, V, H, W, 3)
+        torch.Tensor,  # gs_densities       (B, V, H, W, 1)
+        torch.Tensor,  # gs_rgb             (B, V, H, W, 3)
+        torch.Tensor,  # semantic_argmax    (B, V, H, W)   int64
+        torch.Tensor,  # normals            (B, V, H, W, 3)
+        torch.Tensor,  # affine             (B, n_affine_tokens, 3, 4)
+    ]:
+        """Run the static model heads on pre-extracted tensors.
+
+        Inputs (B=1):
+            rgb:                     (1, V, H, W, 3)
+            c2w:                     (1, V, 4, 4) -- end-of-frame, scene-rescaled
+            fov:                     (1, V, 2)    -- (fov_w, fov_h) in radians
+            rays:                    (1, V, H, W, 6) -- ``[origin (3), dir (3)]``
+            distance_to_depth_scale: (1, V, H, W, 1)
+            camera_idxs:             (1, V) int64
+
+        Returns the *unmasked* per-pixel gaussian fields plus the affine
+        matrix. Static/dynamic split, cuboid-track-based mask refinement,
+        and final flatten + gather happen in ``KelvinInferenceModel``.
+        """
+        scene_rescale = self.scene_rescale
+
+        # ----- Encoder -----
+        # Mirror KelvinDAv3Encoder.encode while consuming stacked tensors.
+        B, V, H, W, _ = rgb.shape
+        x = self.encoder.patch_embed_img(
+            self.encoder.rgb_normalize(rearrange(rgb, "B V H W C -> (B V) C H W"))
+        )
+        x = rearrange(x, "(B V) h w C -> B V h w C", B=B, V=V)
+        camera_encodings = self.encoder.embed_camera.forward(c2w, fov)
+        with torch.autocast("cuda", enabled=True):
+            img_feats, _ = self.encoder.vit.get_intermediate_features(
+                x,
+                block_indices=self.encoder.take_block_indices,
+                global_cls_token=camera_encodings.unsqueeze(2),
+            )
+        encoded_deepest = img_feats[-1]
+
+        # ----- Decoder static path -----
+        # Run the decoder heads that feed the exported static layer. Per-pixel
+        # masking happens in KelvinInferenceModel so it can use cuboid tracks.
+        img_feats_flat = [rearrange(feat, "B V h w C -> (B V) h w C") for feat in img_feats]
+        chunk_size = self.decoder.config.dpt_chunk_size
+
+        # Depth
+        depth_and_dconf = self.decoder.depth_head(
+            img_feats_flat, output_shape=(H, W), chunk_size=chunk_size
+        )
+        depth_and_dconf = rearrange(depth_and_dconf, "(B V) C H W -> B V C H W", B=B, V=V)
+        pred_depth = torch.exp(
+            depth_and_dconf[:, :, 0].unsqueeze(-1) - math.log(scene_rescale)
+        )  # (B, V, H, W, 1)
+
+        # Context head
+        rgb_in_flat = rearrange(rgb, "B V H W C -> (B V) C H W")
+        rgb_fusion_features = self.decoder.rgb_fusion(rgb_in_flat)
+        context_features_tensor = self.decoder.context_head(
+            img_feats_flat,
+            output_shape=(H, W),
+            fusion_features=rgb_fusion_features,
+            chunk_size=chunk_size,
+        )
+        context_features_tensor = rearrange(
+            context_features_tensor, "(B V) C H W -> B V H W C", B=B, V=V
+        )
+        n_semantic = self.decoder.n_semantic_classes
+        context_rgb, context_world_normal, context_semantic_logits = (
+            context_features_tensor.split([3, 3, n_semantic], dim=-1)
+        )
+        context_rgb = self.decoder.gaussian_activations.rgb(context_rgb)
+        context_world_normal = torch.nn.functional.normalize(context_world_normal, dim=-1)
+        semantic_argmax = torch.argmax(context_semantic_logits, dim=-1)  # (B, V, H, W)
+
+        # Gaussian heads
+        gs_params_tensor = self.decoder.gaussians_head(
+            img_feats_flat, output_shape=(H, W), fusion_features=None, chunk_size=chunk_size
+        )
+        gs_params_tensor = rearrange(gs_params_tensor, "(B V) C H W -> B V H W C", B=B, V=V)
+        gs_scale, gs_world_quaternion, gs_opacity = gs_params_tensor.split([3, 4, 1], dim=-1)
+        gs_distance = pred_depth / distance_to_depth_scale  # (B, V, H, W, 1)
+
+        gs_scale = self.decoder.gaussian_activations.scale(gs_scale, scene_rescale=scene_rescale)
+        # Mirror of KelvinSemanticClass.opacity_mask_from_semantic_probs (excludes ego + sky)
+        semantic_probs = torch.softmax(context_semantic_logits, dim=-1)
+        ego = semantic_probs[..., self._SEMANTIC_EGO : self._SEMANTIC_EGO + 1]
+        sky = semantic_probs[..., self._SEMANTIC_SKY : self._SEMANTIC_SKY + 1]
+        gs_valid_mask = 1.0 - ego - sky
+        gs_opacity = (
+            self.decoder.gaussian_activations.opacity(gs_opacity)
+            * (gs_valid_mask > 0.5).float().detach()
+        )
+        gs_world_quaternion = self.decoder.gaussian_activations.rotation(gs_world_quaternion)
+        gs_xyz = rays[..., :3] + rays[..., 3:] * gs_distance  # (B, V, H, W, 3)
+
+        # ----- Per-camera affine post-processing -----
+        encoded_deepest_tokens = rearrange(encoded_deepest, "B V h w C -> B (V h w) C")
+        _, affine_latents = self.post_processing.transform_tokens(
+            encoded_deepest_tokens, camera_idxs
+        )
+        affine_matrix_3, affine_bias = self.post_processing.decode_affine(affine_latents)
+        affine_matrix = torch.cat([affine_matrix_3, affine_bias[..., None]], dim=-1)
+
+        return (
+            gs_xyz,
+            gs_world_quaternion,
+            gs_scale,
+            gs_opacity,
+            context_rgb,
+            semantic_argmax,
+            context_world_normal,
+            affine_matrix,
+        )

--- a/instant_nurec/model/system.py
+++ b/instant_nurec/model/system.py
@@ -29,6 +29,7 @@ from tqdm import tqdm
 from instant_nurec.datasets.tracks import CuboidTracks
 from instant_nurec.config_schema.instantnurec import GaussiansInstantNuRecSystemConfig
 from instant_nurec.datasets.datamodule import InstantNuRecDataModule
+from instant_nurec.model.inference import KelvinInferenceModel
 from instant_nurec.predict.export_ply import export_ply
 from instant_nurec.predict.primitive_merge import KelvinPrimitiveMerge
 from instant_nurec.primitives.base import BaseInstantNuRecPrimitive
@@ -40,15 +41,21 @@ logger = logging.getLogger(__name__)
 
 
 class GaussiansInstantNuRecSystem(nn.Module):
-    """Predict-only system; the predict driver invokes hooks directly.
-
-    Instances are constructed by ``instant_nurec.model.make`` via
-    ``__new__`` + manual attribute assignment.
-    """
+    """Predict-only system; the predict driver invokes hooks directly."""
 
     config: GaussiansInstantNuRecSystemConfig
-    model: nn.Module
+    model: KelvinInferenceModel
     datamodule: InstantNuRecDataModule
+
+    def __init__(self, config, model: KelvinInferenceModel) -> None:
+        super().__init__()
+        self.out_dir = config.out_dir
+        self.run_id = config.run_id
+        self.config = config.system
+        self.predict_config = config.predict
+        self.export_preprocess = config.model.export_preprocess
+        self.datamodule = InstantNuRecDataModule(config)
+        self.model = model
 
     @property
     def device(self) -> torch.device:
@@ -135,4 +142,3 @@ class GaussiansInstantNuRecSystem(nn.Module):
                 meta,
                 chunk_suffix,
             )
-

--- a/instant_nurec/pretrained.py
+++ b/instant_nurec/pretrained.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Resolve the pretrained InstantNuRec model artifact.
+"""Resolve the pretrained InstantNuRec weight checkpoint.
 
 ``download_instant_nurec_pt()`` returns the local path to
-``instant_nurec.pt``, downloading from Hugging Face on first use into
+``pth/instant_nurec_pa_front_1.1.0.pth``, downloading from Hugging Face on first use into
 the standard HF hub cache. Setting ``INSTANT_NUREC_FULL_PT`` to an
 existing local path short-circuits the download (useful for offline
 use).
@@ -35,15 +35,15 @@ logger = logging.getLogger(__name__)
 
 
 MODEL_REPO_ID = "nvidia/instant-nurec"
-MODEL_FILENAME = "instant_nurec.pt"
+MODEL_FILENAME = "pth/instant_nurec_pa_front_1.1.0.pth"
 
 
 class PretrainedModelError(RuntimeError):
-    """Raised when ``instant_nurec.pt`` cannot be resolved."""
+    """Raised when the Instant NuRec PA-front checkpoint cannot be resolved."""
 
 
 def download_instant_nurec_pt(*, cache_dir: Optional[str | Path] = None) -> str:
-    """Return the local path to ``instant_nurec.pt``.
+    """Return the local path to :data:`MODEL_FILENAME`.
 
     Resolution order:
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,6 +32,7 @@ from pydantic import ValidationError
 
 from instant_nurec.config_schema.dataset import (
     AdaptiveSequentialFrameBatchSamplerConfig,
+    CameraSubsamplerConfig,
     NCoreInstantNuRecCuboidTracksParamsConfig,
 )
 from instant_nurec.config_schema.instantnurec import GaussiansInstantNuRecSystemConfig, InstantNuRecConfig
@@ -132,6 +133,22 @@ def test_primitive_export_preprocess_default():
 
 
 # ---------------------------------------------------------------------------
+# KelvinModelConfig
+# ---------------------------------------------------------------------------
+
+
+def test_kelvin_model_config_exposes_architecture_defaults():
+    cfg = KelvinModelConfig()
+    assert isinstance(cfg.export_preprocess, PrimitiveExportPreprocessConfig)
+    assert cfg.encoder.embed_dim == 1536
+    assert cfg.encoder.take_block_indices == [5, 7, 9, 11]
+    assert cfg.decoder.dpt_dim == 128
+    assert cfg.sky.cubemap_size == 448
+    assert cfg.scene_rescale == 0.15
+    assert cfg.track_padding_m == [1.0, 1.0, 1.0]
+
+
+# ---------------------------------------------------------------------------
 # NCoreInstantNuRecCuboidTracksParamsConfig
 # ---------------------------------------------------------------------------
 
@@ -181,8 +198,15 @@ def test_adaptive_sequential_frame_batch_sampler_basic():
     cfg = AdaptiveSequentialFrameBatchSamplerConfig(
         n_samples_per_sequence=2, max_frame_gap_timestamp_us=200000
     )
+    assert cfg.n_frames_per_sample == 18
     assert cfg.n_samples_per_sequence == 2
     assert cfg.max_frame_gap_timestamp_us == 200000
+
+
+def test_camera_subsampler_public_model_dimensions():
+    cfg = CameraSubsamplerConfig()
+    assert cfg.frame_width == 784
+    assert cfg.frame_height == 448
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Branch-coverage tests for ``instant_nurec.model.jit_adapter``.
+"""Branch-coverage tests for ``instant_nurec.model.inference``.
 
 End-to-end inference exercises the adapter on GPU; here we cover the
 shape-correctness and masking branches in isolation.
@@ -33,9 +33,9 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 
-from instant_nurec.model.jit_adapter import (  # noqa: E402
+from instant_nurec.model.inference import (  # noqa: E402
     _PLACEHOLDER_SKY_CUBEMAP_SIZE,
-    JITKelvinAdapter,
+    KelvinInferenceModel,
 )
 from instant_nurec.primitives.kelvin_primitive import (  # noqa: E402
     KelvinDynamicLayer,
@@ -44,11 +44,11 @@ from instant_nurec.primitives.kelvin_primitive import (  # noqa: E402
 )
 
 
-# ---------- JITKelvinAdapter (CPU-only, mocked jit_module) ----------
+# ---------- KelvinInferenceModel (CPU-only, mocked static_core) ----------
 
 
-class _FakeJITModule(torch.nn.Module):
-    """Fake JIT module emitting per-pixel tensors so the adapter's
+class _FakeStaticCore(torch.nn.Module):
+    """Fake source core emitting per-pixel tensors so the adapter's
     flatten + gather logic can be exercised without GPU."""
 
     def __init__(self, B: int, V: int, H: int, W: int, n_cams: int, dynamic_pixel_idx: int = -1):
@@ -81,20 +81,20 @@ class _FakeJITModule(torch.nn.Module):
         return gs_xyz, gs_rotations, gs_scales, gs_densities, gs_rgb, semantic, normals, affine
 
 
-def _make_adapter(jit_module: _FakeJITModule, scene_rescale: float = 0.5) -> JITKelvinAdapter:
-    """Adapter constructor reads buffers off the JIT module; attach mocks
-    sized to match the fake module's per-pixel output."""
+def _make_adapter(static_core: _FakeStaticCore, scene_rescale: float = 0.5) -> KelvinInferenceModel:
+    """Build the inference wrapper around the small fake source core."""
     from types import SimpleNamespace
 
-    jit_module.static_core = SimpleNamespace(
-        scene_rescale_buffer=torch.tensor(scene_rescale, dtype=torch.float32),
-        expected_b=torch.tensor(jit_module.B, dtype=torch.int64),
-        expected_v=torch.tensor(jit_module.V, dtype=torch.int64),
-        expected_h=torch.tensor(jit_module.H, dtype=torch.int64),
-        expected_w=torch.tensor(jit_module.W, dtype=torch.int64),
-        decoder=SimpleNamespace(cuboids_dims_padding=torch.tensor([0.1, 0.1, 0.1])),
+    static_core.decoder = SimpleNamespace(
+        cuboids_dims_padding=torch.tensor([0.1, 0.1, 0.1]),
     )
-    return JITKelvinAdapter(jit_module=jit_module)
+    return KelvinInferenceModel(
+        static_core=static_core,
+        scene_rescale=scene_rescale,
+        expected_frames=static_core.V,
+        expected_height=static_core.H,
+        expected_width=static_core.W,
+    )
 
 
 def _fake_batch(V: int = 2, H: int = 4, W: int = 4):
@@ -145,7 +145,7 @@ def _stub_sensor_helpers(monkeypatch):
     derive fov; bypass it with a passthrough so tests don't need real ncore
     sensor types. Also stub ``tquat_to_se3_matrix`` since the fake batch's
     pose tensor is not a real quaternion."""
-    from instant_nurec.model import jit_adapter as adapter_mod
+    from instant_nurec.model import inference as adapter_mod
 
     monkeypatch.setattr(adapter_mod, "to_simple_pinhole_model_parameters", lambda p: p)
 
@@ -161,14 +161,14 @@ def _stub_sensor_helpers(monkeypatch):
 
 def test_reconstruct_no_cuboid_tracks_returns_one_primitive_per_batch():
     V, H, W = 2, 4, 4
-    jit = _FakeJITModule(B=1, V=V, H=H, W=W, n_cams=1)
-    adapter = _make_adapter(jit)
+    core = _FakeStaticCore(B=1, V=V, H=H, W=W, n_cams=1)
+    adapter = _make_adapter(core)
 
     out = adapter.reconstruct([_fake_batch(V, H, W)], cuboid_tracks=None)
 
     assert len(out) == 1
     primitive = out[0]
-    # No dynamic pixels in the fake jit module -> all V*H*W gaussians are static.
+    # No dynamic pixels in the fake core module -> all V*H*W gaussians are static.
     assert len(primitive.static_layer) == V * H * W
     assert isinstance(primitive.static_layer, KelvinStaticLayer)
     assert isinstance(primitive.dynamic_layers, list)
@@ -180,8 +180,8 @@ def test_reconstruct_no_cuboid_tracks_returns_one_primitive_per_batch():
 def test_reconstruct_drops_movable_pixels_in_semantic_only_mode():
     V, H, W = 2, 4, 4
     # Mark one pixel as MOVABLE -- semantic-only branch should drop it.
-    jit = _FakeJITModule(B=1, V=V, H=H, W=W, n_cams=1, dynamic_pixel_idx=5)
-    adapter = _make_adapter(jit)
+    core = _FakeStaticCore(B=1, V=V, H=H, W=W, n_cams=1, dynamic_pixel_idx=5)
+    adapter = _make_adapter(core)
 
     out = adapter.reconstruct([_fake_batch(V, H, W)], cuboid_tracks=None)
 
@@ -190,8 +190,8 @@ def test_reconstruct_drops_movable_pixels_in_semantic_only_mode():
 
 def test_reconstruct_uses_placeholder_sky_cubemap_shape():
     V, H, W = 2, 4, 4
-    jit = _FakeJITModule(B=1, V=V, H=H, W=W, n_cams=1)
-    adapter = _make_adapter(jit)
+    core = _FakeStaticCore(B=1, V=V, H=H, W=W, n_cams=1)
+    adapter = _make_adapter(core)
     out = adapter.reconstruct([_fake_batch(V, H, W)], cuboid_tracks=None)
     sky = out[0].sky_cubemap
     s = _PLACEHOLDER_SKY_CUBEMAP_SIZE
@@ -201,19 +201,19 @@ def test_reconstruct_uses_placeholder_sky_cubemap_shape():
 
 def test_reconstruct_affine_matrix_shape_squeezed_to_per_camera():
     V, H, W, n_cams = 2, 4, 4, 3
-    jit = _FakeJITModule(B=1, V=V, H=H, W=W, n_cams=n_cams)
-    adapter = _make_adapter(jit)
+    core = _FakeStaticCore(B=1, V=V, H=H, W=W, n_cams=n_cams)
+    adapter = _make_adapter(core)
     out = adapter.reconstruct([_fake_batch(V, H, W)], cuboid_tracks=None)
     assert out[0].affine_matrix.shape == (n_cams, 3, 4)
 
 
-def test_reconstruct_passes_extracted_tensors_to_jit_module():
+def test_reconstruct_passes_extracted_tensors_to_static_core():
     V, H, W = 2, 4, 4
-    jit = _FakeJITModule(B=1, V=V, H=H, W=W, n_cams=1)
-    adapter = _make_adapter(jit)
+    core = _FakeStaticCore(B=1, V=V, H=H, W=W, n_cams=1)
+    adapter = _make_adapter(core)
     adapter.reconstruct([_fake_batch(V, H, W)], cuboid_tracks=None)
 
-    rgb, c2w, fov, rays, distance_to_depth_scale, camera_idxs = jit.calls[0]
+    rgb, c2w, fov, rays, distance_to_depth_scale, camera_idxs = core.calls[0]
     # Every input is shape ``(1, V, ...)`` with the leading B=1 dim added by
     # the adapter's per-batch unsqueeze.
     assert rgb.shape == (1, V, H, W, 3)
@@ -226,10 +226,17 @@ def test_reconstruct_passes_extracted_tensors_to_jit_module():
 
 def test_reconstruct_static_layer_semantic_class_is_uint8():
     V, H, W = 2, 4, 4
-    jit = _FakeJITModule(B=1, V=V, H=H, W=W, n_cams=1)
-    adapter = _make_adapter(jit)
+    core = _FakeStaticCore(B=1, V=V, H=H, W=W, n_cams=1)
+    adapter = _make_adapter(core)
     out = adapter.reconstruct([_fake_batch(V, H, W)], cuboid_tracks=None)
     assert out[0].static_layer.semantic_class.dtype == torch.uint8
+
+
+def test_reconstruct_rejects_input_shape_that_does_not_match_public_config():
+    adapter = _make_adapter(_FakeStaticCore(B=1, V=2, H=4, W=4, n_cams=1))
+
+    with pytest.raises(ValueError, match="Input shape mismatch"):
+        adapter.reconstruct([_fake_batch(V=1, H=4, W=4)], cuboid_tracks=None)
 
 
 # ---------- prepare_context ----------
@@ -239,7 +246,7 @@ def test_prepare_context_passthrough():
     from types import SimpleNamespace
 
     context = [SimpleNamespace()]
-    adapter = _make_adapter(_FakeJITModule(B=1, V=2, H=4, W=4, n_cams=1))
+    adapter = _make_adapter(_FakeStaticCore(B=1, V=2, H=4, W=4, n_cams=1))
     assert adapter.prepare_context(context) is context
 
 
@@ -247,7 +254,7 @@ def test_prepare_context_passthrough():
 
 
 def test_empty_dynamic_layer_has_zero_gaussians_with_correct_dtypes():
-    adapter = _make_adapter(_FakeJITModule(1, 1, 1, 1, 1))
+    adapter = _make_adapter(_FakeStaticCore(1, 1, 1, 1, 1))
     layer = adapter._empty_dynamic_layer(torch.device("cpu"))
     assert len(layer) == 0
     assert layer.keyframe_timestamps_us.dtype == torch.int64
@@ -255,7 +262,7 @@ def test_empty_dynamic_layer_has_zero_gaussians_with_correct_dtypes():
 
 
 def test_placeholder_sky_cubemap_dtype_and_shape():
-    adapter = _make_adapter(_FakeJITModule(1, 1, 1, 1, 1))
+    adapter = _make_adapter(_FakeStaticCore(1, 1, 1, 1, 1))
     cube = adapter._placeholder_sky_cubemap(torch.device("cpu"), torch.float64)
     assert cube.shape == (6, _PLACEHOLDER_SKY_CUBEMAP_SIZE, _PLACEHOLDER_SKY_CUBEMAP_SIZE, 3)
     assert cube.dtype == torch.float64
@@ -266,7 +273,7 @@ def test_pytest_collected(monkeypatch):
     """Sentinel: pytest must always pass at least one named test in this
     module to confirm the file isn't accidentally skipped by collection
     rules."""
-    monkeypatch.setenv("__JIT_ADAPTER_TEST_SENTINEL__", "1")
+    monkeypatch.setenv("__INFERENCE_MODEL_TEST_SENTINEL__", "1")
     assert True
 
 

--- a/tests/test_pretrained.py
+++ b/tests/test_pretrained.py
@@ -40,7 +40,7 @@ def _reset_env(monkeypatch):
 def test_env_var_override_short_circuits_download(monkeypatch, tmp_path):
     """Setting INSTANT_NUREC_FULL_PT to an existing file returns it directly,
     without consulting huggingface_hub."""
-    fake_pt = tmp_path / "local-instant_nurec.pt"
+    fake_pt = tmp_path / "local-instant_nurec_weights.pt"
     fake_pt.write_bytes(b"")
     monkeypatch.setenv("INSTANT_NUREC_FULL_PT", str(fake_pt))
 
@@ -70,7 +70,7 @@ def test_download_forwards_explicit_cache_dir_kwarg(monkeypatch, tmp_path):
 
     def _fake_dl(**kw):
         captured.update(kw)
-        return "/some/cached/path/instant_nurec.pt"
+        return "/some/cached/path/instant_nurec_weights.pt"
 
     fake_hf = types.ModuleType("huggingface_hub")
     fake_hf.hf_hub_download = _fake_dl
@@ -78,7 +78,7 @@ def test_download_forwards_explicit_cache_dir_kwarg(monkeypatch, tmp_path):
     monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
 
     out = pretrained.download_instant_nurec_pt(cache_dir=tmp_path / "explicit")
-    assert out == "/some/cached/path/instant_nurec.pt"
+    assert out == "/some/cached/path/instant_nurec_weights.pt"
     assert captured["repo_id"] == pretrained.MODEL_REPO_ID
     assert captured["filename"] == pretrained.MODEL_FILENAME
     assert captured["cache_dir"] == str(tmp_path / "explicit")
@@ -90,7 +90,7 @@ def test_download_without_cache_dir_omits_cache_dir_kwarg(monkeypatch):
 
     def _fake_dl(**kw):
         captured.update(kw)
-        return "/anywhere/instant_nurec.pt"
+        return "/anywhere/instant_nurec_weights.pt"
 
     fake_hf = types.ModuleType("huggingface_hub")
     fake_hf.hf_hub_download = _fake_dl
@@ -104,13 +104,13 @@ def test_download_without_cache_dir_omits_cache_dir_kwarg(monkeypatch):
 def test_cached_copy_short_circuits_download(monkeypatch):
     """If the file is in the HF cache, return it without calling hf_hub_download."""
     fake_hf = types.ModuleType("huggingface_hub")
-    fake_hf.try_to_load_from_cache = lambda **kw: "/cached/instant_nurec.pt"
+    fake_hf.try_to_load_from_cache = lambda **kw: "/cached/instant_nurec_weights.pt"
     fake_hf.hf_hub_download = lambda **kw: pytest.fail(
         "hf_hub_download must not be called when the file is already cached"
     )
     monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
 
-    assert pretrained.download_instant_nurec_pt() == "/cached/instant_nurec.pt"
+    assert pretrained.download_instant_nurec_pt() == "/cached/instant_nurec_weights.pt"
 
 
 def test_download_failure_raises_pretrained_model_error(monkeypatch):

--- a/tests/test_systems_make.py
+++ b/tests/test_systems_make.py
@@ -25,8 +25,10 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
+import torch
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -34,11 +36,18 @@ sys.path.insert(0, str(REPO_ROOT))
 
 
 from instant_nurec import pretrained  # noqa: E402
-from instant_nurec.model import _resolve_model_pt_path, _validate_camera_ids  # noqa: E402
+from instant_nurec import model as model_mod  # noqa: E402
+from instant_nurec.model import (  # noqa: E402
+    ModelCheckpointError,
+    ModelNotFoundError,
+    _load_model_state_dict,
+    _resolve_model_pt_path,
+    _validate_camera_ids,
+)
 
 
 def test_resolve_returns_path_when_download_succeeds(monkeypatch, tmp_path):
-    fake_pt = tmp_path / "instant_nurec.pt"
+    fake_pt = tmp_path / "instant_nurec_weights.pt"
     fake_pt.write_bytes(b"")
     monkeypatch.setattr(pretrained, "download_instant_nurec_pt", lambda **kw: str(fake_pt))
     assert _resolve_model_pt_path() == str(fake_pt)
@@ -112,3 +121,112 @@ def test_validate_camera_ids_error_message_anchors_to_sequence_path():
             context_camera_ids=["cam_zzz"],
             sequence_path="/some/seq.json",
         )
+
+
+# ---------- _load_model_state_dict ----------
+
+
+def test_load_model_state_dict_accepts_plain_tensor_mapping(tmp_path):
+    checkpoint = tmp_path / "weights.pt"
+    expected = {"layer.weight": torch.arange(3)}
+    torch.save(expected, checkpoint)
+
+    actual = _load_model_state_dict(str(checkpoint))
+
+    assert actual.keys() == expected.keys()
+    assert torch.equal(actual["layer.weight"], expected["layer.weight"])
+
+
+@pytest.mark.parametrize("payload", [[torch.ones(1)], {"layer.weight": "not-a-tensor"}])
+def test_load_model_state_dict_rejects_non_state_dict_payload(tmp_path, payload):
+    checkpoint = tmp_path / "invalid.pt"
+    torch.save(payload, checkpoint)
+
+    with pytest.raises(ModelCheckpointError, match="plain state dictionary"):
+        _load_model_state_dict(str(checkpoint))
+
+
+def test_load_model_state_dict_rejects_legacy_traced_archive_before_torch_load(
+    monkeypatch, tmp_path
+):
+    import zipfile
+
+    checkpoint = tmp_path / "legacy.pt"
+    with zipfile.ZipFile(checkpoint, "w") as archive:
+        archive.writestr("legacy/constants.pkl", b"")
+
+    monkeypatch.setattr(
+        torch,
+        "load",
+        lambda *args, **kwargs: pytest.fail("legacy archive must be rejected before torch.load"),
+    )
+    with pytest.raises(ModelCheckpointError, match="legacy traced-model archive"):
+        _load_model_state_dict(str(checkpoint))
+
+
+# ---------- make ----------
+
+
+def test_make_raises_when_checkpoint_cannot_be_resolved(monkeypatch):
+    monkeypatch.setattr(model_mod, "_resolve_model_pt_path", lambda: None)
+
+    with pytest.raises(ModelNotFoundError, match=pretrained.MODEL_FILENAME):
+        model_mod.make(SimpleNamespace())
+
+
+def test_make_builds_source_core_and_loads_weights(monkeypatch, tmp_path):
+    checkpoint = tmp_path / pretrained.MODEL_FILENAME
+    checkpoint.parent.mkdir(parents=True)
+    checkpoint.write_bytes(b"placeholder")
+    state_dict = {"encoder.weight": torch.ones(1)}
+    calls = {}
+
+    class FakeCore:
+        def __init__(self, config):
+            calls["core_config"] = config
+
+        def load_state_dict(self, loaded, *, strict):
+            calls["loaded"] = loaded
+            calls["strict"] = strict
+
+    class FakeInference:
+        def __init__(self, core, **kwargs):
+            calls["inference_core"] = core
+            calls["inference_kwargs"] = kwargs
+
+    sentinel_system = object()
+    model_config = SimpleNamespace(scene_rescale=0.15)
+    dataset_config = SimpleNamespace(
+        context_camera_ids=["front", "left"],
+        frame_batch_sampler=SimpleNamespace(n_frames_per_sample=9),
+        camera_subsampler=SimpleNamespace(frame_height=448, frame_width=784),
+    )
+    config = SimpleNamespace(
+        model=model_config,
+        dataset=SimpleNamespace(predict=dataset_config),
+    )
+
+    monkeypatch.setattr(model_mod, "_resolve_model_pt_path", lambda: str(checkpoint))
+    monkeypatch.setattr(model_mod, "_preflight_validate_camera_ids", lambda cfg: calls.setdefault("preflight", cfg))
+    monkeypatch.setattr(model_mod, "_load_model_state_dict", lambda path: state_dict)
+    monkeypatch.setattr(model_mod, "KelvinStaticCore", FakeCore)
+    monkeypatch.setattr(model_mod, "KelvinInferenceModel", FakeInference)
+    monkeypatch.setattr(
+        model_mod,
+        "GaussiansInstantNuRecSystem",
+        lambda cfg, model: calls.update(system_args=(cfg, model)) or sentinel_system,
+    )
+
+    result = model_mod.make(config)
+
+    assert result is sentinel_system
+    assert calls["preflight"] is config
+    assert calls["core_config"] is model_config
+    assert calls["loaded"] is state_dict
+    assert calls["strict"] is True
+    assert calls["inference_kwargs"] == {
+        "scene_rescale": 0.15,
+        "expected_frames": 18,
+        "expected_height": 448,
+        "expected_width": 784,
+    }


### PR DESCRIPTION
## Summary

- replace the TorchScript/JIT model boundary with the released eager PyTorch source implementation
- load a plain weights-only state dictionary into `KelvinStaticCore`
- publish the Kelvin architecture under `instant_nurec/model/`
- configure the released PA-front input contract through the existing public config schema
- point automatic checkpoint resolution at [`pth/instant_nurec_pa_front_1.1.0.pth`](https://huggingface.co/nvidia/instant-nurec/blob/main/pth/instant_nurec_pa_front_1.1.0.pth)
- update public documentation and model-loading tests

This PR intentionally contains no changes under `internal/`.

## Result parity

Compared `main`'s released JIT artifact with this branch's eager model on an RTX 5090 using the canonical `(B=1, V=18, H=448, W=784)` input:

- semantic labels: exact, 0 mismatches
- affine output: exact
- xyz maximum absolute difference: `7.4863e-05`
- normals maximum absolute difference: `1.4093e-04`
- all other floating outputs remained within the same small eager-vs-JIT numerical drift range

## Checkpoint

- Hugging Face path: `nvidia/instant-nurec/pth/instant_nurec_pa_front_1.1.0.pth`
- tensors: 574; strict state-dict loading succeeds
- size: `730,200,087` bytes
- SHA-256: `a3b707342cc12d910383f14c8bad4445dcaf42623ce2044394cf53693dfea94b`

## Validation

Followed the README setup flow exactly:

```bash
./setup.sh
source .venv/bin/activate
```

Then ran:

```bash
ruff check instant_nurec tests
pytest -q tests/
git diff --check
```

Result: `477 passed`; Ruff and diff checks passed.

The README example clip also completed end to end with `--merge`: 2 chunks / 3,177,988 pre-merge Gaussians produced a valid merged PLY with 1,918,461 Gaussians.
