### PR TITLE
feat(model): add PA multiview release profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ NCore V4 Sequence ─► Frame Batching ─► Eager PyTorch Model ─► 3D Gau
 
 ## Model Architecture
 
-The released model is implemented entirely in this repository. Its
-pixel-aligned pipeline consists of:
+The released PA-front and PA-multiview models are implemented entirely
+in this repository. Their pixel-aligned pipeline consists of:
 
 1. a multi-view vision-transformer encoder with alternating local and
    global attention;
@@ -107,8 +107,9 @@ image as a generic CUDA environment.
 
 #### Download Model Checkpoints [optional]
 
-> **Note:** `pth/instant_nurec_pa_front_1.1.0.pth` is auto-downloaded into the Hugging Face
-> hub cache on the first inference run.
+> **Note:** The checkpoint selected by `--model` is auto-downloaded into
+> the Hugging Face hub cache on the first inference run. PA-front remains
+> the default.
 
 However, you can also manually download the model into a directory of
 your choice:
@@ -119,11 +120,12 @@ hf auth login
 hf download nvidia/instant-nurec --local-dir checkpoints
 ```
 
-This places the following file in `checkpoints/`:
+This places the following files in `checkpoints/`:
 
     checkpoints/
     └── pth/
-        └── instant_nurec_pa_front_1.1.0.pth
+        ├── instant_nurec_pa_front_1.1.0.pth
+        └── instant_nurec_pa_multiview_1.1.0.pth
 
 Point the pipeline at this local copy by exporting:
 
@@ -131,16 +133,25 @@ Point the pipeline at this local copy by exporting:
 export INSTANT_NUREC_FULL_PT="$(pwd)/checkpoints/pth/instant_nurec_pa_front_1.1.0.pth"
 ```
 
+When using a local override, make sure the file matches the `--model`
+selection.
+
 </details>
 
 <details>
 <summary><b>Inference</b></summary>
 
-> **Note:** The pretrained weights `pth/instant_nurec_pa_front_1.1.0.pth` are fetched
-> on first inference run from the Hugging Face
-> repo `nvidia/instant-nurec` and cached locally; subsequent runs read
-> it from the cache. Set `INSTANT_NUREC_FULL_PT` to a local path to
-> override the auto-download.
+> **Note:** The selected pretrained weights are fetched on first inference
+> from the Hugging Face repo `nvidia/instant-nurec` and cached locally;
+> subsequent runs read them from the cache. Set `INSTANT_NUREC_FULL_PT`
+> to a matching local checkpoint to override the auto-download.
+
+Two pixel-aligned release profiles are available:
+
+| profile | checkpoint | default input |
+| --- | --- | --- |
+| `pa-front` | `pth/instant_nurec_pa_front_1.1.0.pth` | 18 × `camera_front_wide_120fov`, 784×448 |
+| `pa-multiview` | `pth/instant_nurec_pa_multiview_1.1.0.pth` | 18 frames per camera across front-wide, cross-left, and cross-right, 504×280 (54 images total) |
 
 ##### First run — end-to-end on a public demo clip
 
@@ -162,6 +173,23 @@ python run_inference.py \
     --output-dir ./demo_output \
     --merge
 ```
+
+To run the pixel-aligned multiview model on the same clip, add its model
+profile. The default three-camera ordering matches the released model's
+inference configuration:
+
+```bash
+python run_inference.py \
+    --model pa-multiview \
+    --ncore-path ./demo_clip/clips/000da9de-0ee5-465a-9a2d-e7e91d3016bb/pai_000da9de-0ee5-465a-9a2d-e7e91d3016bb.json \
+    --output-dir ./demo_output_multiview \
+    --merge
+```
+
+`--camera-id` can be repeated to override the profile camera set. The
+multiview checkpoint supports 1, 3, or 5 context cameras; each camera
+contributes 18 frames. Five-camera inference has a larger working set and
+may require more GPU memory.
 
 Success looks like a single PLY at
 `./demo_output/<run_id>/ply/pai_000da9de-.../pai_000da9de-....ply` —
@@ -229,11 +257,12 @@ Output layout: PLYs only, under `out_dir/<run_id>/ply/<sequence_id>/...ply`.
 
 | flag | default | purpose |
 | --- | --- | --- |
+| `--model` | `pa-front` | Released input/checkpoint profile: `pa-front` or `pa-multiview`. |
 | `--ncore-path` | (required) | A `.json` file (single sequence) or a `.lst` manifest (one JSON path per line). |
 | `--output-dir` | (required) | Directory the pipeline writes PLYs into. |
 | `--merge` | absent (false) | Boolean flag. When set, merges per-chunk primitives into a single frustum-ownership PLY per sequence (`<seq>.ply`) and runs kl-optimal voxelization (target count from `--n-gaussians`). Absent (default): per-chunk PLYs (`<seq>_chunk{N}.ply`), no voxelization. |
 | `--n-gaussians` | `2000000` | Target number of static Gaussians after voxelization. Only consulted when `--merge` is set. The voxel size is searched iteratively via bracketed binary search to land the count in `[0.9 * target, target]`. |
-| `--camera-id` | `camera_front_wide_120fov` | ncorev4 context-camera id used as model input. Exactly one camera is required. |
+| `--camera-id` | profile-dependent | Override a context camera. Repeat once per camera in canonical order. PA-front requires 1; PA-multiview supports 1, 3, or 5 and defaults to front-wide, cross-left, cross-right. |
 | `--max-chunks` | `8` | Maximum number of time-chunks processed per clip. One chunk spans up to 13.5 s, so the default covers 8 × 13.5 = 108 s. Longer clips are truncated and a `WARNING` is logged naming the dropped chunk count and the `--max-chunks` value needed to cover the full clip — bump to `ceil(clip_seconds / 13.5)` to silence it. |
 | `--log-level` | `INFO` | `DEBUG` / `INFO` / `WARNING` / `ERROR` / `CRITICAL`. |
 
@@ -241,7 +270,7 @@ Output layout: PLYs only, under `out_dir/<run_id>/ply/<sequence_id>/...ply`.
 
 | variable | purpose |
 | --- | --- |
-| `INSTANT_NUREC_FULL_PT` | Absolute path to a local `instant_nurec_pa_front_1.1.0.pth`. Takes priority over the auto-downloaded copy. |
+| `INSTANT_NUREC_FULL_PT` | Absolute path to a local weights-only checkpoint matching `--model`. Takes priority over the auto-downloaded copy. |
 | `INSTANT_NUREC_RUN_ID` | Override the per-run shortuuid; useful when scripting reproducible output paths. |
 
 </details>

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -3,13 +3,16 @@
 | Symptom | Cause | Fix |
 | --- | --- | --- |
 | `PretrainedModelError: Could not download nvidia/instant-nurec/pth/instant_nurec_pa_front_1.1.0.pth` | No network / proxy blocks `huggingface.co` or `*.cloudfront.net` | Set `HTTPS_PROXY`, or copy `instant_nurec_pa_front_1.1.0.pth` locally and set `INSTANT_NUREC_FULL_PT` to its absolute path. |
-| `ModelCheckpointError: ... is a legacy traced-model archive` | `INSTANT_NUREC_FULL_PT` points at the retired artifact | Download `pth/instant_nurec_pa_front_1.1.0.pth` and update the environment variable. |
+| `PretrainedModelError: Could not download nvidia/instant-nurec/pth/instant_nurec_pa_multiview_1.1.0.pth` | The PA-multiview artifact is unavailable or network access is blocked | Set `HTTPS_PROXY`, or copy `instant_nurec_pa_multiview_1.1.0.pth` locally, select `--model pa-multiview`, and set `INSTANT_NUREC_FULL_PT` to its absolute path. |
+| `ModelCheckpointError: ... is a legacy traced-model archive` | `INSTANT_NUREC_FULL_PT` points at the retired artifact | Download the weights-only checkpoint matching `--model` and update the environment variable. |
+| `RuntimeError: Error(s) in loading state_dict` after setting `INSTANT_NUREC_FULL_PT` | The local override does not match `--model` | Use `instant_nurec_pa_front_1.1.0.pth` with `pa-front`, or `instant_nurec_pa_multiview_1.1.0.pth` with `pa-multiview`. |
 | `PretrainedModelError: huggingface_hub is required` | Dependency missing | `uv sync --frozen`. |
 | `ValueError: --ncore-path ...: not an existing JSON/LST file` | Path doesn't resolve | Check the resolved path; `.lst` entries resolve relative to the LST file's dir, not `$PWD`. |
 | `ValueError: --ncore-path must end in .json or .lst` | Wrong suffix | Pass a single `.json` or a `.lst` manifest. |
 | `InstantNuRecDataError: Context camera <id> not found in supervision cameras [...]` | `--camera-id` not in the ncorev4 sequence | Inspect the JSON's camera list and pass a matching id. |
+| `ValueError: pa-multiview expects 1, 3, 5 context camera(s)` | Unsupported number of repeated `--camera-id` flags | Use the default three cameras, or pass exactly 1, 3, or 5 camera ids. |
 | `RuntimeError: Found no NVIDIA driver` / `Torch not compiled with CUDA enabled` | No GPU, driver below the [NuRec hardware minimums](https://docs.nvidia.com/nurec/basics/hardware.html#hardware-setup-and-requirements), or non-CUDA torch wheel | `nvidia-smi` to confirm GPU + driver; `python -c "import torch; print(torch.cuda.is_available())"` must be `True`. No CPU fallback exists. |
-| `torch.cuda.OutOfMemoryError` during `Predicting in chunks` | `--max-chunks` × per-chunk working set exceeds VRAM | Lower `--max-chunks`. |
+| `torch.cuda.OutOfMemoryError` during `Predicting in chunks` | The per-chunk working set exceeds VRAM; PA-multiview and five-camera overrides use more memory | Prefer the default three-camera multiview profile (or one camera), and lower `--max-chunks` to reduce host-side batching. |
 | `WARNING ... Clip spans Xs ... chunk(s) will be silently dropped` | Clip longer than `--max-chunks × 13.5 s` (default 108 s) | Bump `--max-chunks` to the value the warning prints. |
 
 For anything not listed, file a GitHub issue with the full traceback, `nvidia-smi`, `python --version`, and `pip list | grep -iE "torch|huggingface|instant"`.

--- a/instant_nurec/cli.py
+++ b/instant_nurec/cli.py
@@ -28,8 +28,12 @@ import sys
 from pathlib import Path
 from typing import Sequence
 
+from instant_nurec.pretrained import (
+    DEFAULT_MODEL_VARIANT,
+    MODEL_VARIANTS,
+    get_model_profile,
+)
 
-_DEFAULT_CAMERA_ID = "camera_front_wide_120fov"
 _DEFAULT_MAX_CHUNKS = 8
 _DEFAULT_N_GAUSSIANS = 2_000_000
 
@@ -38,6 +42,16 @@ def make_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="instant_nurec",
         description="Standalone Kelvin predict-mode CLI.",
+    )
+    parser.add_argument(
+        "--model",
+        choices=MODEL_VARIANTS,
+        default=DEFAULT_MODEL_VARIANT,
+        help=(
+            "Released model profile. pa-front uses one 784x448 camera; "
+            "pa-multiview uses three 504x280 cameras by default. "
+            f"Default: {DEFAULT_MODEL_VARIANT}."
+        ),
     )
     parser.add_argument(
         "--ncore-path",
@@ -81,13 +95,16 @@ def make_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--camera-id",
+        dest="camera_ids",
+        metavar="CAMERA_ID",
         type=str,
-        default=_DEFAULT_CAMERA_ID,
+        action="append",
+        default=None,
         help=(
-            f"ncorev4 context-camera id used as model input "
-            f"(default: '{_DEFAULT_CAMERA_ID}'). Wires both "
-            f"context_camera_ids and supervision_camera_ids to [CAMERA_ID]. "
-            f"Exactly one camera is required."
+            "Override a profile's ncorev4 context camera. Repeat the flag to "
+            "provide multiple cameras in canonical order. pa-front requires "
+            "one camera; pa-multiview supports 1, 3, or 5. If omitted, the "
+            "selected profile's camera set is used."
         ),
     )
     parser.add_argument(
@@ -123,20 +140,39 @@ def main(argv: Sequence[str] | None = None) -> int:
         InstantNuRecSplitsConfig,
     )
     from instant_nurec.config_schema.instantnurec import InstantNuRecConfig
+    from instant_nurec.config_schema.models import KelvinDPTDecoderConfig, KelvinModelConfig
     from instant_nurec.config_schema.predict import PredictConfig, PrimitiveMergeConfig
     from instant_nurec.ncore_input import resolve_ncore_paths
     from instant_nurec.predict.run import run_predict
 
     json_paths = resolve_ncore_paths(args.ncore_path)
+    profile = get_model_profile(args.model)
+    camera_ids = list(args.camera_ids or profile.context_camera_ids)
+    allowed_camera_counts = profile.supported_camera_counts
+    if len(camera_ids) not in allowed_camera_counts:
+        counts = ", ".join(str(count) for count in allowed_camera_counts)
+        raise ValueError(
+            f"{args.model} expects {counts} context camera(s); got {len(camera_ids)}. "
+            "Repeat --camera-id once per camera."
+        )
 
     config = InstantNuRecConfig(
         out_dir=str(args.output_dir),
+        release_profile=args.model,
+        model=KelvinModelConfig(
+            decoder=KelvinDPTDecoderConfig(motion_depth=profile.motion_depth),
+        ),
         dataset=InstantNuRecSplitsConfig(
             predict=NCoreInstantNuRecDatasetConfig(
                 ncore_json_paths=[str(p) for p in json_paths],
-                context_camera_ids=[args.camera_id],
-                supervision_camera_ids=[args.camera_id],
+                camera_subsampler={
+                    "frame_width": profile.frame_width,
+                    "frame_height": profile.frame_height,
+                },
+                context_camera_ids=camera_ids,
+                supervision_camera_ids=camera_ids,
                 frame_batch_sampler=AdaptiveSequentialFrameBatchSamplerConfig(
+                    n_frames_per_sample=profile.n_frames_per_sample,
                     n_samples_per_sequence=args.max_chunks,
                 ),
             ),

--- a/instant_nurec/config_schema/dataset.py
+++ b/instant_nurec/config_schema/dataset.py
@@ -42,7 +42,9 @@ class NCoreInstantNuRecCuboidTracksParamsConfig(BaseConfigSchema):
 class AdaptiveSequentialFrameBatchSamplerConfig(BaseConfigSchema):
     """Adaptive sequential frame-batch sampler config.
 
-    The released checkpoint was trained with 18 input frames per sample.
+    The released checkpoints use 18 frames per camera and sample. The total
+    model view dimension is this value multiplied by the number of context
+    cameras (for example, 54 for the default three-camera multiview profile).
     """
 
     n_frames_per_sample: int = Field(
@@ -72,7 +74,7 @@ class AdaptiveSequentialFrameBatchSamplerConfig(BaseConfigSchema):
 
 
 class CameraSubsamplerConfig(BaseConfigSchema):
-    """Image dimensions expected by the released model."""
+    """Image dimensions expected by the selected release profile."""
 
     frame_width: int = Field(
         default=784,

--- a/instant_nurec/config_schema/instantnurec.py
+++ b/instant_nurec/config_schema/instantnurec.py
@@ -23,6 +23,7 @@ from instant_nurec.config_schema.base_schema import BaseConfigSchema, Field
 from instant_nurec.config_schema.dataset import InstantNuRecSplitsConfig
 from instant_nurec.config_schema.models import KelvinModelConfig
 from instant_nurec.config_schema.predict import PredictConfig
+from instant_nurec.pretrained import DEFAULT_MODEL_VARIANT, ModelVariant
 
 
 class GaussiansInstantNuRecSystemConfig(BaseConfigSchema):
@@ -41,6 +42,11 @@ class InstantNuRecConfig(BaseConfigSchema):
     """
 
     seed: int = Field(default=38, description="Random seed.")
+
+    release_profile: ModelVariant = Field(
+        default=DEFAULT_MODEL_VARIANT,
+        description="Released checkpoint/input profile to use for inference.",
+    )
 
     out_dir: str
 

--- a/instant_nurec/model/__init__.py
+++ b/instant_nurec/model/__init__.py
@@ -42,10 +42,12 @@ class ModelCheckpointError(RuntimeError):
     """The resolved file is not a source-model state dictionary."""
 
 
-def _resolve_model_pt_path() -> Optional[str]:
+def _resolve_model_pt_path(
+    model_variant: pretrained.ModelVariant = pretrained.DEFAULT_MODEL_VARIANT,
+) -> Optional[str]:
     """Return the local path to the weight checkpoint or ``None`` on failure."""
     try:
-        return pretrained.download_instant_nurec_pt()
+        return pretrained.download_instant_nurec_pt(model_variant)
     except pretrained.PretrainedModelError:
         return None
 
@@ -115,14 +117,18 @@ def _preflight_validate_camera_ids(config: "InstantNuRecConfig") -> None:
     )
 
 
-def _load_model_state_dict(path: str) -> dict[str, torch.Tensor]:
+def _load_model_state_dict(
+    path: str,
+    *,
+    expected_filename: str = pretrained.MODEL_FILENAME,
+) -> dict[str, torch.Tensor]:
     """Load a weights-only checkpoint and reject legacy traced archives."""
     if zipfile.is_zipfile(path):
         with zipfile.ZipFile(path) as archive:
             if any(name.endswith("/constants.pkl") for name in archive.namelist()):
                 raise ModelCheckpointError(
                     f"{path} is a legacy traced-model archive. Download "
-                    f"{pretrained.MODEL_FILENAME} or point INSTANT_NUREC_FULL_PT "
+                    f"{expected_filename} or point INSTANT_NUREC_FULL_PT "
                     "at the released weights-only checkpoint."
                 )
 
@@ -143,17 +149,21 @@ def make(config: "InstantNuRecConfig") -> GaussiansInstantNuRecSystem:
     Resolution: ``INSTANT_NUREC_FULL_PT`` env var takes priority; otherwise
     the artifact is fetched from Hugging Face.
     """
-    full_pt_path = _resolve_model_pt_path()
+    profile = pretrained.get_model_profile(config.release_profile)
+    full_pt_path = _resolve_model_pt_path(config.release_profile)
     if not full_pt_path or not os.path.exists(full_pt_path):
         raise ModelNotFoundError(
-            f"{pretrained.MODEL_FILENAME} not found. Either set INSTANT_NUREC_FULL_PT to a "
+            f"{profile.filename} not found. Either set INSTANT_NUREC_FULL_PT to a "
             f"local .pt path or ensure {pretrained.MODEL_REPO_ID!r} is reachable."
         )
 
     _preflight_validate_camera_ids(config)
     logger.info("Loading source-model weights from %s.", full_pt_path)
     static_core = KelvinStaticCore(config.model)
-    static_core.load_state_dict(_load_model_state_dict(full_pt_path), strict=True)
+    static_core.load_state_dict(
+        _load_model_state_dict(full_pt_path, expected_filename=profile.filename),
+        strict=True,
+    )
 
     dataset_config = config.dataset.predict
     assert dataset_config is not None, "dataset.predict must be configured for inference"

--- a/instant_nurec/pretrained.py
+++ b/instant_nurec/pretrained.py
@@ -13,13 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Resolve the pretrained InstantNuRec weight checkpoint.
+"""Resolve released InstantNuRec weight checkpoints.
 
-``download_instant_nurec_pt()`` returns the local path to
-``pth/instant_nurec_pa_front_1.1.0.pth``, downloading from Hugging Face on first use into
-the standard HF hub cache. Setting ``INSTANT_NUREC_FULL_PT`` to an
-existing local path short-circuits the download (useful for offline
-use).
+``download_instant_nurec_pt()`` downloads the selected release profile
+from Hugging Face into the standard hub cache. Setting
+``INSTANT_NUREC_FULL_PT`` to an existing local path short-circuits the
+download (useful for offline use); the override must match the selected
+profile.
 """
 
 from __future__ import annotations
@@ -27,23 +27,83 @@ from __future__ import annotations
 import logging
 import os
 
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional, get_args
 
 
 logger = logging.getLogger(__name__)
 
 
 MODEL_REPO_ID = "nvidia/instant-nurec"
-MODEL_FILENAME = "pth/instant_nurec_pa_front_1.1.0.pth"
+
+ModelVariant = Literal["pa-front", "pa-multiview"]
+MODEL_VARIANTS: tuple[ModelVariant, ...] = get_args(ModelVariant)
+DEFAULT_MODEL_VARIANT: ModelVariant = "pa-front"
+
+
+@dataclass(frozen=True)
+class ModelProfile:
+    """Inference contract associated with a released checkpoint."""
+
+    filename: str
+    context_camera_ids: tuple[str, ...]
+    frame_width: int
+    frame_height: int
+    n_frames_per_sample: int
+    motion_depth: int
+    supported_camera_counts: tuple[int, ...]
+
+
+MODEL_PROFILES: dict[ModelVariant, ModelProfile] = {
+    "pa-front": ModelProfile(
+        filename="pth/instant_nurec_pa_front_1.1.0.pth",
+        context_camera_ids=("camera_front_wide_120fov",),
+        frame_width=784,
+        frame_height=448,
+        n_frames_per_sample=18,
+        motion_depth=1,
+        supported_camera_counts=(1,),
+    ),
+    "pa-multiview": ModelProfile(
+        filename="pth/instant_nurec_pa_multiview_1.1.0.pth",
+        context_camera_ids=(
+            "camera_front_wide_120fov",
+            "camera_cross_left_120fov",
+            "camera_cross_right_120fov",
+        ),
+        frame_width=504,
+        frame_height=280,
+        n_frames_per_sample=18,
+        motion_depth=1,
+        supported_camera_counts=(1, 3, 5),
+    ),
+}
+
+# Backward-compatible alias for callers that imported the original single
+# checkpoint constant. PA-front remains the default release profile.
+MODEL_FILENAME = MODEL_PROFILES[DEFAULT_MODEL_VARIANT].filename
+
+
+def get_model_profile(model_variant: ModelVariant | str) -> ModelProfile:
+    """Return the release profile for ``model_variant``."""
+    try:
+        return MODEL_PROFILES[model_variant]  # type: ignore[index]
+    except KeyError as e:
+        choices = ", ".join(MODEL_VARIANTS)
+        raise ValueError(f"Unknown model variant {model_variant!r}; choose one of: {choices}") from e
 
 
 class PretrainedModelError(RuntimeError):
-    """Raised when the Instant NuRec PA-front checkpoint cannot be resolved."""
+    """Raised when an Instant NuRec checkpoint cannot be resolved."""
 
 
-def download_instant_nurec_pt(*, cache_dir: Optional[str | Path] = None) -> str:
-    """Return the local path to :data:`MODEL_FILENAME`.
+def download_instant_nurec_pt(
+    model_variant: ModelVariant = DEFAULT_MODEL_VARIANT,
+    *,
+    cache_dir: Optional[str | Path] = None,
+) -> str:
+    """Return the local path to the selected release checkpoint.
 
     Resolution order:
 
@@ -53,6 +113,8 @@ def download_instant_nurec_pt(*, cache_dir: Optional[str | Path] = None) -> str:
        When ``cache_dir`` is passed it is forwarded verbatim; otherwise
        ``huggingface_hub`` uses its standard hub cache.
     """
+
+    profile = get_model_profile(model_variant)
 
     env_path = os.environ.get("INSTANT_NUREC_FULL_PT")
     if env_path and Path(env_path).exists():
@@ -72,7 +134,7 @@ def download_instant_nurec_pt(*, cache_dir: Optional[str | Path] = None) -> str:
             "pip install huggingface_hub"
         ) from e
 
-    hf_kwargs: dict = {"repo_id": MODEL_REPO_ID, "filename": MODEL_FILENAME}
+    hf_kwargs: dict = {"repo_id": MODEL_REPO_ID, "filename": profile.filename}
     if target is not None:
         hf_kwargs["cache_dir"] = str(target)
 
@@ -82,11 +144,11 @@ def download_instant_nurec_pt(*, cache_dir: Optional[str | Path] = None) -> str:
         return cached
 
     try:
-        logger.info("Downloading %s/%s ...", MODEL_REPO_ID, MODEL_FILENAME)
+        logger.info("Downloading %s/%s ...", MODEL_REPO_ID, profile.filename)
         return hf_hub_download(**hf_kwargs)
     except Exception as e:
         raise PretrainedModelError(
-            f"Could not download {MODEL_REPO_ID}/{MODEL_FILENAME}. "
+            f"Could not download {MODEL_REPO_ID}/{profile.filename}. "
             f"Set INSTANT_NUREC_FULL_PT to a local copy of "
-            f"{MODEL_FILENAME} as a fallback. Underlying error: {e}"
+            f"{profile.filename} as a fallback. Underlying error: {e}"
         ) from e

--- a/run.sh
+++ b/run.sh
@@ -46,7 +46,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$NCORE_PATH" ]] || [[ -z "$OUTPUT_DIR" ]]; then
-    echo "usage: $0 --ncore-path <path> --output-dir <path> [--merge] [--n-gaussians N] [--log-level ...]" >&2
+    echo "usage: $0 [--model pa-front|pa-multiview] --ncore-path <path> --output-dir <path> [--merge] [--n-gaussians N] [--log-level ...]" >&2
     exit 64
 fi
 

--- a/run_inference.py
+++ b/run_inference.py
@@ -18,7 +18,8 @@
 
 Invocation::
 
-    python run_inference.py --ncore-path <path> --output-dir <path> [--merge] [--n-gaussians N]
+    python run_inference.py --model <pa-front|pa-multiview> \
+        --ncore-path <path> --output-dir <path> [--merge] [--n-gaussians N]
 
 Defers to ``instant_nurec.cli.main``.
 """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,6 +55,37 @@ def test_parser_default_merge_is_false() -> None:
     assert args.merge is False
 
 
+def test_parser_defaults_to_pa_front() -> None:
+    from instant_nurec.cli import make_parser
+    args = make_parser().parse_args(["--ncore-path", "/x", "--output-dir", "/y"])
+    assert args.model == "pa-front"
+    assert args.camera_ids is None
+
+
+def test_parser_accepts_multiview_and_repeated_camera_ids() -> None:
+    from instant_nurec.cli import make_parser
+    args = make_parser().parse_args([
+        "--model", "pa-multiview",
+        "--ncore-path", "/x",
+        "--output-dir", "/y",
+        "--camera-id", "front",
+        "--camera-id", "left",
+        "--camera-id", "right",
+    ])
+    assert args.model == "pa-multiview"
+    assert args.camera_ids == ["front", "left", "right"]
+
+
+def test_parser_rejects_unknown_model() -> None:
+    from instant_nurec.cli import make_parser
+    with pytest.raises(SystemExit):
+        make_parser().parse_args([
+            "--model", "unknown",
+            "--ncore-path", "/x",
+            "--output-dir", "/y",
+        ])
+
+
 def test_parser_default_n_gaussians() -> None:
     from instant_nurec.cli import make_parser
     args = make_parser().parse_args(["--ncore-path", "/x", "--output-dir", "/y"])
@@ -163,6 +194,75 @@ def test_main_no_merge_constructs_config_with_disabled_merge(
     assert cfg.out_dir == "/o"
     assert cfg.dataset.predict.ncore_json_paths == [str(json_path.resolve())]
     assert cfg.predict.primitive_merge.enabled is False
+    assert cfg.release_profile == "pa-front"
+    assert cfg.dataset.predict.context_camera_ids == ["camera_front_wide_120fov"]
+    assert cfg.dataset.predict.camera_subsampler.frame_width == 784
+    assert cfg.dataset.predict.camera_subsampler.frame_height == 448
+
+
+def test_main_multiview_uses_release_profile(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    fake_run_predict = _install_runtime_stubs(monkeypatch)
+    json_path = _make_json_path(tmp_path)
+    from instant_nurec.cli import main
+
+    rc = main([
+        "--model", "pa-multiview",
+        "--ncore-path", str(json_path),
+        "--output-dir", "/o",
+    ])
+
+    assert rc == 0
+    cfg = fake_run_predict.call_args.args[0]
+    assert cfg.release_profile == "pa-multiview"
+    assert cfg.dataset.predict.context_camera_ids == [
+        "camera_front_wide_120fov",
+        "camera_cross_left_120fov",
+        "camera_cross_right_120fov",
+    ]
+    assert cfg.dataset.predict.supervision_camera_ids == cfg.dataset.predict.context_camera_ids
+    assert cfg.dataset.predict.camera_subsampler.frame_width == 504
+    assert cfg.dataset.predict.camera_subsampler.frame_height == 280
+    assert cfg.dataset.predict.frame_batch_sampler.n_frames_per_sample == 18
+    assert cfg.model.decoder.motion_depth == 1
+
+
+def test_main_multiview_accepts_five_camera_overrides(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    fake_run_predict = _install_runtime_stubs(monkeypatch)
+    json_path = _make_json_path(tmp_path)
+    from instant_nurec.cli import main
+    cameras = ["front", "cross-left", "cross-right", "rear-left", "rear-right"]
+    argv = [
+        "--model", "pa-multiview",
+        "--ncore-path", str(json_path),
+        "--output-dir", "/o",
+    ]
+    for camera in cameras:
+        argv.extend(["--camera-id", camera])
+
+    assert main(argv) == 0
+    cfg = fake_run_predict.call_args.args[0]
+    assert cfg.dataset.predict.context_camera_ids == cameras
+
+
+def test_main_rejects_unsupported_multiview_camera_count(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    _install_runtime_stubs(monkeypatch)
+    json_path = _make_json_path(tmp_path)
+    from instant_nurec.cli import main
+
+    with pytest.raises(ValueError, match="expects 1, 3, 5 context camera"):
+        main([
+            "--model", "pa-multiview",
+            "--ncore-path", str(json_path),
+            "--output-dir", "/o",
+            "--camera-id", "front",
+            "--camera-id", "left",
+        ])
 
 
 def test_main_lst_path_resolves_each_line(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -256,6 +256,19 @@ def test_config_post_init_no_env(tmp_path, monkeypatch):
     monkeypatch.delenv("INSTANT_NUREC_RUN_ID", raising=False)
     cfg = InstantNuRecConfig(**_make_config_kwargs(tmp_path))
     assert cfg.run_id  # auto-generated shortuuid
+    assert cfg.release_profile == "pa-front"
+
+
+def test_config_accepts_multiview_release_profile(tmp_path):
+    cfg = InstantNuRecConfig(
+        **_make_config_kwargs(tmp_path, release_profile="pa-multiview")
+    )
+    assert cfg.release_profile == "pa-multiview"
+
+
+def test_config_rejects_unknown_release_profile(tmp_path):
+    with pytest.raises(ValidationError):
+        InstantNuRecConfig(**_make_config_kwargs(tmp_path, release_profile="unknown"))
 
 
 def test_config_post_init_env_run_id_overrides(tmp_path, monkeypatch):

--- a/tests/test_pretrained.py
+++ b/tests/test_pretrained.py
@@ -51,6 +51,31 @@ def test_env_var_override_short_circuits_download(monkeypatch, tmp_path):
     assert pretrained.download_instant_nurec_pt() == str(fake_pt)
 
 
+def test_release_profiles_expose_front_and_multiview_contracts():
+    front = pretrained.get_model_profile("pa-front")
+    assert front.filename == "pth/instant_nurec_pa_front_1.1.0.pth"
+    assert front.context_camera_ids == ("camera_front_wide_120fov",)
+    assert (front.frame_width, front.frame_height) == (784, 448)
+    assert front.n_frames_per_sample == 18
+    assert front.supported_camera_counts == (1,)
+
+    multiview = pretrained.get_model_profile("pa-multiview")
+    assert multiview.filename == "pth/instant_nurec_pa_multiview_1.1.0.pth"
+    assert multiview.context_camera_ids == (
+        "camera_front_wide_120fov",
+        "camera_cross_left_120fov",
+        "camera_cross_right_120fov",
+    )
+    assert (multiview.frame_width, multiview.frame_height) == (504, 280)
+    assert multiview.n_frames_per_sample == 18
+    assert multiview.supported_camera_counts == (1, 3, 5)
+
+
+def test_unknown_release_profile_is_rejected():
+    with pytest.raises(ValueError, match="Unknown model variant"):
+        pretrained.get_model_profile("not-a-model")
+
+
 def test_env_var_pointing_at_missing_file_falls_through(monkeypatch, tmp_path):
     """If INSTANT_NUREC_FULL_PT points nowhere, we still reach hf_hub_download."""
     monkeypatch.setenv("INSTANT_NUREC_FULL_PT", str(tmp_path / "nope.pt"))
@@ -82,6 +107,24 @@ def test_download_forwards_explicit_cache_dir_kwarg(monkeypatch, tmp_path):
     assert captured["repo_id"] == pretrained.MODEL_REPO_ID
     assert captured["filename"] == pretrained.MODEL_FILENAME
     assert captured["cache_dir"] == str(tmp_path / "explicit")
+
+
+def test_download_multiview_uses_its_profile_filename(monkeypatch):
+    captured: dict = {}
+
+    def _fake_dl(**kw):
+        captured.update(kw)
+        return "/some/cached/path/instant_nurec_pa_multiview_1.1.0.pth"
+
+    fake_hf = types.ModuleType("huggingface_hub")
+    fake_hf.hf_hub_download = _fake_dl
+    fake_hf.try_to_load_from_cache = lambda **kw: None
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+
+    out = pretrained.download_instant_nurec_pt("pa-multiview")
+
+    assert out.endswith("instant_nurec_pa_multiview_1.1.0.pth")
+    assert captured["filename"] == pretrained.MODEL_PROFILES["pa-multiview"].filename
 
 
 def test_download_without_cache_dir_omits_cache_dir_kwarg(monkeypatch):

--- a/tests/test_systems_make.py
+++ b/tests/test_systems_make.py
@@ -49,12 +49,12 @@ from instant_nurec.model import (  # noqa: E402
 def test_resolve_returns_path_when_download_succeeds(monkeypatch, tmp_path):
     fake_pt = tmp_path / "instant_nurec_weights.pt"
     fake_pt.write_bytes(b"")
-    monkeypatch.setattr(pretrained, "download_instant_nurec_pt", lambda **kw: str(fake_pt))
+    monkeypatch.setattr(pretrained, "download_instant_nurec_pt", lambda *args, **kw: str(fake_pt))
     assert _resolve_model_pt_path() == str(fake_pt)
 
 
 def test_resolve_returns_none_when_download_raises(monkeypatch):
-    def _raise(**kwargs):
+    def _raise(*args, **kwargs):
         raise pretrained.PretrainedModelError("offline")
 
     monkeypatch.setattr(pretrained, "download_instant_nurec_pt", _raise)
@@ -65,13 +65,25 @@ def test_resolve_returns_none_when_download_raises(monkeypatch):
 def test_resolve_only_calls_downloader_once_per_invocation(monkeypatch):
     calls = {"n": 0}
 
-    def _fake(**kwargs):
+    def _fake(*args, **kwargs):
         calls["n"] += 1
         return "/tmp/something.pt"
 
     monkeypatch.setattr(pretrained, "download_instant_nurec_pt", _fake)
     _resolve_model_pt_path()
     assert calls["n"] == 1
+
+
+def test_resolve_forwards_multiview_variant(monkeypatch):
+    calls = []
+
+    def _fake(model_variant, **kwargs):
+        calls.append(model_variant)
+        return "/tmp/multiview.pth"
+
+    monkeypatch.setattr(pretrained, "download_instant_nurec_pt", _fake)
+    assert _resolve_model_pt_path("pa-multiview") == "/tmp/multiview.pth"
+    assert calls == ["pa-multiview"]
 
 
 # ---------- _validate_camera_ids ----------
@@ -168,10 +180,10 @@ def test_load_model_state_dict_rejects_legacy_traced_archive_before_torch_load(
 
 
 def test_make_raises_when_checkpoint_cannot_be_resolved(monkeypatch):
-    monkeypatch.setattr(model_mod, "_resolve_model_pt_path", lambda: None)
+    monkeypatch.setattr(model_mod, "_resolve_model_pt_path", lambda model_variant: None)
 
     with pytest.raises(ModelNotFoundError, match=pretrained.MODEL_FILENAME):
-        model_mod.make(SimpleNamespace())
+        model_mod.make(SimpleNamespace(release_profile="pa-front"))
 
 
 def test_make_builds_source_core_and_loads_weights(monkeypatch, tmp_path):
@@ -202,13 +214,22 @@ def test_make_builds_source_core_and_loads_weights(monkeypatch, tmp_path):
         camera_subsampler=SimpleNamespace(frame_height=448, frame_width=784),
     )
     config = SimpleNamespace(
+        release_profile="pa-front",
         model=model_config,
         dataset=SimpleNamespace(predict=dataset_config),
     )
 
-    monkeypatch.setattr(model_mod, "_resolve_model_pt_path", lambda: str(checkpoint))
+    monkeypatch.setattr(
+        model_mod,
+        "_resolve_model_pt_path",
+        lambda model_variant: calls.update(model_variant=model_variant) or str(checkpoint),
+    )
     monkeypatch.setattr(model_mod, "_preflight_validate_camera_ids", lambda cfg: calls.setdefault("preflight", cfg))
-    monkeypatch.setattr(model_mod, "_load_model_state_dict", lambda path: state_dict)
+    monkeypatch.setattr(
+        model_mod,
+        "_load_model_state_dict",
+        lambda path, **kwargs: state_dict,
+    )
     monkeypatch.setattr(model_mod, "KelvinStaticCore", FakeCore)
     monkeypatch.setattr(model_mod, "KelvinInferenceModel", FakeInference)
     monkeypatch.setattr(
@@ -221,6 +242,7 @@ def test_make_builds_source_core_and_loads_weights(monkeypatch, tmp_path):
 
     assert result is sentinel_system
     assert calls["preflight"] is config
+    assert calls["model_variant"] == "pa-front"
     assert calls["core_config"] is model_config
     assert calls["loaded"] is state_dict
     assert calls["strict"] is True


### PR DESCRIPTION
## Summary

- add a `pa-multiview` pixel-aligned release profile alongside the existing `pa-front` default
- select profile-specific Hugging Face checkpoints and input contracts through `--model`
- configure PA-multiview for 18 frames per camera across front-wide, cross-left, and cross-right at 504x280 (54 images total)
- allow repeatable `--camera-id` overrides for supported 1-, 3-, and 5-camera multiview layouts
- document model selection, local checkpoint overrides, memory expectations, and troubleshooting

## Compatibility

- `pa-front` remains the default, including the backward-compatible `MODEL_FILENAME` alias
- existing static/dynamic filtering behavior is unchanged; this PR does not add a blanket `MOVABLE` semantic-class filter
- this PR contains only public runtime, documentation, and test changes

## Public checkpoint

- https://huggingface.co/nvidia/instant-nurec/blob/main/pth/instant_nurec_pa_multiview_1.1.0.pth
- 730,202,407 bytes
- SHA-256 / LFS OID: `946e2f66aca98ce8bcdbb2d84f4292ffc2c0a59958c6a8410d24cce3d4b3933a`
- 574-tensor weights-only checkpoint; strict state-dict loading succeeds

## Validation

Set up from the public checkout using the README instructions:

```bash
./setup.sh
source .venv/bin/activate
```

Then ran:

```bash
.venv/bin/ruff check .
.venv/bin/python -m pytest tests/ -q
git diff --check
```

- `487 passed, 2 skipped`
- Ruff passed
- diff check passed

End-to-end PA-multiview inference on the public demo clip also succeeded on an RTX 5090 with two static PLY chunks:

- chunk 0: 2,967,877 Gaussians
- chunk 1: 2,659,108 Gaussians
- zero non-finite-density Gaussians removed
