### PR TITLE
feat(model): release point-query front profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ htmlcov/
 .scratch*/
 
 # Generated runtime artifacts
+artifacts/
 *.pt
 *.ckpt
 *.pkl

--- a/README.md
+++ b/README.md
@@ -3,24 +3,24 @@
 
 # InstantNuRec: Feed-Forward 3D Gaussian Reconstruction from Driving Logs
 
-[![Project Page](https://img.shields.io/badge/Project-Page-green)](https://research.nvidia.com/labs/sil/projects/instant-nurec/) [![Paper](https://img.shields.io/badge/arXiv-Paper-b31b1b?logo=arxiv)](https://research.nvidia.com/labs/sil/projects/instant-nurec/assets/InstantNuRec.pdf) [![License](https://img.shields.io/badge/License-Apache--2.0-orange)](LICENSE.txt) [![Model](https://img.shields.io/badge/HF-Model-yellow?logo=huggingface&style=flat-square)](https://huggingface.co/nvidia/instant-nurec) [![Data](https://img.shields.io/badge/NCore-0d9488?logo=database&logoColor=white&style=flat-square)](https://huggingface.co/datasets/nvidia/PhysicalAI-Autonomous-Vehicles-NCore)
+[![Project Page](https://img.shields.io/badge/Project-Page-green)](https://research.nvidia.com/labs/sil/projects/instant-nurec/) [![Paper](https://img.shields.io/badge/arXiv-Paper-b31b1b?logo=arxiv)](https://arxiv.org/pdf/2607.14203) [![License](https://img.shields.io/badge/License-Apache--2.0-orange)](LICENSE.txt) [![Model](https://img.shields.io/badge/HF-Model-yellow?logo=huggingface&style=flat-square)](https://huggingface.co/nvidia/instant-nurec) [![Data](https://img.shields.io/badge/NCore-0d9488?logo=database&logoColor=white&style=flat-square)](https://huggingface.co/datasets/nvidia/PhysicalAI-Autonomous-Vehicles-NCore)
 
 **NVIDIA**
 
 ## Announcements
 
-- **July 2026:** The [InstantNuRec project page](https://research.nvidia.com/labs/sil/projects/instant-nurec/) and [paper](https://research.nvidia.com/labs/sil/projects/instant-nurec/assets/InstantNuRec.pdf) are now available.
+- **July 2026:** The [InstantNuRec project page](https://research.nvidia.com/labs/sil/projects/instant-nurec/) and [paper](https://arxiv.org/pdf/2607.14203) are now available.
 
-### Abstract
+## Abstract
 
-Reconstructing dynamic outdoor scenes from autonomous-vehicle driving
-logs traditionally requires lengthy per-scene optimization. InstantNuRec
-takes a different route: a feed-forward transformer directly infers a
-dynamic 3D-Gaussian scene representation in a single forward pass.
-Given a short window of multi-camera observations from an AV log, the
-model emits a Gaussian primitive per pixel — covering geometry,
-appearance, and per-Gaussian motion — which can be rendered in real
-time and interchanged with existing simulation pipelines.
+3D simulation platforms are critical for autonomous driving because they enable end-to-end policy evaluation, thereby reducing development costs and improving safety. In recent years, neural simulation has become predominant, with methods such as NuRec playing a central role; however, these methods remain relatively slow and typically require per-scene tuning. In this work, we present Instant NuRec, a feed-forward neural reconstruction model that turns a short multi-view driving log into a fully simulatable 3D Gaussian Splatting (3DGS) world in a single forward pass. The model accepts multi-view input from a calibrated camera rig and emits a layered output consisting of static and dynamic 3DGS layers, a sky cubemap, and per-camera ISP corrections, while providing native support for non-pinhole camera models via 3DGUT. It reconstructs a 10–20-second multi-camera scene in roughly 1.5 seconds and achieves a PSNR on the Waymo Open Dataset that is 2.01 dB above the strongest evaluated baseline. Instant NuRec is deeply integrated into NuRec and is compatible with AlpaSim for closed-loop simulation.
+
+> **Repository scope:** This standalone CLI exports only the static scene
+> Gaussians to PLY. The abstract above describes the complete research model.
+
+![InstantNuRec demo](docs/demo.gif)
+
+## Pipeline Overview
 
 This repo goes from ncorev4 ingest → frame batch prep → forward pass
 → 3D-Gaussian PLY export. The PLY output is usable directly as a
@@ -34,45 +34,7 @@ but run on different runtimes: Instant-NuRec is a native-Python
 feed-forward preview (seconds per clip); NuRec is a Docker-based
 per-scene refinement pipeline that produces a high-fidelity USDZ.
 
-![InstantNuRec demo](docs/demo.gif)
-
-### Background
-
-Instant NuRec is a feed-forward reconstruction model that converts
-driving logs into 3D Gaussian Splatting (3DGS) representations. Its
-vision-transformer backbone and DPT-decoders output a high-fidelity
-3D environment that's ready for simulations.
-
-Instant NuRec leverages the following foundational technologies:
-[Depth-Anything-V3](https://github.com/ByteDance-Seed/depth-anything-3),
-[STORM](https://github.com/NVlabs/GaussianSTORM), and
-[BTimer](https://research.nvidia.com/labs/toronto-ai/bullet-timer/).
-
-## Pipeline Overview
-
 NCore V4 Sequence ─► Frame Batching ─► Eager PyTorch Model ─► 3D Gaussians ─► PLY (per-chunk or merged)
-
-## Model Architecture
-
-The released PA-front and PA-multiview models are implemented entirely
-in this repository. Their pixel-aligned pipeline consists of:
-
-1. a multi-view vision-transformer encoder with alternating local and
-   global attention;
-2. DPT heads for depth, RGB, normals, semantics, Gaussian parameters,
-   and motion;
-3. a cubemap sky decoder; and
-4. per-camera affine color post-processing.
-
-The reusable attention, embedding, DPT, and camera-encoding layers live
-under [`instant_nurec/model/blocks`](instant_nurec/model/blocks), the
-encoder/decoder definitions under
-[`instant_nurec/model/backbone`](instant_nurec/model/backbone), and the
-complete model composition in
-[`instant_nurec/model/kelvin.py`](instant_nurec/model/kelvin.py).
-Inference runs the PLY-relevant heads directly from source via
-[`static_core.py`](instant_nurec/model/static_core.py); the downloaded
-checkpoint contains weights only.
 
 ## User Guide
 
@@ -125,7 +87,8 @@ This places the following files in `checkpoints/`:
     checkpoints/
     └── pth/
         ├── instant_nurec_pa_front_1.1.0.pth
-        └── instant_nurec_pa_multiview_1.1.0.pth
+        ├── instant_nurec_pa_multiview_1.1.0.pth
+        └── instant_nurec_pq_road_1.0.0.pth
 
 Point the pipeline at this local copy by exporting:
 
@@ -146,12 +109,13 @@ selection.
 > subsequent runs read them from the cache. Set `INSTANT_NUREC_FULL_PT`
 > to a matching local checkpoint to override the auto-download.
 
-Two pixel-aligned release profiles are available:
+The following inference profiles are available:
 
-| profile | checkpoint | default input |
+| model | description | default input |
 | --- | --- | --- |
-| `pa-front` | `pth/instant_nurec_pa_front_1.1.0.pth` | 18 × `camera_front_wide_120fov`, 784×448 |
-| `pa-multiview` | `pth/instant_nurec_pa_multiview_1.1.0.pth` | 18 frames per camera across front-wide, cross-left, and cross-right, 504×280 (54 images total) |
+| `pa-front` | Front-camera profile. **Dense pixel-aligned** Gaussians. | 18 × `camera_front_wide_120fov`, 784×448 |
+| `pa-multiview` | 1, 3, or 5 cameras. **Dense pixel-aligned** Gaussians. | 18 frames per camera across front-wide, cross-left, and cross-right, 504×280 (54 images total) |
+| `pq-front` | Fixed front-wide camera. **Selective point-query** Gaussians (fewer outputs). | 18 × `camera_front_wide_120fov`, 784×448 |
 
 ##### First run — end-to-end on a public demo clip
 
@@ -169,35 +133,22 @@ hf download \
 
 # Reconstruct it
 python run_inference.py \
+    --model pa-front \
     --ncore-path ./demo_clip/clips/000da9de-0ee5-465a-9a2d-e7e91d3016bb/pai_000da9de-0ee5-465a-9a2d-e7e91d3016bb.json \
     --output-dir ./demo_output \
     --merge
 ```
 
-To run the pixel-aligned multiview model on the same clip, add its model
-profile. The default three-camera ordering matches the released model's
-inference configuration:
-
-```bash
-python run_inference.py \
-    --model pa-multiview \
-    --ncore-path ./demo_clip/clips/000da9de-0ee5-465a-9a2d-e7e91d3016bb/pai_000da9de-0ee5-465a-9a2d-e7e91d3016bb.json \
-    --output-dir ./demo_output_multiview \
-    --merge
-```
-
-`--camera-id` can be repeated to override the profile camera set. The
-multiview checkpoint supports 1, 3, or 5 context cameras; each camera
-contributes 18 frames. Five-camera inference has a larger working set and
-may require more GPU memory.
-
-Success looks like a single PLY at
+For the default `pa-front` command above, success looks like a single PLY at
 `./demo_output/<run_id>/ply/pai_000da9de-.../pai_000da9de-....ply` —
 ~1.88 M Gaussians, kl-optimal voxelized from 2.87 M merged (3.18 M
 pre-merge across 2 chunks) to land in `[0.9 * --n-gaussians,
 --n-gaussians]` (default target 2 M). Omit `--merge` to write
 per-chunk PLYs instead (voxelization is bundled with merge and
 runs only when the flag is set).
+
+To run another model on the same clip, select its profile, such as
+`--model pa-multiview` or `--model pq-front`.
 
 ##### View your output
 
@@ -257,13 +208,13 @@ Output layout: PLYs only, under `out_dir/<run_id>/ply/<sequence_id>/...ply`.
 
 | flag | default | purpose |
 | --- | --- | --- |
-| `--model` | `pa-front` | Released input/checkpoint profile: `pa-front` or `pa-multiview`. |
+| `--model` | `pa-front` | Input/checkpoint profile: `pa-front`, `pa-multiview`, or `pq-front`. |
 | `--ncore-path` | (required) | A `.json` file (single sequence) or a `.lst` manifest (one JSON path per line). |
 | `--output-dir` | (required) | Directory the pipeline writes PLYs into. |
 | `--merge` | absent (false) | Boolean flag. When set, merges per-chunk primitives into a single frustum-ownership PLY per sequence (`<seq>.ply`) and runs kl-optimal voxelization (target count from `--n-gaussians`). Absent (default): per-chunk PLYs (`<seq>_chunk{N}.ply`), no voxelization. |
 | `--n-gaussians` | `2000000` | Target number of static Gaussians after voxelization. Only consulted when `--merge` is set. The voxel size is searched iteratively via bracketed binary search to land the count in `[0.9 * target, target]`. |
-| `--camera-id` | profile-dependent | Override a context camera. Repeat once per camera in canonical order. PA-front requires 1; PA-multiview supports 1, 3, or 5 and defaults to front-wide, cross-left, cross-right. |
-| `--max-chunks` | `8` | Maximum number of time-chunks processed per clip. One chunk spans up to 13.5 s, so the default covers 8 × 13.5 = 108 s. Longer clips are truncated and a `WARNING` is logged naming the dropped chunk count and the `--max-chunks` value needed to cover the full clip — bump to `ceil(clip_seconds / 13.5)` to silence it. |
+| `--camera-id` | profile-dependent | Override a context camera. Repeat once per camera in canonical order. `pa-front` requires 1; `pa-multiview` supports 1, 3, or 5; `pq-front` is fixed to `camera_front_wide_120fov`. |
+| `--max-chunks` | `8` | Maximum number of time-chunks processed per clip. One chunk spans up to 13.5 s, so the default covers 108 s. Longer clips are truncated and a `WARNING` logs the required value. |
 | `--log-level` | `INFO` | `DEBUG` / `INFO` / `WARNING` / `ERROR` / `CRITICAL`. |
 
 #### Environment variables
@@ -286,9 +237,9 @@ instant-nurec/
 │   ├── config_schema/              # pydantic schemas + public architecture defaults
 │   ├── datasets/                   # ncorev4 ingest + cuboid-track helpers
 │   ├── model/
-│   │   ├── backbone/               # multi-view encoder, DPT decoder, sky decoder
+│   │   ├── backbone/               # multi-view encoder, dense/PQ decoders, sky decoder
 │   │   ├── blocks/                 # attention, embeddings, DPT, camera encoding
-│   │   ├── kelvin.py               # complete source model composition
+│   │   ├── kelvin.py               # dense full-model composition
 │   │   ├── static_core.py          # eager PLY-reconstruction heads
 │   │   ├── inference.py            # masking + primitive packaging
 │   │   └── system.py               # predict-loop harness
@@ -329,8 +280,11 @@ as initialization for per-scene refinement.
 For common errors and fixes (HF auth, driver / CUDA mismatch, OOM at
 chunk-prep, `--max-chunks` truncation), see
 [TROUBLESHOOTING.md](TROUBLESHOOTING.md). Anything not listed there:
-file a GitHub issue with the full traceback, `nvidia-smi`, and
-`python --version`.
+file a [GitHub issue](../../issues/new/choose). For runtime bugs, include the
+full traceback, `nvidia-smi`, and `python --version`. Report security
+vulnerabilities through [NVIDIA's Vulnerability Disclosure
+Program](https://app.intigriti.com/programs/nvidia/nvidiavdp/detail); do not
+file security issues publicly.
 
 ## License
 
@@ -343,12 +297,13 @@ in [THIRD_PARTY_LICENSE.txt](THIRD_PARTY_LICENSE.txt).
 If you find this work useful in your research, please consider citing:
 
 ```bibtex
-@misc{instantnurec2026,
-  author       = {{NVIDIA}},
-  title        = {Instant NuRec},
-  year         = {2026},
-  publisher    = {GitHub},
-  howpublished = {\url{https://github.com/NVIDIA/instant-nurec}}
+@techreport{nvidia2026instantnurec,
+  title       = {Instant NuRec: Feed-Forward 3D Gaussian Reconstruction
+                 for Driving Scene Simulation},
+  author      = {{NVIDIA}},
+  institution = {NVIDIA},
+  year        = {2026},
+  url         = {https://arxiv.org/abs/2607.14203}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ NCore V4 Sequence ─► Frame Batching ─► Eager PyTorch Model ─► 3D Gau
 
 ## Model Architecture
 
-The released model is implemented entirely in this repository. Its
-pixel-aligned pipeline consists of:
+The released PA-front and PA-multiview models are implemented entirely
+in this repository. Their pixel-aligned pipeline consists of:
 
 1. a multi-view vision-transformer encoder with alternating local and
    global attention;
@@ -107,8 +107,9 @@ image as a generic CUDA environment.
 
 #### Download Model Checkpoints [optional]
 
-> **Note:** `pth/instant_nurec_pa_front_1.1.0.pth` is auto-downloaded into the Hugging Face
-> hub cache on the first inference run.
+> **Note:** The checkpoint selected by `--model` is auto-downloaded into
+> the Hugging Face hub cache on the first inference run. PA-front remains
+> the default.
 
 However, you can also manually download the model into a directory of
 your choice:
@@ -119,11 +120,12 @@ hf auth login
 hf download nvidia/instant-nurec --local-dir checkpoints
 ```
 
-This places the following file in `checkpoints/`:
+This places the following files in `checkpoints/`:
 
     checkpoints/
     └── pth/
-        └── instant_nurec_pa_front_1.1.0.pth
+        ├── instant_nurec_pa_front_1.1.0.pth
+        └── instant_nurec_pa_multiview_1.1.0.pth
 
 Point the pipeline at this local copy by exporting:
 
@@ -131,16 +133,25 @@ Point the pipeline at this local copy by exporting:
 export INSTANT_NUREC_FULL_PT="$(pwd)/checkpoints/pth/instant_nurec_pa_front_1.1.0.pth"
 ```
 
+When using a local override, make sure the file matches the `--model`
+selection.
+
 </details>
 
 <details>
 <summary><b>Inference</b></summary>
 
-> **Note:** The pretrained weights `pth/instant_nurec_pa_front_1.1.0.pth` are fetched
-> on first inference run from the Hugging Face
-> repo `nvidia/instant-nurec` and cached locally; subsequent runs read
-> it from the cache. Set `INSTANT_NUREC_FULL_PT` to a local path to
-> override the auto-download.
+> **Note:** The selected pretrained weights are fetched on first inference
+> from the Hugging Face repo `nvidia/instant-nurec` and cached locally;
+> subsequent runs read them from the cache. Set `INSTANT_NUREC_FULL_PT`
+> to a matching local checkpoint to override the auto-download.
+
+Two pixel-aligned release profiles are available:
+
+| profile | checkpoint | default input |
+| --- | --- | --- |
+| `pa-front` | `pth/instant_nurec_pa_front_1.1.0.pth` | 18 × `camera_front_wide_120fov`, 784×448 |
+| `pa-multiview` | `pth/instant_nurec_pa_multiview_1.1.0.pth` | 18 frames per camera across front-wide, cross-left, and cross-right, 504×280 (54 images total) |
 
 ##### First run — end-to-end on a public demo clip
 
@@ -162,6 +173,23 @@ python run_inference.py \
     --output-dir ./demo_output \
     --merge
 ```
+
+To run the pixel-aligned multiview model on the same clip, add its model
+profile. The default three-camera ordering matches the released model's
+inference configuration:
+
+```bash
+python run_inference.py \
+    --model pa-multiview \
+    --ncore-path ./demo_clip/clips/000da9de-0ee5-465a-9a2d-e7e91d3016bb/pai_000da9de-0ee5-465a-9a2d-e7e91d3016bb.json \
+    --output-dir ./demo_output_multiview \
+    --merge
+```
+
+`--camera-id` can be repeated to override the profile camera set. The
+multiview checkpoint supports 1, 3, or 5 context cameras; each camera
+contributes 18 frames. Five-camera inference has a larger working set and
+may require more GPU memory.
 
 Success looks like a single PLY at
 `./demo_output/<run_id>/ply/pai_000da9de-.../pai_000da9de-....ply` —
@@ -229,11 +257,12 @@ Output layout: PLYs only, under `out_dir/<run_id>/ply/<sequence_id>/...ply`.
 
 | flag | default | purpose |
 | --- | --- | --- |
+| `--model` | `pa-front` | Released input/checkpoint profile: `pa-front` or `pa-multiview`. |
 | `--ncore-path` | (required) | A `.json` file (single sequence) or a `.lst` manifest (one JSON path per line). |
 | `--output-dir` | (required) | Directory the pipeline writes PLYs into. |
 | `--merge` | absent (false) | Boolean flag. When set, merges per-chunk primitives into a single frustum-ownership PLY per sequence (`<seq>.ply`) and runs kl-optimal voxelization (target count from `--n-gaussians`). Absent (default): per-chunk PLYs (`<seq>_chunk{N}.ply`), no voxelization. |
 | `--n-gaussians` | `2000000` | Target number of static Gaussians after voxelization. Only consulted when `--merge` is set. The voxel size is searched iteratively via bracketed binary search to land the count in `[0.9 * target, target]`. |
-| `--camera-id` | `camera_front_wide_120fov` | ncorev4 context-camera id used as model input. Exactly one camera is required. |
+| `--camera-id` | profile-dependent | Override a context camera. Repeat once per camera in canonical order. PA-front requires 1; PA-multiview supports 1, 3, or 5 and defaults to front-wide, cross-left, cross-right. |
 | `--max-chunks` | `8` | Maximum number of time-chunks processed per clip. One chunk spans up to 13.5 s, so the default covers 8 × 13.5 = 108 s. Longer clips are truncated and a `WARNING` is logged naming the dropped chunk count and the `--max-chunks` value needed to cover the full clip — bump to `ceil(clip_seconds / 13.5)` to silence it. |
 | `--log-level` | `INFO` | `DEBUG` / `INFO` / `WARNING` / `ERROR` / `CRITICAL`. |
 
@@ -241,7 +270,7 @@ Output layout: PLYs only, under `out_dir/<run_id>/ply/<sequence_id>/...ply`.
 
 | variable | purpose |
 | --- | --- |
-| `INSTANT_NUREC_FULL_PT` | Absolute path to a local `instant_nurec_pa_front_1.1.0.pth`. Takes priority over the auto-downloaded copy. |
+| `INSTANT_NUREC_FULL_PT` | Absolute path to a local weights-only checkpoint matching `--model`. Takes priority over the auto-downloaded copy. |
 | `INSTANT_NUREC_RUN_ID` | Override the per-run shortuuid; useful when scripting reproducible output paths. |
 
 </details>

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -3,13 +3,16 @@
 | Symptom | Cause | Fix |
 | --- | --- | --- |
 | `PretrainedModelError: Could not download nvidia/instant-nurec/pth/instant_nurec_pa_front_1.1.0.pth` | No network / proxy blocks `huggingface.co` or `*.cloudfront.net` | Set `HTTPS_PROXY`, or copy `instant_nurec_pa_front_1.1.0.pth` locally and set `INSTANT_NUREC_FULL_PT` to its absolute path. |
-| `ModelCheckpointError: ... is a legacy traced-model archive` | `INSTANT_NUREC_FULL_PT` points at the retired artifact | Download `pth/instant_nurec_pa_front_1.1.0.pth` and update the environment variable. |
+| `PretrainedModelError: Could not download nvidia/instant-nurec/pth/instant_nurec_pa_multiview_1.1.0.pth` | The PA-multiview artifact is unavailable or network access is blocked | Set `HTTPS_PROXY`, or copy `instant_nurec_pa_multiview_1.1.0.pth` locally, select `--model pa-multiview`, and set `INSTANT_NUREC_FULL_PT` to its absolute path. |
+| `ModelCheckpointError: ... is a legacy traced-model archive` | `INSTANT_NUREC_FULL_PT` points at the retired artifact | Download the weights-only checkpoint matching `--model` and update the environment variable. |
+| `RuntimeError: Error(s) in loading state_dict` after setting `INSTANT_NUREC_FULL_PT` | The local override does not match `--model` | Use `instant_nurec_pa_front_1.1.0.pth` with `pa-front`, or `instant_nurec_pa_multiview_1.1.0.pth` with `pa-multiview`. |
 | `PretrainedModelError: huggingface_hub is required` | Dependency missing | `uv sync --frozen`. |
 | `ValueError: --ncore-path ...: not an existing JSON/LST file` | Path doesn't resolve | Check the resolved path; `.lst` entries resolve relative to the LST file's dir, not `$PWD`. |
 | `ValueError: --ncore-path must end in .json or .lst` | Wrong suffix | Pass a single `.json` or a `.lst` manifest. |
 | `InstantNuRecDataError: Context camera <id> not found in supervision cameras [...]` | `--camera-id` not in the ncorev4 sequence | Inspect the JSON's camera list and pass a matching id. |
+| `ValueError: pa-multiview expects 1, 3, 5 context camera(s)` | Unsupported number of repeated `--camera-id` flags | Use the default three cameras, or pass exactly 1, 3, or 5 camera ids. |
 | `RuntimeError: Found no NVIDIA driver` / `Torch not compiled with CUDA enabled` | No GPU, driver below the [NuRec hardware minimums](https://docs.nvidia.com/nurec/basics/hardware.html#hardware-setup-and-requirements), or non-CUDA torch wheel | `nvidia-smi` to confirm GPU + driver; `python -c "import torch; print(torch.cuda.is_available())"` must be `True`. No CPU fallback exists. |
-| `torch.cuda.OutOfMemoryError` during `Predicting in chunks` | `--max-chunks` × per-chunk working set exceeds VRAM | Lower `--max-chunks`. |
+| `torch.cuda.OutOfMemoryError` during `Predicting in chunks` | The per-chunk working set exceeds VRAM; PA-multiview and five-camera overrides use more memory | Prefer the default three-camera multiview profile (or one camera), and lower `--max-chunks` to reduce host-side batching. |
 | `WARNING ... Clip spans Xs ... chunk(s) will be silently dropped` | Clip longer than `--max-chunks × 13.5 s` (default 108 s) | Bump `--max-chunks` to the value the warning prints. |
 
 For anything not listed, file a GitHub issue with the full traceback, `nvidia-smi`, `python --version`, and `pip list | grep -iE "torch|huggingface|instant"`.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -4,15 +4,16 @@
 | --- | --- | --- |
 | `PretrainedModelError: Could not download nvidia/instant-nurec/pth/instant_nurec_pa_front_1.1.0.pth` | No network / proxy blocks `huggingface.co` or `*.cloudfront.net` | Set `HTTPS_PROXY`, or copy `instant_nurec_pa_front_1.1.0.pth` locally and set `INSTANT_NUREC_FULL_PT` to its absolute path. |
 | `PretrainedModelError: Could not download nvidia/instant-nurec/pth/instant_nurec_pa_multiview_1.1.0.pth` | The PA-multiview artifact is unavailable or network access is blocked | Set `HTTPS_PROXY`, or copy `instant_nurec_pa_multiview_1.1.0.pth` locally, select `--model pa-multiview`, and set `INSTANT_NUREC_FULL_PT` to its absolute path. |
+| `PretrainedModelError: Could not download nvidia/instant-nurec/pth/instant_nurec_pq_road_1.0.0.pth` | The point-query artifact is unavailable or network access is blocked | Set `HTTPS_PROXY`, or copy `instant_nurec_pq_road_1.0.0.pth` locally, select `--model pq-front`, and set `INSTANT_NUREC_FULL_PT` to its absolute path. |
 | `ModelCheckpointError: ... is a legacy traced-model archive` | `INSTANT_NUREC_FULL_PT` points at the retired artifact | Download the weights-only checkpoint matching `--model` and update the environment variable. |
-| `RuntimeError: Error(s) in loading state_dict` after setting `INSTANT_NUREC_FULL_PT` | The local override does not match `--model` | Use `instant_nurec_pa_front_1.1.0.pth` with `pa-front`, or `instant_nurec_pa_multiview_1.1.0.pth` with `pa-multiview`. |
+| `RuntimeError: Error(s) in loading state_dict` after setting `INSTANT_NUREC_FULL_PT` | The local override does not match `--model` | Use the PA-front checkpoint with `pa-front`, PA-multiview with `pa-multiview`, or the PQ-road checkpoint with `pq-front`. |
 | `PretrainedModelError: huggingface_hub is required` | Dependency missing | `uv sync --frozen`. |
 | `ValueError: --ncore-path ...: not an existing JSON/LST file` | Path doesn't resolve | Check the resolved path; `.lst` entries resolve relative to the LST file's dir, not `$PWD`. |
 | `ValueError: --ncore-path must end in .json or .lst` | Wrong suffix | Pass a single `.json` or a `.lst` manifest. |
 | `InstantNuRecDataError: Context camera <id> not found in supervision cameras [...]` | `--camera-id` not in the ncorev4 sequence | Inspect the JSON's camera list and pass a matching id. |
 | `ValueError: pa-multiview expects 1, 3, 5 context camera(s)` | Unsupported number of repeated `--camera-id` flags | Use the default three cameras, or pass exactly 1, 3, or 5 camera ids. |
 | `RuntimeError: Found no NVIDIA driver` / `Torch not compiled with CUDA enabled` | No GPU, driver below the [NuRec hardware minimums](https://docs.nvidia.com/nurec/basics/hardware.html#hardware-setup-and-requirements), or non-CUDA torch wheel | `nvidia-smi` to confirm GPU + driver; `python -c "import torch; print(torch.cuda.is_available())"` must be `True`. No CPU fallback exists. |
-| `torch.cuda.OutOfMemoryError` during `Predicting in chunks` | The per-chunk working set exceeds VRAM; PA-multiview and five-camera overrides use more memory | Prefer the default three-camera multiview profile (or one camera), and lower `--max-chunks` to reduce host-side batching. |
-| `WARNING ... Clip spans Xs ... chunk(s) will be silently dropped` | Clip longer than `--max-chunks × 13.5 s` (default 108 s) | Bump `--max-chunks` to the value the warning prints. |
+| `torch.cuda.OutOfMemoryError` during `Predicting in chunks` | The per-chunk working set exceeds VRAM; multiview and five-camera overrides use more memory | For PA-multiview, prefer the default three-camera profile (or one camera) over a five-camera override. |
+| `WARNING ... Clip spans Xs ... chunk(s) will be silently dropped` | Clip exceeds `--max-chunks × 13.5 s` (108 s by default) | Bump `--max-chunks` to the value the warning prints. |
 
 For anything not listed, file a GitHub issue with the full traceback, `nvidia-smi`, `python --version`, and `pip list | grep -iE "torch|huggingface|instant"`.

--- a/instant_nurec/cli.py
+++ b/instant_nurec/cli.py
@@ -48,8 +48,10 @@ def make_parser() -> argparse.ArgumentParser:
         choices=MODEL_VARIANTS,
         default=DEFAULT_MODEL_VARIANT,
         help=(
-            "Released model profile. pa-front uses one 784x448 camera; "
-            "pa-multiview uses three 504x280 cameras by default. "
+            "Released model profile. pa-front uses one 784x448 camera with 18 frames; "
+            "pa-multiview uses three 504x280 cameras with 18 frames each by default; "
+            "pq-front uses the selective point-query decoder with 18 front-camera "
+            "frames. "
             f"Default: {DEFAULT_MODEL_VARIANT}."
         ),
     )
@@ -102,9 +104,10 @@ def make_parser() -> argparse.ArgumentParser:
         default=None,
         help=(
             "Override a profile's ncorev4 context camera. Repeat the flag to "
-            "provide multiple cameras in canonical order. pa-front requires "
-            "one camera; pa-multiview supports 1, 3, or 5. If omitted, the "
-            "selected profile's camera set is used."
+            "provide multiple cameras in canonical order. The selected profile "
+            "validates its camera contract. pq-front is fixed to "
+            "camera_front_wide_120fov. If omitted, the profile's default camera "
+            "set is used."
         ),
     )
     parser.add_argument(
@@ -113,11 +116,10 @@ def make_parser() -> argparse.ArgumentParser:
         default=_DEFAULT_MAX_CHUNKS,
         help=(
             f"Maximum number of time-chunks processed per clip "
-            f"(default: {_DEFAULT_MAX_CHUNKS}). One chunk spans up to 13.5 s, "
-            f"so the default covers 8 * 13.5 = 108 s. Longer clips are "
+            f"(default: {_DEFAULT_MAX_CHUNKS}). One chunk spans up to 13.5 s. "
+            f"Longer clips are "
             f"truncated and a WARNING is logged naming the dropped chunk "
-            f"count and the --max-chunks value needed to cover the full clip; "
-            f"bump it to ceil(clip_seconds / 13.5) to silence the warning."
+            f"count and the --max-chunks value needed to cover the full clip."
         ),
     )
     parser.add_argument(
@@ -140,7 +142,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         InstantNuRecSplitsConfig,
     )
     from instant_nurec.config_schema.instantnurec import InstantNuRecConfig
-    from instant_nurec.config_schema.models import KelvinDPTDecoderConfig, KelvinModelConfig
+    from instant_nurec.config_schema.models import (
+        KelvinDPTDecoderConfig,
+        KelvinModelConfig,
+        KelvinPointQueryCADecoderConfig,
+    )
     from instant_nurec.config_schema.predict import PredictConfig, PrimitiveMergeConfig
     from instant_nurec.ncore_input import resolve_ncore_paths
     from instant_nurec.predict.run import run_predict
@@ -156,11 +162,17 @@ def main(argv: Sequence[str] | None = None) -> int:
             "Repeat --camera-id once per camera."
         )
 
+    decoder_config = (
+        KelvinPointQueryCADecoderConfig(motion_depth=profile.motion_depth)
+        if profile.decoder_kind == "point-query"
+        else KelvinDPTDecoderConfig(motion_depth=profile.motion_depth)
+    )
+
     config = InstantNuRecConfig(
         out_dir=str(args.output_dir),
         release_profile=args.model,
         model=KelvinModelConfig(
-            decoder=KelvinDPTDecoderConfig(motion_depth=profile.motion_depth),
+            decoder=decoder_config,
         ),
         dataset=InstantNuRecSplitsConfig(
             predict=NCoreInstantNuRecDatasetConfig(

--- a/instant_nurec/cli.py
+++ b/instant_nurec/cli.py
@@ -28,8 +28,12 @@ import sys
 from pathlib import Path
 from typing import Sequence
 
+from instant_nurec.pretrained import (
+    DEFAULT_MODEL_VARIANT,
+    MODEL_VARIANTS,
+    get_model_profile,
+)
 
-_DEFAULT_CAMERA_ID = "camera_front_wide_120fov"
 _DEFAULT_MAX_CHUNKS = 8
 _DEFAULT_N_GAUSSIANS = 2_000_000
 
@@ -38,6 +42,16 @@ def make_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="instant_nurec",
         description="Standalone Kelvin predict-mode CLI.",
+    )
+    parser.add_argument(
+        "--model",
+        choices=MODEL_VARIANTS,
+        default=DEFAULT_MODEL_VARIANT,
+        help=(
+            "Released model profile. pa-front uses one 784x448 camera; "
+            "pa-multiview uses three 504x280 cameras by default. "
+            f"Default: {DEFAULT_MODEL_VARIANT}."
+        ),
     )
     parser.add_argument(
         "--ncore-path",
@@ -81,13 +95,16 @@ def make_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--camera-id",
+        dest="camera_ids",
+        metavar="CAMERA_ID",
         type=str,
-        default=_DEFAULT_CAMERA_ID,
+        action="append",
+        default=None,
         help=(
-            f"ncorev4 context-camera id used as model input "
-            f"(default: '{_DEFAULT_CAMERA_ID}'). Wires both "
-            f"context_camera_ids and supervision_camera_ids to [CAMERA_ID]. "
-            f"Exactly one camera is required."
+            "Override a profile's ncorev4 context camera. Repeat the flag to "
+            "provide multiple cameras in canonical order. pa-front requires "
+            "one camera; pa-multiview supports 1, 3, or 5. If omitted, the "
+            "selected profile's camera set is used."
         ),
     )
     parser.add_argument(
@@ -123,20 +140,39 @@ def main(argv: Sequence[str] | None = None) -> int:
         InstantNuRecSplitsConfig,
     )
     from instant_nurec.config_schema.instantnurec import InstantNuRecConfig
+    from instant_nurec.config_schema.models import KelvinDPTDecoderConfig, KelvinModelConfig
     from instant_nurec.config_schema.predict import PredictConfig, PrimitiveMergeConfig
     from instant_nurec.ncore_input import resolve_ncore_paths
     from instant_nurec.predict.run import run_predict
 
     json_paths = resolve_ncore_paths(args.ncore_path)
+    profile = get_model_profile(args.model)
+    camera_ids = list(args.camera_ids or profile.context_camera_ids)
+    allowed_camera_counts = profile.supported_camera_counts
+    if len(camera_ids) not in allowed_camera_counts:
+        counts = ", ".join(str(count) for count in allowed_camera_counts)
+        raise ValueError(
+            f"{args.model} expects {counts} context camera(s); got {len(camera_ids)}. "
+            "Repeat --camera-id once per camera."
+        )
 
     config = InstantNuRecConfig(
         out_dir=str(args.output_dir),
+        release_profile=args.model,
+        model=KelvinModelConfig(
+            decoder=KelvinDPTDecoderConfig(motion_depth=profile.motion_depth),
+        ),
         dataset=InstantNuRecSplitsConfig(
             predict=NCoreInstantNuRecDatasetConfig(
                 ncore_json_paths=[str(p) for p in json_paths],
-                context_camera_ids=[args.camera_id],
-                supervision_camera_ids=[args.camera_id],
+                camera_subsampler={
+                    "frame_width": profile.frame_width,
+                    "frame_height": profile.frame_height,
+                },
+                context_camera_ids=camera_ids,
+                supervision_camera_ids=camera_ids,
                 frame_batch_sampler=AdaptiveSequentialFrameBatchSamplerConfig(
+                    n_frames_per_sample=profile.n_frames_per_sample,
                     n_samples_per_sequence=args.max_chunks,
                 ),
             ),

--- a/instant_nurec/config_schema/README.md
+++ b/instant_nurec/config_schema/README.md
@@ -18,10 +18,11 @@ limitations under the License.
 
 The runtime config is constructed in code from `pydantic` models. Field
 defaults are encoded directly on each schema; `cli.py` only specifies the
-fields it overrides via CLI flags (input dataset path, output directory,
-merge mode, camera id, max chunks).
+fields it overrides via CLI flags (model profile, input dataset path, output
+directory, merge mode, camera id, max chunks).
 
-Model parameters are sourced by the runtime, not via these schemas.
+Architecture and inference parameters are typed here; learned tensors come
+from the selected weights-only checkpoint.
 
 ## What's in scope here
 
@@ -30,7 +31,7 @@ Model parameters are sourced by the runtime, not via these schemas.
 | `instantnurec.py` | `InstantNuRecConfig` (top-level), `GaussiansInstantNuRecSystemConfig` |
 | `dataset.py` | `InstantNuRecSplitsConfig`, `NCoreInstantNuRecDatasetConfig`, `AdaptiveSequentialFrameBatchSamplerConfig`, `NCoreInstantNuRecCuboidTracksParamsConfig` |
 | `predict.py` | `PredictConfig`, `PrimitiveMergeConfig` |
-| `models.py` | `KelvinModelConfig` (slim — only `export_preprocess`), `PrimitiveExportPreprocessConfig` |
+| `models.py` | `KelvinModelConfig`, encoder and dense/point-query decoder configs, activation and export-preprocess configs |
 
 ## BaseConfigSchema
 

--- a/instant_nurec/config_schema/dataset.py
+++ b/instant_nurec/config_schema/dataset.py
@@ -42,9 +42,9 @@ class NCoreInstantNuRecCuboidTracksParamsConfig(BaseConfigSchema):
 class AdaptiveSequentialFrameBatchSamplerConfig(BaseConfigSchema):
     """Adaptive sequential frame-batch sampler config.
 
-    The released checkpoints use 18 frames per camera and sample. The total
-    model view dimension is this value multiplied by the number of context
-    cameras (for example, 54 for the default three-camera multiview profile).
+    Release profiles supply this value. Each current profile uses 18 frames per
+    camera, and the total model view dimension is this value multiplied by the
+    context-camera count.
     """
 
     n_frames_per_sample: int = Field(

--- a/instant_nurec/config_schema/dataset.py
+++ b/instant_nurec/config_schema/dataset.py
@@ -42,7 +42,9 @@ class NCoreInstantNuRecCuboidTracksParamsConfig(BaseConfigSchema):
 class AdaptiveSequentialFrameBatchSamplerConfig(BaseConfigSchema):
     """Adaptive sequential frame-batch sampler config.
 
-    The released checkpoint was trained with 18 input frames per sample.
+    The released checkpoints use 18 frames per camera and sample. The total
+    model view dimension is this value multiplied by the number of context
+    cameras (for example, 54 for the default three-camera multiview profile).
     """
 
     n_frames_per_sample: int = Field(
@@ -72,7 +74,7 @@ class AdaptiveSequentialFrameBatchSamplerConfig(BaseConfigSchema):
 
 
 class CameraSubsamplerConfig(BaseConfigSchema):
-    """Image dimensions expected by the released model."""
+    """Image dimensions expected by the selected release profile."""
 
     frame_width: int = Field(
         default=784,

--- a/instant_nurec/config_schema/instantnurec.py
+++ b/instant_nurec/config_schema/instantnurec.py
@@ -23,6 +23,7 @@ from instant_nurec.config_schema.base_schema import BaseConfigSchema, Field
 from instant_nurec.config_schema.dataset import InstantNuRecSplitsConfig
 from instant_nurec.config_schema.models import KelvinModelConfig
 from instant_nurec.config_schema.predict import PredictConfig
+from instant_nurec.pretrained import DEFAULT_MODEL_VARIANT, ModelVariant
 
 
 class GaussiansInstantNuRecSystemConfig(BaseConfigSchema):
@@ -41,6 +42,11 @@ class InstantNuRecConfig(BaseConfigSchema):
     """
 
     seed: int = Field(default=38, description="Random seed.")
+
+    release_profile: ModelVariant = Field(
+        default=DEFAULT_MODEL_VARIANT,
+        description="Released checkpoint/input profile to use for inference.",
+    )
 
     out_dir: str
 

--- a/instant_nurec/config_schema/instantnurec.py
+++ b/instant_nurec/config_schema/instantnurec.py
@@ -21,9 +21,9 @@ import shortuuid
 
 from instant_nurec.config_schema.base_schema import BaseConfigSchema, Field
 from instant_nurec.config_schema.dataset import InstantNuRecSplitsConfig
-from instant_nurec.config_schema.models import KelvinModelConfig
+from instant_nurec.config_schema.models import KelvinModelConfig, KelvinPointQueryCADecoderConfig
 from instant_nurec.config_schema.predict import PredictConfig
-from instant_nurec.pretrained import DEFAULT_MODEL_VARIANT, ModelVariant
+from instant_nurec.pretrained import DEFAULT_MODEL_VARIANT, ModelVariant, get_model_profile
 
 
 class GaussiansInstantNuRecSystemConfig(BaseConfigSchema):
@@ -68,5 +68,26 @@ class InstantNuRecConfig(BaseConfigSchema):
     )
 
     def model_post_init(self, __context) -> None:
+        profile = get_model_profile(self.release_profile)
+        configured_decoder_kind = (
+            "point-query"
+            if isinstance(self.model.decoder, KelvinPointQueryCADecoderConfig)
+            else "pixel-aligned"
+        )
+        if configured_decoder_kind != profile.decoder_kind:
+            raise ValueError(
+                f"release_profile={self.release_profile!r} requires a "
+                f"{profile.decoder_kind} decoder, but model.decoder is "
+                f"{configured_decoder_kind}"
+            )
+        predict_dataset = self.dataset.predict
+        if profile.decoder_kind == "point-query" and predict_dataset is not None:
+            context_camera_ids = tuple(predict_dataset.context_camera_ids)
+            if context_camera_ids != profile.context_camera_ids:
+                required = ", ".join(profile.context_camera_ids)
+                raise ValueError(
+                    f"release_profile={self.release_profile!r} requires context camera(s): {required}"
+                )
+
         if (env_run_id := os.environ.get("INSTANT_NUREC_RUN_ID")) is not None:
             self.run_id = env_run_id

--- a/instant_nurec/config_schema/models.py
+++ b/instant_nurec/config_schema/models.py
@@ -48,8 +48,6 @@ class GaussiansActivationConfig(BaseConfigSchema):
     )
 
 
-
-
 class KelvinDAv3EncoderConfig(BaseConfigSchema):
     depth: int = Field(default=12)
     n_heads: int = Field(default=12)
@@ -62,6 +60,8 @@ class KelvinDAv3EncoderConfig(BaseConfigSchema):
 
 
 class KelvinDPTDecoderConfig(BaseConfigSchema):
+    name: Literal["dpt-decoder"] = "dpt-decoder"
+
     dpt_dim: int = Field(default=128)
     dpt_reassemble_hidden_dims: List[int] = Field(default_factory=lambda: [96, 192, 384, 768])
 
@@ -76,6 +76,56 @@ class KelvinDPTDecoderConfig(BaseConfigSchema):
 
     def model_post_init(self, __context) -> None:
         assert self.dpt_dim > 0, "DPT dimension must be positive"
+
+
+class KelvinPointQueryCADecoderConfig(BaseConfigSchema):
+    """Configuration for the selective point-query cross-attention decoder."""
+
+    name: Literal["point-query-ca-decoder"] = "point-query-ca-decoder"
+
+    # Shared DPT heads for depth, context features, and checkpoint compatibility.
+    dpt_dim: int = Field(default=128)
+    dpt_reassemble_hidden_dims: List[int] = Field(default_factory=lambda: [96, 192, 384, 768])
+    checkpointing: bool = Field(default=True, description="Whether to checkpoint the DPT heads")
+    dpt_chunk_size: int = Field(default=4, description="Chunk size for the DPT heads. -1 disables chunking.")
+    time_encoding_dim: int = Field(default=256, description="Dimension of the time sinusoidal encoding")
+    motion_depth: int = Field(default=1, description="Depth of the motion head")
+
+    # Cross-attention Gaussian head.
+    ca_depth: int = Field(default=3, ge=1, description="Number of cross-attention decoder blocks")
+    use_qk_norm: bool = Field(default=True, description="Whether to normalize cross-attention queries and keys")
+    layer_scale_init_values: float | None = Field(default=1e-4, description="Layer-scale initialization")
+    xyz_downsample_stride: int = Field(default=2, ge=1, description="Stride for the regular point-query grid")
+    grid_center_stride: int = Field(
+        default=8,
+        ge=1,
+        description="Number of candidate-grid cells per side represented by one point-query token",
+    )
+
+    # Selective ROAD queries. Selection uses predicted semantic logits in public inference.
+    road_xyz_downsample_stride: int | None = Field(
+        default=1,
+        ge=1,
+        description="Stride for extra ROAD point queries; None disables the selective ROAD branch",
+    )
+    road_token_threshold: float = Field(
+        default=1.0,
+        gt=0.0,
+        le=1.0,
+        description="Minimum ROAD fraction in a token for the token to be selected",
+    )
+    road_max_tokens_per_view: int | None = Field(
+        default=512,
+        ge=1,
+        description="Maximum number of selective ROAD tokens emitted per input view",
+    )
+
+    def model_post_init(self, __context) -> None:
+        assert self.dpt_dim > 0, "DPT dimension must be positive"
+        if self.road_xyz_downsample_stride is not None:
+            assert self.road_max_tokens_per_view is not None, (
+                "road_max_tokens_per_view must be set when selective ROAD queries are enabled"
+            )
 
 
 class KelvinSkyCubemapDecoderConfig(BaseConfigSchema):
@@ -106,7 +156,10 @@ class KelvinModelConfig(BaseConfigSchema):
     patch_shape: Tuple[int, int] = Field(default=(14, 14))
 
     encoder: KelvinDAv3EncoderConfig = Field(default_factory=KelvinDAv3EncoderConfig)
-    decoder: KelvinDPTDecoderConfig = Field(default_factory=KelvinDPTDecoderConfig)
+    decoder: KelvinDPTDecoderConfig | KelvinPointQueryCADecoderConfig = Field(
+        default_factory=KelvinDPTDecoderConfig,
+        discriminator="name",
+    )
     activations: GaussiansActivationConfig = Field(
         default_factory=GaussiansActivationConfig, description="Activation functions configuration."
     )

--- a/instant_nurec/model/__init__.py
+++ b/instant_nurec/model/__init__.py
@@ -42,10 +42,12 @@ class ModelCheckpointError(RuntimeError):
     """The resolved file is not a source-model state dictionary."""
 
 
-def _resolve_model_pt_path() -> Optional[str]:
+def _resolve_model_pt_path(
+    model_variant: pretrained.ModelVariant = pretrained.DEFAULT_MODEL_VARIANT,
+) -> Optional[str]:
     """Return the local path to the weight checkpoint or ``None`` on failure."""
     try:
-        return pretrained.download_instant_nurec_pt()
+        return pretrained.download_instant_nurec_pt(model_variant)
     except pretrained.PretrainedModelError:
         return None
 
@@ -115,14 +117,18 @@ def _preflight_validate_camera_ids(config: "InstantNuRecConfig") -> None:
     )
 
 
-def _load_model_state_dict(path: str) -> dict[str, torch.Tensor]:
+def _load_model_state_dict(
+    path: str,
+    *,
+    expected_filename: str = pretrained.MODEL_FILENAME,
+) -> dict[str, torch.Tensor]:
     """Load a weights-only checkpoint and reject legacy traced archives."""
     if zipfile.is_zipfile(path):
         with zipfile.ZipFile(path) as archive:
             if any(name.endswith("/constants.pkl") for name in archive.namelist()):
                 raise ModelCheckpointError(
                     f"{path} is a legacy traced-model archive. Download "
-                    f"{pretrained.MODEL_FILENAME} or point INSTANT_NUREC_FULL_PT "
+                    f"{expected_filename} or point INSTANT_NUREC_FULL_PT "
                     "at the released weights-only checkpoint."
                 )
 
@@ -143,17 +149,21 @@ def make(config: "InstantNuRecConfig") -> GaussiansInstantNuRecSystem:
     Resolution: ``INSTANT_NUREC_FULL_PT`` env var takes priority; otherwise
     the artifact is fetched from Hugging Face.
     """
-    full_pt_path = _resolve_model_pt_path()
+    profile = pretrained.get_model_profile(config.release_profile)
+    full_pt_path = _resolve_model_pt_path(config.release_profile)
     if not full_pt_path or not os.path.exists(full_pt_path):
         raise ModelNotFoundError(
-            f"{pretrained.MODEL_FILENAME} not found. Either set INSTANT_NUREC_FULL_PT to a "
+            f"{profile.filename} not found. Either set INSTANT_NUREC_FULL_PT to a "
             f"local .pt path or ensure {pretrained.MODEL_REPO_ID!r} is reachable."
         )
 
     _preflight_validate_camera_ids(config)
     logger.info("Loading source-model weights from %s.", full_pt_path)
     static_core = KelvinStaticCore(config.model)
-    static_core.load_state_dict(_load_model_state_dict(full_pt_path), strict=True)
+    static_core.load_state_dict(
+        _load_model_state_dict(full_pt_path, expected_filename=profile.filename),
+        strict=True,
+    )
 
     dataset_config = config.dataset.predict
     assert dataset_config is not None, "dataset.predict must be configured for inference"

--- a/instant_nurec/model/backbone/decoders.py
+++ b/instant_nurec/model/backbone/decoders.py
@@ -29,14 +29,21 @@ from instant_nurec.config_schema.models import (
     KelvinDAv3EncoderConfig,
     KelvinDPTDecoderConfig,
     KelvinModelConfig,
+    KelvinPointQueryCADecoderConfig,
 )
 from instant_nurec.model.activations import GaussianActivations, GaussianParams
 from instant_nurec.model.blocks.aa_vit import AlternateAttentionVisionTransformer
+from instant_nurec.model.blocks.attention import CrossAttentionBlock, KVProjector
 from instant_nurec.model.blocks.dpt import DPTFullHead
 from instant_nurec.model.blocks.embeds import ContinuousTimeEmbed
 from instant_nurec.model.backbone.base import (
     KelvinLatent,
     KelvinMultiscaleFeaturesLatent,
+)
+from instant_nurec.model.backbone.grid_tokens import (
+    FullResInputs,
+    build_grid_tokens,
+    concat_grid_tokens,
 )
 from instant_nurec.primitives.kelvin_primitive import (
     KelvinDynamicLayer,
@@ -46,6 +53,7 @@ from instant_nurec.primitives.kelvin_primitive import (
 from instant_nurec.utils.motion import TimeRemapping, warp_points_with_cuboid_tracks
 from instant_nurec.utils.batch import DataAndRenderingBatch
 from instant_nurec.utils.misc import unpack_optional
+from instant_nurec.utils.nn_extensions import TypedModuleList
 
 
 logger = logging.getLogger(__name__)
@@ -56,6 +64,20 @@ class KelvinDecoderReturn:
     # Allowing all dynamic layers
     static_layer: KelvinStaticLayer | None
     dynamic_layers: list[KelvinDynamicLayer]
+
+
+@dataclass(kw_only=True, slots=True)
+class KelvinPointQueryDecoderReturn:
+    """Sparse static fields emitted by :class:`KelvinPointQueryCADecoder`."""
+
+    positions: torch.Tensor
+    rotations: torch.Tensor
+    scales: torch.Tensor
+    densities: torch.Tensor
+    rgb: torch.Tensor
+    semantic_class: torch.Tensor
+    normals: torch.Tensor
+    source_indices: torch.Tensor
 
 
 class KelvinDPTDecoder(nn.Module):
@@ -476,3 +498,175 @@ class KelvinDPTDecoder(nn.Module):
             )
 
         return return_values
+
+
+class KelvinPointQueryCADecoder(KelvinDPTDecoder):
+    """Selective point-query Gaussian head on top of the shared DPT heads.
+
+    The module hierarchy intentionally matches the released checkpoint. The
+    public-only decode method omits training supervision and dynamic-layer
+    construction; dynamic-track filtering is performed by the inference
+    wrapper after sparse Gaussians have been emitted.
+    """
+
+    config: KelvinPointQueryCADecoderConfig
+
+    def __init__(self, config: KelvinPointQueryCADecoderConfig, model_config: KelvinModelConfig):
+        dpt_config = KelvinDPTDecoderConfig(
+            dpt_dim=config.dpt_dim,
+            dpt_reassemble_hidden_dims=config.dpt_reassemble_hidden_dims,
+            checkpointing=config.checkpointing,
+            dpt_chunk_size=config.dpt_chunk_size,
+            time_encoding_dim=config.time_encoding_dim,
+            motion_depth=config.motion_depth,
+        )
+        super().__init__(dpt_config, model_config)
+        self.config = config
+
+        # The point-query checkpoint replaces the dense DPT Gaussian head.
+        del self.gaussians_head
+
+        embed_dim = model_config.encoder.embed_dim
+        n_heads = model_config.encoder.n_heads
+        gaussians_per_token = config.grid_center_stride**2
+        n_gaussian_parameters = 3 + 4 + 1  # scale, rotation, opacity
+
+        self.xyz_embed = nn.Sequential(
+            nn.Linear(gaussians_per_token * 3, embed_dim),
+            nn.LayerNorm(embed_dim),
+        )
+        self.ca_feature_norm = nn.LayerNorm(embed_dim)
+        self.ca_kv_projector = KVProjector(
+            dim=embed_dim,
+            n_heads=n_heads,
+            kv_bias=True,
+            k_norm=config.use_qk_norm,
+        )
+        self.ca_blocks = TypedModuleList(
+            [
+                CrossAttentionBlock(
+                    embed_dim,
+                    n_heads,
+                    qkv_bias=True,
+                    attn_drop=0.0,
+                    proj_drop=0.0,
+                    qk_norm=config.use_qk_norm,
+                    mlp_ratio=4.0,
+                    dropout=0.0,
+                    layer_scale_init_values=config.layer_scale_init_values,
+                    kv_projector=None,
+                )
+                for _ in range(config.ca_depth)
+            ]
+        )
+
+        if not isinstance(model_config.encoder, KelvinDAv3EncoderConfig):
+            raise TypeError("KelvinPointQueryCADecoder requires a KelvinDAv3EncoderConfig encoder")
+        n_scales = len(model_config.encoder.take_block_indices)
+        self.ca_kv_proj = nn.Linear(n_scales * embed_dim, embed_dim, bias=False)
+        self.gs_linear = nn.Linear(embed_dim, gaussians_per_token * n_gaussian_parameters)
+
+    @torch.autocast("cuda", enabled=False)
+    def decode_static_gaussians(
+        self,
+        encoded_latent: KelvinMultiscaleFeaturesLatent,
+        *,
+        full_xyz: torch.Tensor,
+        context_rgb: torch.Tensor,
+        context_semantic_logits: torch.Tensor,
+        context_world_normal: torch.Tensor,
+        scene_rescale: float,
+    ) -> KelvinPointQueryDecoderReturn:
+        """Decode regular and selective ROAD queries into sparse Gaussians.
+
+        All full-resolution tensors use ``(B, V, H, W, C)`` layout. ROAD
+        candidates and the opacity-valid mask are derived solely from predicted
+        semantic logits; the public path does not require GT semantic labels.
+        """
+        batch_size, n_views, height, width, xyz_dim = full_xyz.shape
+        if xyz_dim != 3:
+            raise ValueError(f"full_xyz must end in three channels, got {tuple(full_xyz.shape)}")
+        if context_rgb.shape != (batch_size, n_views, height, width, 3):
+            raise ValueError(f"Unexpected context_rgb shape: {tuple(context_rgb.shape)}")
+        if context_world_normal.shape != (batch_size, n_views, height, width, 3):
+            raise ValueError(f"Unexpected context_world_normal shape: {tuple(context_world_normal.shape)}")
+        if context_semantic_logits.shape[:4] != (batch_size, n_views, height, width):
+            raise ValueError(f"Unexpected context_semantic_logits shape: {tuple(context_semantic_logits.shape)}")
+
+        semantic_probs = torch.softmax(context_semantic_logits, dim=-1)
+        semantic_class = torch.argmax(context_semantic_logits, dim=-1)
+        valid_mask = KelvinSemanticClass.opacity_mask_from_semantic_probs(semantic_probs)
+        source_indices = torch.arange(
+            n_views * height * width,
+            dtype=torch.int64,
+            device=full_xyz.device,
+        ).reshape(1, n_views, height, width)
+        source_indices = source_indices.expand(batch_size, -1, -1, -1)
+
+        full = FullResInputs(
+            xyz=full_xyz,
+            valid_mask=valid_mask,
+            ctx_rgb=context_rgb,
+            sem_class=semantic_class,
+            normals=context_world_normal,
+            source_indices=source_indices,
+        )
+        token_groups = [
+            build_grid_tokens(
+                stride=self.config.xyz_downsample_stride,
+                cell_size=self.config.grid_center_stride,
+                full=full,
+            )
+        ]
+
+        if self.config.road_xyz_downsample_stride is not None:
+            if self.config.road_max_tokens_per_view is None:
+                raise ValueError("road_max_tokens_per_view must be set when selective ROAD queries are enabled")
+            road_pixel_mask = semantic_class == int(KelvinSemanticClass.ROAD)
+            token_groups.append(
+                build_grid_tokens(
+                    stride=self.config.road_xyz_downsample_stride,
+                    cell_size=self.config.grid_center_stride,
+                    full=full,
+                    keep_pixel_mask=road_pixel_mask,
+                    keep_token_threshold=self.config.road_token_threshold,
+                    max_tokens_per_view=self.config.road_max_tokens_per_view,
+                )
+            )
+
+        query_xyz = torch.cat([tokens.query_xyz for tokens in token_groups], dim=1)
+        queries = self.xyz_embed(query_xyz.flatten(-2, -1))
+
+        kv_features = self.ca_kv_proj(
+            torch.cat(
+                [rearrange(feature, "B V h w C -> B (V h w) C") for feature in encoded_latent.features],
+                dim=-1,
+            )
+        )
+        kv_features = self.ca_feature_norm(kv_features)
+        projected_keys, projected_values = self.ca_kv_projector(k=kv_features, v=kv_features)
+        for block in self.ca_blocks:
+            queries = block(queries, projected_keys, projected_values)
+
+        gaussians_per_token = self.config.grid_center_stride**2
+        gaussian_attributes = rearrange(
+            self.gs_linear(queries),
+            "B M (K P) -> B (M K) P",
+            K=gaussians_per_token,
+        )
+        tokens = concat_grid_tokens(token_groups)
+        scale, rotation, opacity = gaussian_attributes.split([3, 4, 1], dim=-1)
+        scale = self.gaussian_activations.scale(scale, scene_rescale=scene_rescale)
+        rotation = self.gaussian_activations.rotation(rotation)
+        opacity = self.gaussian_activations.opacity(opacity) * tokens.point_valid_mask.detach()
+
+        return KelvinPointQueryDecoderReturn(
+            positions=tokens.gs_xyz,
+            rotations=rotation,
+            scales=scale,
+            densities=opacity,
+            rgb=tokens.gs_ctx_rgb,
+            semantic_class=tokens.gs_sem_class,
+            normals=tokens.gs_normals,
+            source_indices=tokens.gs_source_indices,
+        )

--- a/instant_nurec/model/backbone/grid_tokens.py
+++ b/instant_nurec/model/backbone/grid_tokens.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Grid tokenization used by the selective point-query decoder.
+
+The public inference path keeps only the tensors needed to emit and filter
+static Gaussians. In particular, training supervision and motion-flow tensors
+are intentionally absent.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+
+import torch
+
+from einops import rearrange
+
+
+@dataclass(kw_only=True, slots=True)
+class GridTokens:
+    """Grouped query positions and aligned per-Gaussian source values."""
+
+    query_xyz: torch.Tensor
+    gs_xyz: torch.Tensor
+    point_valid_mask: torch.Tensor
+    gs_ctx_rgb: torch.Tensor
+    gs_sem_class: torch.Tensor
+    gs_normals: torch.Tensor
+    gs_source_indices: torch.Tensor
+
+
+@dataclass(kw_only=True, slots=True)
+class FullResInputs:
+    """Full-resolution tensors consumed by :func:`build_grid_tokens`."""
+
+    xyz: torch.Tensor
+    valid_mask: torch.Tensor
+    ctx_rgb: torch.Tensor
+    sem_class: torch.Tensor
+    normals: torch.Tensor
+    source_indices: torch.Tensor
+
+
+def concat_grid_tokens(tokens: list[GridTokens]) -> GridTokens:
+    """Concatenate regular and selective token groups in input order."""
+    if not tokens:
+        raise ValueError("At least one GridTokens instance is required")
+    if len(tokens) == 1:
+        return tokens[0]
+    return GridTokens(
+        **{
+            field.name: torch.cat([getattr(token, field.name) for token in tokens], dim=1)
+            for field in fields(GridTokens)
+        }
+    )
+
+
+def _flatten_token_points(x: torch.Tensor) -> torch.Tensor:
+    if x.ndim == 4:
+        return rearrange(x, "B M K C -> B (M K) C")
+    if x.ndim == 3:
+        return rearrange(x, "B M K -> B (M K)")
+    raise ValueError(f"Expected a grouped tensor with 3 or 4 dimensions, got {tuple(x.shape)}")
+
+
+def _make_group_pipeline(
+    *,
+    stride: int,
+    cell_size: int,
+    cropped_height: int,
+    cropped_width: int,
+    selected_indices: torch.Tensor | None,
+):
+    def gather_tokens(x: torch.Tensor) -> torch.Tensor:
+        assert selected_indices is not None
+        index = selected_indices
+        for _ in x.shape[3:]:
+            index = index.unsqueeze(-1)
+        return torch.gather(x, dim=2, index=index.expand(*selected_indices.shape, *x.shape[3:]))
+
+    def run(x: torch.Tensor) -> torch.Tensor:
+        if x.ndim == 5:
+            x = x[:, :, ::stride, ::stride, :]
+            x = x[:, :, :cropped_height, :cropped_width, :]
+            x = rearrange(
+                x,
+                "B V (h c1) (w c2) C -> B V (h w) (c1 c2) C",
+                c1=cell_size,
+                c2=cell_size,
+            )
+        elif x.ndim == 4:
+            x = x[:, :, ::stride, ::stride]
+            x = x[:, :, :cropped_height, :cropped_width]
+            x = rearrange(
+                x,
+                "B V (h c1) (w c2) -> B V (h w) (c1 c2)",
+                c1=cell_size,
+                c2=cell_size,
+            )
+        else:
+            raise ValueError(f"Expected a full-resolution tensor with 4 or 5 dimensions, got {tuple(x.shape)}")
+
+        if selected_indices is not None:
+            x = gather_tokens(x)
+
+        if x.ndim == 5:
+            return rearrange(x, "B V M K C -> B (V M) K C")
+        return rearrange(x, "B V M K -> B (V M) K")
+
+    return run
+
+
+def build_grid_tokens(
+    *,
+    stride: int,
+    cell_size: int,
+    full: FullResInputs,
+    keep_pixel_mask: torch.Tensor | None = None,
+    keep_token_threshold: float = 0.0,
+    max_tokens_per_view: int | None = None,
+) -> GridTokens:
+    """Downsample pixels, group them into tokens, and optionally cap tokens.
+
+    When ``keep_pixel_mask`` is supplied, a token is eligible when at least
+    ``keep_token_threshold`` of its sub-points are selected. Each view emits a
+    fixed number of token slots; unused slots have a zero validity mask.
+    """
+    if stride < 1:
+        raise ValueError("stride must be at least 1")
+    if cell_size < 1:
+        raise ValueError("cell_size must be at least 1")
+    if not 0.0 <= keep_token_threshold <= 1.0:
+        raise ValueError("keep_token_threshold must be in [0, 1]")
+
+    batch_size, n_views, height, width, xyz_dim = full.xyz.shape
+    if xyz_dim != 3:
+        raise ValueError(f"xyz must have three channels, got {tuple(full.xyz.shape)}")
+    expected_prefix = (batch_size, n_views, height, width)
+    for name in ("valid_mask", "ctx_rgb", "sem_class", "normals", "source_indices"):
+        tensor = getattr(full, name)
+        if tensor.shape[:4] != expected_prefix:
+            raise ValueError(f"{name} must start with {expected_prefix}, got {tuple(tensor.shape)}")
+
+    strided_height = (height + stride - 1) // stride
+    strided_width = (width + stride - 1) // stride
+    cropped_height = (strided_height // cell_size) * cell_size
+    cropped_width = (strided_width // cell_size) * cell_size
+    if cropped_height == 0 or cropped_width == 0:
+        raise ValueError(f"Input {height}x{width} is too small for stride={stride} and cell_size={cell_size}")
+
+    selected_indices: torch.Tensor | None = None
+    token_valid: torch.Tensor | None = None
+    if keep_pixel_mask is not None:
+        if keep_pixel_mask.shape != expected_prefix:
+            raise ValueError(f"keep_pixel_mask must have shape {expected_prefix}, got {tuple(keep_pixel_mask.shape)}")
+        if max_tokens_per_view is None or max_tokens_per_view < 1:
+            raise ValueError("max_tokens_per_view must be positive when keep_pixel_mask is provided")
+
+        keep_pixel_mask = keep_pixel_mask[:, :, ::stride, ::stride]
+        keep_pixel_mask = keep_pixel_mask[:, :, :cropped_height, :cropped_width]
+        grouped_keep = rearrange(
+            keep_pixel_mask,
+            "B V (h c1) (w c2) -> B V (h w) (c1 c2)",
+            c1=cell_size,
+            c2=cell_size,
+        ).float()
+        keep_ratio = grouped_keep.mean(dim=-1)
+        keep_token = keep_ratio >= keep_token_threshold
+        n_tokens_per_view = keep_token.shape[-1]
+        n_selected = min(max_tokens_per_view, n_tokens_per_view)
+        random_scores = torch.rand_like(keep_ratio)
+        random_scores = random_scores.masked_fill(~keep_token, float("-inf"))
+        selected_scores, selected_indices = torch.topk(random_scores, k=n_selected, dim=-1)
+        token_valid = torch.isfinite(selected_scores)
+
+    run = _make_group_pipeline(
+        stride=stride,
+        cell_size=cell_size,
+        cropped_height=cropped_height,
+        cropped_width=cropped_width,
+        selected_indices=selected_indices,
+    )
+    xyz = run(full.xyz)
+    valid_mask = run(full.valid_mask)
+    context_rgb = run(full.ctx_rgb)
+    semantic_class = run(full.sem_class)
+    normals = run(full.normals)
+    source_indices = run(full.source_indices)
+
+    if token_valid is not None:
+        token_valid = rearrange(token_valid, "B V M -> B (V M)")
+        valid_mask = valid_mask * token_valid[..., None, None].to(valid_mask.dtype)
+
+    return GridTokens(
+        query_xyz=xyz,
+        gs_xyz=_flatten_token_points(xyz),
+        point_valid_mask=_flatten_token_points(valid_mask),
+        gs_ctx_rgb=_flatten_token_points(context_rgb),
+        gs_sem_class=_flatten_token_points(semantic_class),
+        gs_normals=_flatten_token_points(normals),
+        gs_source_indices=_flatten_token_points(source_indices),
+    )

--- a/instant_nurec/model/inference.py
+++ b/instant_nurec/model/inference.py
@@ -32,7 +32,7 @@ import torch
 from torch import nn
 
 from instant_nurec.datasets.tracks import CuboidTracks
-from instant_nurec.model.static_core import KelvinStaticCore
+from instant_nurec.model.static_core import KelvinPointQueryStaticOutput, KelvinStaticCore
 from instant_nurec.primitives.kelvin_primitive import (
     KelvinDynamicLayer,
     KelvinInstantNuRecPrimitive,
@@ -149,6 +149,7 @@ class KelvinInferenceModel(nn.Module):
         semantic_argmax: torch.Tensor,
         rendering_camera,
         cuboid_tracks_b: CuboidTracks | None,
+        source_indices: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Compute the dynamic mask.
 
@@ -158,7 +159,8 @@ class KelvinInferenceModel(nn.Module):
         With ``cuboid_tracks_b``: refine via point-cuboid intersection
         (and fallback ray-cuboid intersection on movable rays).
         """
-        # Single-batch slice: shapes (V, H, W, 3) and (V, H, W).
+        # Single-batch slice: dense outputs have shapes (V, H, W, 3) and
+        # (V, H, W); point-query outputs have shapes (N, 3) and (N,).
         gs_xyz_v = gs_xyz[0]
         semantic_v = semantic_argmax[0]
 
@@ -172,6 +174,12 @@ class KelvinInferenceModel(nn.Module):
         movable_mask = semantic_v == self._semantic_movable_value()
         rays = rendering_camera.rays  # (V, H, W, 6)
         ray_ts = unpack_optional(rendering_camera.rays_timestamps_us)  # (V, H, W, 1)
+        if source_indices is not None:
+            # The sparse decoder carries each Gaussian's flattened source-pixel
+            # index so cuboid-track association uses the aligned ray and time.
+            source_indices_v = source_indices[0].long()
+            rays = rays.reshape(-1, 6)[source_indices_v]
+            ray_ts = ray_ts.reshape(-1, 1)[source_indices_v]
 
         aux_ray_intersection_result = dynamic_track.ray_intersection(
             rays[..., :3][movable_mask],
@@ -225,21 +233,38 @@ class KelvinInferenceModel(nn.Module):
         for bidx, batch in enumerate(context):
             tensors = self._extract_tensors(batch)
             self._validate_input_shape(tensors[0])
-            (
-                gs_xyz,
-                gs_rotations,
-                gs_scales,
-                gs_densities,
-                gs_rgb,
-                semantic_argmax,
-                normals,
-                affine,
-            ) = self.static_core(*tensors)
+            static_output = self.static_core(*tensors)
+            if isinstance(static_output, KelvinPointQueryStaticOutput):
+                gs_xyz = static_output.positions
+                gs_rotations = static_output.rotations
+                gs_scales = static_output.scales
+                gs_densities = static_output.densities
+                gs_rgb = static_output.rgb
+                semantic_argmax = static_output.semantic_class
+                normals = static_output.normals
+                affine = static_output.affine_matrix
+                source_indices = static_output.source_indices
+            else:
+                (
+                    gs_xyz,
+                    gs_rotations,
+                    gs_scales,
+                    gs_densities,
+                    gs_rgb,
+                    semantic_argmax,
+                    normals,
+                    affine,
+                ) = static_output
+                source_indices = None
 
             rendering_camera = unpack_optional(unpack_optional(batch.rendering).camera)
             cuboid_tracks_b = cuboid_tracks[bidx] if cuboid_tracks is not None else None
             dynamic_mask = self._compute_dynamic_mask(
-                gs_xyz, semantic_argmax, rendering_camera, cuboid_tracks_b
+                gs_xyz,
+                semantic_argmax,
+                rendering_camera,
+                cuboid_tracks_b,
+                source_indices,
             )
 
             # Flatten and gather static-only.

--- a/instant_nurec/model/kelvin.py
+++ b/instant_nurec/model/kelvin.py
@@ -25,7 +25,7 @@ import torch.nn as nn
 from einops import rearrange
 
 from instant_nurec.datasets.tracks import CuboidTracks
-from instant_nurec.config_schema.models import KelvinModelConfig
+from instant_nurec.config_schema.models import KelvinModelConfig, KelvinPointQueryCADecoderConfig
 from instant_nurec.model.backbone.decoders import KelvinDPTDecoder
 from instant_nurec.model.backbone.encoders import KelvinDAv3Encoder
 from instant_nurec.model.backbone.sky import CubemapDecoderSky
@@ -48,6 +48,11 @@ class KelvinInstantNuRec(nn.Module):
 
     def __init__(self, config: KelvinModelConfig):
         super().__init__()
+        if isinstance(config.decoder, KelvinPointQueryCADecoderConfig):
+            raise TypeError(
+                "KelvinInstantNuRec full-model composition only supports the dense DPT decoder; "
+                "use KelvinStaticCore for point-query inference"
+            )
         self.config = config
         self.encoder = KelvinDAv3Encoder(config.encoder, config)
         self.decoder = KelvinDPTDecoder(config.decoder, config)

--- a/instant_nurec/model/static_core.py
+++ b/instant_nurec/model/static_core.py
@@ -25,15 +25,39 @@ from __future__ import annotations
 
 import math
 
+from dataclasses import dataclass
+
 import torch
 
 from einops import rearrange
 from torch import nn
 
-from instant_nurec.model.backbone.decoders import KelvinDPTDecoder
+from instant_nurec.model.backbone.base import KelvinMultiscaleFeaturesLatent
+from instant_nurec.model.backbone.decoders import KelvinDPTDecoder, KelvinPointQueryCADecoder
 from instant_nurec.model.backbone.encoders import KelvinDAv3Encoder
 from instant_nurec.model.post_processing import PerCameraAffinePostProcessing
-from instant_nurec.config_schema.models import KelvinModelConfig
+from instant_nurec.config_schema.models import KelvinModelConfig, KelvinPointQueryCADecoderConfig
+
+
+@dataclass(kw_only=True, slots=True)
+class KelvinPointQueryStaticOutput:
+    """Sparse point-query Gaussians and their source-pixel alignment.
+
+    ``source_indices`` indexes the flattened ``(V, H, W)`` input grid.  The
+    inference wrapper uses it to gather the corresponding rays and rolling-
+    shutter timestamps before applying the same cuboid-track filtering as the
+    dense pixel-aligned path.
+    """
+
+    positions: torch.Tensor
+    rotations: torch.Tensor
+    scales: torch.Tensor
+    densities: torch.Tensor
+    rgb: torch.Tensor
+    semantic_class: torch.Tensor
+    normals: torch.Tensor
+    affine_matrix: torch.Tensor
+    source_indices: torch.Tensor
 
 
 class KelvinStaticCore(nn.Module):
@@ -50,13 +74,17 @@ class KelvinStaticCore(nn.Module):
         inference_config.encoder.checkpointing = "none"
         inference_config.decoder.checkpointing = False
         self.encoder = KelvinDAv3Encoder(inference_config.encoder, inference_config)
-        self.decoder = KelvinDPTDecoder(inference_config.decoder, inference_config)
+        if isinstance(inference_config.decoder, KelvinPointQueryCADecoderConfig):
+            self.decoder = KelvinPointQueryCADecoder(inference_config.decoder, inference_config)
+        else:
+            self.decoder = KelvinDPTDecoder(inference_config.decoder, inference_config)
         self.post_processing = PerCameraAffinePostProcessing(
             embed_dim=inference_config.encoder.embed_dim,
             init_token_scale=0.02,
         )
         self.scene_rescale = inference_config.scene_rescale
 
+    @torch.autocast("cuda", enabled=False)
     def forward(
         self,
         rgb: torch.Tensor,
@@ -65,16 +93,19 @@ class KelvinStaticCore(nn.Module):
         rays: torch.Tensor,
         distance_to_depth_scale: torch.Tensor,
         camera_idxs: torch.Tensor,
-    ) -> tuple[
-        torch.Tensor,  # gs_xyz             (B, V, H, W, 3)
-        torch.Tensor,  # gs_rotations       (B, V, H, W, 4)
-        torch.Tensor,  # gs_scales          (B, V, H, W, 3)
-        torch.Tensor,  # gs_densities       (B, V, H, W, 1)
-        torch.Tensor,  # gs_rgb             (B, V, H, W, 3)
-        torch.Tensor,  # semantic_argmax    (B, V, H, W)   int64
-        torch.Tensor,  # normals            (B, V, H, W, 3)
-        torch.Tensor,  # affine             (B, n_affine_tokens, 3, 4)
-    ]:
+    ) -> (
+        tuple[
+            torch.Tensor,  # gs_xyz             (B, V, H, W, 3)
+            torch.Tensor,  # gs_rotations       (B, V, H, W, 4)
+            torch.Tensor,  # gs_scales          (B, V, H, W, 3)
+            torch.Tensor,  # gs_densities       (B, V, H, W, 1)
+            torch.Tensor,  # gs_rgb             (B, V, H, W, 3)
+            torch.Tensor,  # semantic_argmax    (B, V, H, W)   int64
+            torch.Tensor,  # normals            (B, V, H, W, 3)
+            torch.Tensor,  # affine             (B, n_affine_tokens, 3, 4)
+        ]
+        | KelvinPointQueryStaticOutput
+    ):
         """Run the static model heads on pre-extracted tensors.
 
         Inputs (B=1):
@@ -85,21 +116,25 @@ class KelvinStaticCore(nn.Module):
             distance_to_depth_scale: (1, V, H, W, 1)
             camera_idxs:             (1, V) int64
 
-        Returns the *unmasked* per-pixel gaussian fields plus the affine
-        matrix. Static/dynamic split, cuboid-track-based mask refinement,
-        and final flatten + gather happen in ``KelvinInferenceModel``.
+        Returns the *unmasked* Gaussian fields plus the affine matrix. The
+        DPT decoder returns the dense tuple layout; the point-query
+        decoder returns :class:`KelvinPointQueryStaticOutput`. Static/dynamic
+        split and cuboid-track-based mask refinement happen in
+        ``KelvinInferenceModel``.
         """
         scene_rescale = self.scene_rescale
+        is_point_query = isinstance(self.decoder, KelvinPointQueryCADecoder)
 
         # ----- Encoder -----
         # Mirror KelvinDAv3Encoder.encode while consuming stacked tensors.
         B, V, H, W, _ = rgb.shape
-        x = self.encoder.patch_embed_img(
-            self.encoder.rgb_normalize(rearrange(rgb, "B V H W C -> (B V) C H W"))
-        )
+        x = self.encoder.patch_embed_img(self.encoder.rgb_normalize(rearrange(rgb, "B V H W C -> (B V) C H W")))
         x = rearrange(x, "(B V) h w C -> B V h w C", B=B, V=V)
         camera_encodings = self.encoder.embed_camera.forward(c2w, fov)
-        with torch.autocast("cuda", enabled=True):
+        # Point-query inference uses BF16 for the ViT; pixel-aligned inference
+        # retains its FP16 path.
+        encoder_dtype = torch.bfloat16 if is_point_query else torch.float16
+        with torch.autocast("cuda", enabled=True, dtype=encoder_dtype):
             img_feats, _ = self.encoder.vit.get_intermediate_features(
                 x,
                 block_indices=self.encoder.take_block_indices,
@@ -114,13 +149,9 @@ class KelvinStaticCore(nn.Module):
         chunk_size = self.decoder.config.dpt_chunk_size
 
         # Depth
-        depth_and_dconf = self.decoder.depth_head(
-            img_feats_flat, output_shape=(H, W), chunk_size=chunk_size
-        )
+        depth_and_dconf = self.decoder.depth_head(img_feats_flat, output_shape=(H, W), chunk_size=chunk_size)
         depth_and_dconf = rearrange(depth_and_dconf, "(B V) C H W -> B V C H W", B=B, V=V)
-        pred_depth = torch.exp(
-            depth_and_dconf[:, :, 0].unsqueeze(-1) - math.log(scene_rescale)
-        )  # (B, V, H, W, 1)
+        pred_depth = torch.exp(depth_and_dconf[:, :, 0].unsqueeze(-1) - math.log(scene_rescale))  # (B, V, H, W, 1)
 
         # Context head
         rgb_in_flat = rearrange(rgb, "B V H W C -> (B V) C H W")
@@ -131,45 +162,67 @@ class KelvinStaticCore(nn.Module):
             fusion_features=rgb_fusion_features,
             chunk_size=chunk_size,
         )
-        context_features_tensor = rearrange(
-            context_features_tensor, "(B V) C H W -> B V H W C", B=B, V=V
-        )
+        context_features_tensor = rearrange(context_features_tensor, "(B V) C H W -> B V H W C", B=B, V=V)
         n_semantic = self.decoder.n_semantic_classes
-        context_rgb, context_world_normal, context_semantic_logits = (
-            context_features_tensor.split([3, 3, n_semantic], dim=-1)
+        context_rgb, context_world_normal, context_semantic_logits = context_features_tensor.split(
+            [3, 3, n_semantic], dim=-1
         )
         context_rgb = self.decoder.gaussian_activations.rgb(context_rgb)
         context_world_normal = torch.nn.functional.normalize(context_world_normal, dim=-1)
-        semantic_argmax = torch.argmax(context_semantic_logits, dim=-1)  # (B, V, H, W)
 
-        # Gaussian heads
-        gs_params_tensor = self.decoder.gaussians_head(
-            img_feats_flat, output_shape=(H, W), fusion_features=None, chunk_size=chunk_size
-        )
-        gs_params_tensor = rearrange(gs_params_tensor, "(B V) C H W -> B V H W C", B=B, V=V)
-        gs_scale, gs_world_quaternion, gs_opacity = gs_params_tensor.split([3, 4, 1], dim=-1)
-        gs_distance = pred_depth / distance_to_depth_scale  # (B, V, H, W, 1)
+        # Point-query replaces the dense Gaussian head with sparse queries.
+        point_query_output = None
+        if is_point_query:
+            gs_distance = pred_depth / distance_to_depth_scale
+            full_xyz = rays[..., :3] + rays[..., 3:] * gs_distance
+            point_query_output = self.decoder.decode_static_gaussians(
+                KelvinMultiscaleFeaturesLatent(features=img_feats),
+                full_xyz=full_xyz,
+                context_rgb=context_rgb,
+                context_semantic_logits=context_semantic_logits,
+                context_world_normal=context_world_normal,
+                scene_rescale=scene_rescale,
+            )
+        else:
+            gs_params_tensor = self.decoder.gaussians_head(
+                img_feats_flat, output_shape=(H, W), fusion_features=None, chunk_size=chunk_size
+            )
+            gs_params_tensor = rearrange(gs_params_tensor, "(B V) C H W -> B V H W C", B=B, V=V)
+            gs_scale, gs_world_quaternion, gs_opacity = gs_params_tensor.split([3, 4, 1], dim=-1)
+            gs_distance = pred_depth / distance_to_depth_scale  # (B, V, H, W, 1)
 
-        gs_scale = self.decoder.gaussian_activations.scale(gs_scale, scene_rescale=scene_rescale)
-        # Mirror of KelvinSemanticClass.opacity_mask_from_semantic_probs (excludes ego + sky)
-        semantic_probs = torch.softmax(context_semantic_logits, dim=-1)
-        ego = semantic_probs[..., self._SEMANTIC_EGO : self._SEMANTIC_EGO + 1]
-        sky = semantic_probs[..., self._SEMANTIC_SKY : self._SEMANTIC_SKY + 1]
-        gs_valid_mask = 1.0 - ego - sky
-        gs_opacity = (
-            self.decoder.gaussian_activations.opacity(gs_opacity)
-            * (gs_valid_mask > 0.5).float().detach()
-        )
-        gs_world_quaternion = self.decoder.gaussian_activations.rotation(gs_world_quaternion)
-        gs_xyz = rays[..., :3] + rays[..., 3:] * gs_distance  # (B, V, H, W, 3)
+            gs_scale = self.decoder.gaussian_activations.scale(gs_scale, scene_rescale=scene_rescale)
+            # Mirror of KelvinSemanticClass.opacity_mask_from_semantic_probs (excludes ego + sky)
+            semantic_probs = torch.softmax(context_semantic_logits, dim=-1)
+            ego = semantic_probs[..., self._SEMANTIC_EGO : self._SEMANTIC_EGO + 1]
+            sky = semantic_probs[..., self._SEMANTIC_SKY : self._SEMANTIC_SKY + 1]
+            gs_valid_mask = 1.0 - ego - sky
+            gs_opacity = self.decoder.gaussian_activations.opacity(gs_opacity) * (gs_valid_mask > 0.5).float().detach()
+            gs_world_quaternion = self.decoder.gaussian_activations.rotation(gs_world_quaternion)
+            gs_xyz = rays[..., :3] + rays[..., 3:] * gs_distance  # (B, V, H, W, 3)
+            semantic_argmax = torch.argmax(context_semantic_logits, dim=-1)  # (B, V, H, W)
 
         # ----- Per-camera affine post-processing -----
         encoded_deepest_tokens = rearrange(encoded_deepest, "B V h w C -> B (V h w) C")
-        _, affine_latents = self.post_processing.transform_tokens(
-            encoded_deepest_tokens, camera_idxs
-        )
+        # Point-query affine attention uses BF16; ``decode_affine`` returns to
+        # FP32. Pixel-aligned inference retains its existing dtype path.
+        with torch.autocast("cuda", enabled=is_point_query, dtype=torch.bfloat16):
+            _, affine_latents = self.post_processing.transform_tokens(encoded_deepest_tokens, camera_idxs)
         affine_matrix_3, affine_bias = self.post_processing.decode_affine(affine_latents)
         affine_matrix = torch.cat([affine_matrix_3, affine_bias[..., None]], dim=-1)
+
+        if point_query_output is not None:
+            return KelvinPointQueryStaticOutput(
+                positions=point_query_output.positions,
+                rotations=point_query_output.rotations,
+                scales=point_query_output.scales,
+                densities=point_query_output.densities,
+                rgb=point_query_output.rgb,
+                semantic_class=point_query_output.semantic_class,
+                normals=point_query_output.normals,
+                affine_matrix=affine_matrix,
+                source_indices=point_query_output.source_indices,
+            )
 
         return (
             gs_xyz,

--- a/instant_nurec/pretrained.py
+++ b/instant_nurec/pretrained.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 
 MODEL_REPO_ID = "nvidia/instant-nurec"
 
-ModelVariant = Literal["pa-front", "pa-multiview"]
+ModelVariant = Literal["pa-front", "pa-multiview", "pq-front"]
 MODEL_VARIANTS: tuple[ModelVariant, ...] = get_args(ModelVariant)
 DEFAULT_MODEL_VARIANT: ModelVariant = "pa-front"
 
@@ -53,6 +53,7 @@ class ModelProfile:
     n_frames_per_sample: int
     motion_depth: int
     supported_camera_counts: tuple[int, ...]
+    decoder_kind: Literal["pixel-aligned", "point-query"]
 
 
 MODEL_PROFILES: dict[ModelVariant, ModelProfile] = {
@@ -64,6 +65,7 @@ MODEL_PROFILES: dict[ModelVariant, ModelProfile] = {
         n_frames_per_sample=18,
         motion_depth=1,
         supported_camera_counts=(1,),
+        decoder_kind="pixel-aligned",
     ),
     "pa-multiview": ModelProfile(
         filename="pth/instant_nurec_pa_multiview_1.1.0.pth",
@@ -77,6 +79,17 @@ MODEL_PROFILES: dict[ModelVariant, ModelProfile] = {
         n_frames_per_sample=18,
         motion_depth=1,
         supported_camera_counts=(1, 3, 5),
+        decoder_kind="pixel-aligned",
+    ),
+    "pq-front": ModelProfile(
+        filename="pth/instant_nurec_pq_road_1.0.0.pth",
+        context_camera_ids=("camera_front_wide_120fov",),
+        frame_width=784,
+        frame_height=448,
+        n_frames_per_sample=18,
+        motion_depth=1,
+        supported_camera_counts=(1,),
+        decoder_kind="point-query",
     ),
 }
 

--- a/instant_nurec/pretrained.py
+++ b/instant_nurec/pretrained.py
@@ -13,13 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Resolve the pretrained InstantNuRec weight checkpoint.
+"""Resolve released InstantNuRec weight checkpoints.
 
-``download_instant_nurec_pt()`` returns the local path to
-``pth/instant_nurec_pa_front_1.1.0.pth``, downloading from Hugging Face on first use into
-the standard HF hub cache. Setting ``INSTANT_NUREC_FULL_PT`` to an
-existing local path short-circuits the download (useful for offline
-use).
+``download_instant_nurec_pt()`` downloads the selected release profile
+from Hugging Face into the standard hub cache. Setting
+``INSTANT_NUREC_FULL_PT`` to an existing local path short-circuits the
+download (useful for offline use); the override must match the selected
+profile.
 """
 
 from __future__ import annotations
@@ -27,23 +27,83 @@ from __future__ import annotations
 import logging
 import os
 
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional, get_args
 
 
 logger = logging.getLogger(__name__)
 
 
 MODEL_REPO_ID = "nvidia/instant-nurec"
-MODEL_FILENAME = "pth/instant_nurec_pa_front_1.1.0.pth"
+
+ModelVariant = Literal["pa-front", "pa-multiview"]
+MODEL_VARIANTS: tuple[ModelVariant, ...] = get_args(ModelVariant)
+DEFAULT_MODEL_VARIANT: ModelVariant = "pa-front"
+
+
+@dataclass(frozen=True)
+class ModelProfile:
+    """Inference contract associated with a released checkpoint."""
+
+    filename: str
+    context_camera_ids: tuple[str, ...]
+    frame_width: int
+    frame_height: int
+    n_frames_per_sample: int
+    motion_depth: int
+    supported_camera_counts: tuple[int, ...]
+
+
+MODEL_PROFILES: dict[ModelVariant, ModelProfile] = {
+    "pa-front": ModelProfile(
+        filename="pth/instant_nurec_pa_front_1.1.0.pth",
+        context_camera_ids=("camera_front_wide_120fov",),
+        frame_width=784,
+        frame_height=448,
+        n_frames_per_sample=18,
+        motion_depth=1,
+        supported_camera_counts=(1,),
+    ),
+    "pa-multiview": ModelProfile(
+        filename="pth/instant_nurec_pa_multiview_1.1.0.pth",
+        context_camera_ids=(
+            "camera_front_wide_120fov",
+            "camera_cross_left_120fov",
+            "camera_cross_right_120fov",
+        ),
+        frame_width=504,
+        frame_height=280,
+        n_frames_per_sample=18,
+        motion_depth=1,
+        supported_camera_counts=(1, 3, 5),
+    ),
+}
+
+# Backward-compatible alias for callers that imported the original single
+# checkpoint constant. PA-front remains the default release profile.
+MODEL_FILENAME = MODEL_PROFILES[DEFAULT_MODEL_VARIANT].filename
+
+
+def get_model_profile(model_variant: ModelVariant | str) -> ModelProfile:
+    """Return the release profile for ``model_variant``."""
+    try:
+        return MODEL_PROFILES[model_variant]  # type: ignore[index]
+    except KeyError as e:
+        choices = ", ".join(MODEL_VARIANTS)
+        raise ValueError(f"Unknown model variant {model_variant!r}; choose one of: {choices}") from e
 
 
 class PretrainedModelError(RuntimeError):
-    """Raised when the Instant NuRec PA-front checkpoint cannot be resolved."""
+    """Raised when an Instant NuRec checkpoint cannot be resolved."""
 
 
-def download_instant_nurec_pt(*, cache_dir: Optional[str | Path] = None) -> str:
-    """Return the local path to :data:`MODEL_FILENAME`.
+def download_instant_nurec_pt(
+    model_variant: ModelVariant = DEFAULT_MODEL_VARIANT,
+    *,
+    cache_dir: Optional[str | Path] = None,
+) -> str:
+    """Return the local path to the selected release checkpoint.
 
     Resolution order:
 
@@ -53,6 +113,8 @@ def download_instant_nurec_pt(*, cache_dir: Optional[str | Path] = None) -> str:
        When ``cache_dir`` is passed it is forwarded verbatim; otherwise
        ``huggingface_hub`` uses its standard hub cache.
     """
+
+    profile = get_model_profile(model_variant)
 
     env_path = os.environ.get("INSTANT_NUREC_FULL_PT")
     if env_path and Path(env_path).exists():
@@ -72,7 +134,7 @@ def download_instant_nurec_pt(*, cache_dir: Optional[str | Path] = None) -> str:
             "pip install huggingface_hub"
         ) from e
 
-    hf_kwargs: dict = {"repo_id": MODEL_REPO_ID, "filename": MODEL_FILENAME}
+    hf_kwargs: dict = {"repo_id": MODEL_REPO_ID, "filename": profile.filename}
     if target is not None:
         hf_kwargs["cache_dir"] = str(target)
 
@@ -82,11 +144,11 @@ def download_instant_nurec_pt(*, cache_dir: Optional[str | Path] = None) -> str:
         return cached
 
     try:
-        logger.info("Downloading %s/%s ...", MODEL_REPO_ID, MODEL_FILENAME)
+        logger.info("Downloading %s/%s ...", MODEL_REPO_ID, profile.filename)
         return hf_hub_download(**hf_kwargs)
     except Exception as e:
         raise PretrainedModelError(
-            f"Could not download {MODEL_REPO_ID}/{MODEL_FILENAME}. "
+            f"Could not download {MODEL_REPO_ID}/{profile.filename}. "
             f"Set INSTANT_NUREC_FULL_PT to a local copy of "
-            f"{MODEL_FILENAME} as a fallback. Underlying error: {e}"
+            f"{profile.filename} as a fallback. Underlying error: {e}"
         ) from e

--- a/run.sh
+++ b/run.sh
@@ -46,7 +46,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$NCORE_PATH" ]] || [[ -z "$OUTPUT_DIR" ]]; then
-    echo "usage: $0 --ncore-path <path> --output-dir <path> [--merge] [--n-gaussians N] [--log-level ...]" >&2
+    echo "usage: $0 [--model pa-front|pa-multiview] --ncore-path <path> --output-dir <path> [--merge] [--n-gaussians N] [--log-level ...]" >&2
     exit 64
 fi
 

--- a/run_inference.py
+++ b/run_inference.py
@@ -18,7 +18,7 @@
 
 Invocation::
 
-    python run_inference.py --model <pa-front|pa-multiview> \
+    python run_inference.py --model <pa-front|pa-multiview|pq-front> \
         --ncore-path <path> --output-dir <path> [--merge] [--n-gaussians N]
 
 Defers to ``instant_nurec.cli.main``.

--- a/run_inference.py
+++ b/run_inference.py
@@ -18,7 +18,8 @@
 
 Invocation::
 
-    python run_inference.py --ncore-path <path> --output-dir <path> [--merge] [--n-gaussians N]
+    python run_inference.py --model <pa-front|pa-multiview> \
+        --ncore-path <path> --output-dir <path> [--merge] [--n-gaussians N]
 
 Defers to ``instant_nurec.cli.main``.
 """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,6 +76,15 @@ def test_parser_accepts_multiview_and_repeated_camera_ids() -> None:
     assert args.camera_ids == ["front", "left", "right"]
 
 
+def test_parser_accepts_point_query_profile() -> None:
+    from instant_nurec.cli import make_parser
+
+    args = make_parser().parse_args(
+        ["--model", "pq-front", "--ncore-path", "/x", "--output-dir", "/y"]
+    )
+    assert args.model == "pq-front"
+
+
 def test_parser_rejects_unknown_model() -> None:
     from instant_nurec.cli import make_parser
     with pytest.raises(SystemExit):
@@ -226,6 +235,50 @@ def test_main_multiview_uses_release_profile(
     assert cfg.dataset.predict.camera_subsampler.frame_height == 280
     assert cfg.dataset.predict.frame_batch_sampler.n_frames_per_sample == 18
     assert cfg.model.decoder.motion_depth == 1
+
+
+def test_main_point_query_uses_point_query_decoder(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_run_predict = _install_runtime_stubs(monkeypatch)
+    json_path = _make_json_path(tmp_path)
+    from instant_nurec.cli import main
+    from instant_nurec.config_schema.models import KelvinPointQueryCADecoderConfig
+
+    assert main(["--model", "pq-front", "--ncore-path", str(json_path), "--output-dir", "/o"]) == 0
+    cfg = fake_run_predict.call_args.args[0]
+    assert cfg.release_profile == "pq-front"
+    assert cfg.dataset.predict.context_camera_ids == ["camera_front_wide_120fov"]
+    assert (
+        cfg.dataset.predict.camera_subsampler.frame_width,
+        cfg.dataset.predict.camera_subsampler.frame_height,
+    ) == (784, 448)
+    assert cfg.dataset.predict.frame_batch_sampler.n_frames_per_sample == 18
+    assert isinstance(cfg.model.decoder, KelvinPointQueryCADecoderConfig)
+
+
+def test_main_point_query_rejects_non_front_camera(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_runtime_stubs(monkeypatch)
+    json_path = _make_json_path(tmp_path)
+    from instant_nurec.cli import main
+
+    with pytest.raises(ValueError, match="requires context camera"):
+        main(
+            [
+                "--model",
+                "pq-front",
+                "--ncore-path",
+                str(json_path),
+                "--output-dir",
+                "/o",
+                "--camera-id",
+                "camera_cross_left_120fov",
+            ]
+        )
 
 
 def test_main_multiview_accepts_five_camera_overrides(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,6 +55,37 @@ def test_parser_default_merge_is_false() -> None:
     assert args.merge is False
 
 
+def test_parser_defaults_to_pa_front() -> None:
+    from instant_nurec.cli import make_parser
+    args = make_parser().parse_args(["--ncore-path", "/x", "--output-dir", "/y"])
+    assert args.model == "pa-front"
+    assert args.camera_ids is None
+
+
+def test_parser_accepts_multiview_and_repeated_camera_ids() -> None:
+    from instant_nurec.cli import make_parser
+    args = make_parser().parse_args([
+        "--model", "pa-multiview",
+        "--ncore-path", "/x",
+        "--output-dir", "/y",
+        "--camera-id", "front",
+        "--camera-id", "left",
+        "--camera-id", "right",
+    ])
+    assert args.model == "pa-multiview"
+    assert args.camera_ids == ["front", "left", "right"]
+
+
+def test_parser_rejects_unknown_model() -> None:
+    from instant_nurec.cli import make_parser
+    with pytest.raises(SystemExit):
+        make_parser().parse_args([
+            "--model", "unknown",
+            "--ncore-path", "/x",
+            "--output-dir", "/y",
+        ])
+
+
 def test_parser_default_n_gaussians() -> None:
     from instant_nurec.cli import make_parser
     args = make_parser().parse_args(["--ncore-path", "/x", "--output-dir", "/y"])
@@ -163,6 +194,75 @@ def test_main_no_merge_constructs_config_with_disabled_merge(
     assert cfg.out_dir == "/o"
     assert cfg.dataset.predict.ncore_json_paths == [str(json_path.resolve())]
     assert cfg.predict.primitive_merge.enabled is False
+    assert cfg.release_profile == "pa-front"
+    assert cfg.dataset.predict.context_camera_ids == ["camera_front_wide_120fov"]
+    assert cfg.dataset.predict.camera_subsampler.frame_width == 784
+    assert cfg.dataset.predict.camera_subsampler.frame_height == 448
+
+
+def test_main_multiview_uses_release_profile(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    fake_run_predict = _install_runtime_stubs(monkeypatch)
+    json_path = _make_json_path(tmp_path)
+    from instant_nurec.cli import main
+
+    rc = main([
+        "--model", "pa-multiview",
+        "--ncore-path", str(json_path),
+        "--output-dir", "/o",
+    ])
+
+    assert rc == 0
+    cfg = fake_run_predict.call_args.args[0]
+    assert cfg.release_profile == "pa-multiview"
+    assert cfg.dataset.predict.context_camera_ids == [
+        "camera_front_wide_120fov",
+        "camera_cross_left_120fov",
+        "camera_cross_right_120fov",
+    ]
+    assert cfg.dataset.predict.supervision_camera_ids == cfg.dataset.predict.context_camera_ids
+    assert cfg.dataset.predict.camera_subsampler.frame_width == 504
+    assert cfg.dataset.predict.camera_subsampler.frame_height == 280
+    assert cfg.dataset.predict.frame_batch_sampler.n_frames_per_sample == 18
+    assert cfg.model.decoder.motion_depth == 1
+
+
+def test_main_multiview_accepts_five_camera_overrides(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    fake_run_predict = _install_runtime_stubs(monkeypatch)
+    json_path = _make_json_path(tmp_path)
+    from instant_nurec.cli import main
+    cameras = ["front", "cross-left", "cross-right", "rear-left", "rear-right"]
+    argv = [
+        "--model", "pa-multiview",
+        "--ncore-path", str(json_path),
+        "--output-dir", "/o",
+    ]
+    for camera in cameras:
+        argv.extend(["--camera-id", camera])
+
+    assert main(argv) == 0
+    cfg = fake_run_predict.call_args.args[0]
+    assert cfg.dataset.predict.context_camera_ids == cameras
+
+
+def test_main_rejects_unsupported_multiview_camera_count(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    _install_runtime_stubs(monkeypatch)
+    json_path = _make_json_path(tmp_path)
+    from instant_nurec.cli import main
+
+    with pytest.raises(ValueError, match="expects 1, 3, 5 context camera"):
+        main([
+            "--model", "pa-multiview",
+            "--ncore-path", str(json_path),
+            "--output-dir", "/o",
+            "--camera-id", "front",
+            "--camera-id", "left",
+        ])
 
 
 def test_main_lst_path_resolves_each_line(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -256,6 +256,19 @@ def test_config_post_init_no_env(tmp_path, monkeypatch):
     monkeypatch.delenv("INSTANT_NUREC_RUN_ID", raising=False)
     cfg = InstantNuRecConfig(**_make_config_kwargs(tmp_path))
     assert cfg.run_id  # auto-generated shortuuid
+    assert cfg.release_profile == "pa-front"
+
+
+def test_config_accepts_multiview_release_profile(tmp_path):
+    cfg = InstantNuRecConfig(
+        **_make_config_kwargs(tmp_path, release_profile="pa-multiview")
+    )
+    assert cfg.release_profile == "pa-multiview"
+
+
+def test_config_rejects_unknown_release_profile(tmp_path):
+    with pytest.raises(ValidationError):
+        InstantNuRecConfig(**_make_config_kwargs(tmp_path, release_profile="unknown"))
 
 
 def test_config_post_init_env_run_id_overrides(tmp_path, monkeypatch):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,11 +33,14 @@ from pydantic import ValidationError
 from instant_nurec.config_schema.dataset import (
     AdaptiveSequentialFrameBatchSamplerConfig,
     CameraSubsamplerConfig,
+    InstantNuRecSplitsConfig,
+    NCoreInstantNuRecDatasetConfig,
     NCoreInstantNuRecCuboidTracksParamsConfig,
 )
 from instant_nurec.config_schema.instantnurec import GaussiansInstantNuRecSystemConfig, InstantNuRecConfig
 from instant_nurec.config_schema.models import (
     KelvinModelConfig,
+    KelvinPointQueryCADecoderConfig,
     PrimitiveExportPreprocessConfig,
 )
 from instant_nurec.config_schema.predict import PredictConfig, PrimitiveMergeConfig
@@ -264,6 +267,54 @@ def test_config_accepts_multiview_release_profile(tmp_path):
         **_make_config_kwargs(tmp_path, release_profile="pa-multiview")
     )
     assert cfg.release_profile == "pa-multiview"
+
+
+def test_config_accepts_point_query_release_profile(tmp_path):
+    cfg = InstantNuRecConfig(
+        **_make_config_kwargs(
+            tmp_path,
+            release_profile="pq-front",
+            model=KelvinModelConfig(decoder=KelvinPointQueryCADecoderConfig()),
+        )
+    )
+    assert cfg.release_profile == "pq-front"
+
+
+def test_config_rejects_point_query_profile_with_pixel_aligned_decoder(tmp_path):
+    with pytest.raises(ValidationError, match="requires a point-query decoder"):
+        InstantNuRecConfig(**_make_config_kwargs(tmp_path, release_profile="pq-front"))
+
+
+def test_config_rejects_point_query_profile_with_non_front_camera(tmp_path):
+    model = KelvinModelConfig(decoder=KelvinPointQueryCADecoderConfig())
+    dataset = InstantNuRecSplitsConfig(
+        predict=NCoreInstantNuRecDatasetConfig(
+            ncore_json_paths=[str(tmp_path / "input.json")],
+            context_camera_ids=["camera_cross_left_120fov"],
+            supervision_camera_ids=["camera_cross_left_120fov"],
+        )
+    )
+    with pytest.raises(ValidationError, match="requires context camera"):
+        InstantNuRecConfig(
+            **_make_config_kwargs(
+                tmp_path,
+                release_profile="pq-front",
+                model=model,
+                dataset=dataset,
+            )
+        )
+
+
+@pytest.mark.parametrize("profile", ["pa-front", "pa-multiview"])
+def test_config_rejects_pixel_aligned_profile_with_point_query_decoder(tmp_path, profile):
+    with pytest.raises(ValidationError, match="requires a pixel-aligned decoder"):
+        InstantNuRecConfig(
+            **_make_config_kwargs(
+                tmp_path,
+                release_profile=profile,
+                model=KelvinModelConfig(decoder=KelvinPointQueryCADecoderConfig()),
+            )
+        )
 
 
 def test_config_rejects_unknown_release_profile(tmp_path):

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -37,6 +37,7 @@ from instant_nurec.model.inference import (  # noqa: E402
     _PLACEHOLDER_SKY_CUBEMAP_SIZE,
     KelvinInferenceModel,
 )
+from instant_nurec.model.static_core import KelvinPointQueryStaticOutput  # noqa: E402
 from instant_nurec.primitives.kelvin_primitive import (  # noqa: E402
     KelvinDynamicLayer,
     KelvinSemanticClass,
@@ -79,6 +80,26 @@ class _FakeStaticCore(torch.nn.Module):
         affine = torch.zeros(B, self.n_cams, 3, 4)
         affine[..., :3] = torch.eye(3)
         return gs_xyz, gs_rotations, gs_scales, gs_densities, gs_rgb, semantic, normals, affine
+
+
+class _FakePointQueryStaticCore(_FakeStaticCore):
+    """Sparse-output counterpart used to cover point-query packaging."""
+
+    def forward(self, rgb, c2w, fov, rays, distance_to_depth_scale, camera_idxs):
+        dense = super().forward(rgb, c2w, fov, rays, distance_to_depth_scale, camera_idxs)
+        xyz, rotations, scales, densities, color, semantic, normals, affine = dense
+        source_indices = torch.tensor([[0, 5, 9]], dtype=torch.int64)
+        return KelvinPointQueryStaticOutput(
+            positions=xyz.reshape(self.B, -1, 3)[:, source_indices[0]],
+            rotations=rotations.reshape(self.B, -1, 4)[:, source_indices[0]],
+            scales=scales.reshape(self.B, -1, 3)[:, source_indices[0]],
+            densities=densities.reshape(self.B, -1, 1)[:, source_indices[0]],
+            rgb=color.reshape(self.B, -1, 3)[:, source_indices[0]],
+            semantic_class=semantic.reshape(self.B, -1)[:, source_indices[0]],
+            normals=normals.reshape(self.B, -1, 3)[:, source_indices[0]],
+            affine_matrix=affine,
+            source_indices=source_indices,
+        )
 
 
 def _make_adapter(static_core: _FakeStaticCore, scene_rescale: float = 0.5) -> KelvinInferenceModel:
@@ -186,6 +207,121 @@ def test_reconstruct_drops_movable_pixels_in_semantic_only_mode():
     out = adapter.reconstruct([_fake_batch(V, H, W)], cuboid_tracks=None)
 
     assert len(out[0].static_layer) == V * H * W - 1
+
+
+def test_reconstruct_with_tracks_keeps_unassociated_movable_gaussians(monkeypatch):
+    from types import SimpleNamespace
+
+    from instant_nurec.model import inference as inference_mod
+    from instant_nurec.utils.types import TrackFlags
+
+    class _AllMovableStaticCore(_FakeStaticCore):
+        def forward(self, *args):
+            output = list(super().forward(*args))
+            output[5].fill_(KelvinSemanticClass.MOVABLE.value)
+            return tuple(output)
+
+    class _DynamicTrack:
+        def ray_intersection(self, origins, directions, timestamps, **kwargs):
+            del origins, directions, timestamps, kwargs
+            return SimpleNamespace(
+                intersections_tracks_idx=torch.zeros(2, 2, dtype=torch.int64),
+                intersections_cnt=torch.tensor([1, 0], dtype=torch.int64),
+            )
+
+    monkeypatch.setattr(
+        inference_mod.CuboidTracks.Ops,
+        "subset_from_mask",
+        lambda tracks, mask: _DynamicTrack(),
+    )
+
+    def _fake_warp(**kwargs):
+        # The first MOVABLE Gaussian is associated with a dynamic track; the
+        # second is parked/unassociated and must remain in the static export.
+        assert torch.equal(kwargs["aux_tracks_idx"].reshape(-1), torch.tensor([0, -1]))
+        return kwargs["aux_tracks_idx"] >= 0, []
+
+    monkeypatch.setattr(inference_mod, "warp_points_with_cuboid_tracks", _fake_warp)
+
+    core = _AllMovableStaticCore(B=1, V=1, H=1, W=2, n_cams=1)
+    adapter = _make_adapter(core)
+    tracks = SimpleNamespace(tracks_flags=torch.tensor([int(TrackFlags.DYNAMIC)]))
+
+    primitive = adapter.reconstruct([_fake_batch(V=1, H=1, W=2)], [tracks])[0]
+
+    assert len(primitive.static_layer) == 1
+    assert torch.equal(primitive.static_layer.positions, torch.tensor([[3.0, 4.0, 5.0]]))
+    assert primitive.static_layer.semantic_class.item() == KelvinSemanticClass.MOVABLE.value
+
+
+def test_reconstruct_packages_sparse_point_query_output():
+    V, H, W = 2, 4, 4
+    core = _FakePointQueryStaticCore(B=1, V=V, H=H, W=W, n_cams=1)
+    adapter = _make_adapter(core)
+
+    out = adapter.reconstruct([_fake_batch(V, H, W)], cuboid_tracks=None)
+
+    assert len(out[0].static_layer) == 3
+    assert torch.equal(
+        out[0].static_layer.positions,
+        torch.arange(V * H * W * 3, dtype=torch.float32).reshape(-1, 3)[[0, 5, 9]],
+    )
+
+
+def test_sparse_dynamic_mask_gathers_aligned_source_rays_and_timestamps(monkeypatch):
+    from types import SimpleNamespace
+
+    from instant_nurec.model import inference as inference_mod
+    from instant_nurec.utils.types import TrackFlags
+
+    adapter = _make_adapter(_FakePointQueryStaticCore(B=1, V=1, H=2, W=3, n_cams=1))
+    rendering = _fake_batch(V=1, H=2, W=3).rendering.camera
+    rendering.rays = torch.arange(6 * 6, dtype=torch.float32).reshape(1, 2, 3, 6)
+    rendering.rays_timestamps_us = torch.arange(6, dtype=torch.int64).reshape(1, 2, 3, 1)
+    source_indices = torch.tensor([[4, 1]], dtype=torch.int64)
+    captured = {}
+
+    class _DynamicTrack:
+        def ray_intersection(self, origins, directions, timestamps, **kwargs):
+            captured["origins"] = origins
+            captured["directions"] = directions
+            captured["ray_timestamps"] = timestamps
+            return SimpleNamespace(
+                intersections_tracks_idx=torch.zeros(2, 2, dtype=torch.int64),
+                intersections_cnt=torch.ones(2, dtype=torch.int64),
+            )
+
+    dynamic_track = _DynamicTrack()
+    monkeypatch.setattr(
+        inference_mod.CuboidTracks.Ops,
+        "subset_from_mask",
+        lambda tracks, mask: dynamic_track,
+    )
+
+    def _fake_warp(**kwargs):
+        captured["points"] = kwargs["points"]
+        captured["source_timestamps"] = kwargs["source_timestamps_us"]
+        return torch.tensor([True, False]), []
+
+    monkeypatch.setattr(inference_mod, "warp_points_with_cuboid_tracks", _fake_warp)
+    xyz = torch.arange(6, dtype=torch.float32).reshape(1, 2, 3)
+    semantic = torch.full((1, 2), KelvinSemanticClass.MOVABLE.value, dtype=torch.int64)
+    tracks = SimpleNamespace(tracks_flags=torch.tensor([int(TrackFlags.DYNAMIC)]))
+
+    dynamic_mask = adapter._compute_dynamic_mask(
+        xyz,
+        semantic,
+        rendering,
+        tracks,
+        source_indices,
+    )
+
+    flat_rays = rendering.rays.reshape(-1, 6)[source_indices[0]]
+    assert torch.equal(captured["origins"], flat_rays[:, :3])
+    assert torch.equal(captured["directions"], flat_rays[:, 3:])
+    assert torch.equal(captured["ray_timestamps"], torch.tensor([4, 1]))
+    assert torch.equal(captured["source_timestamps"], torch.tensor([[4], [1]]))
+    assert torch.equal(dynamic_mask, torch.tensor([True, False]))
 
 
 def test_reconstruct_uses_placeholder_sky_cubemap_shape():

--- a/tests/test_pretrained.py
+++ b/tests/test_pretrained.py
@@ -51,13 +51,14 @@ def test_env_var_override_short_circuits_download(monkeypatch, tmp_path):
     assert pretrained.download_instant_nurec_pt() == str(fake_pt)
 
 
-def test_release_profiles_expose_front_and_multiview_contracts():
+def test_release_profiles_expose_pa_front_and_multiview_contracts():
     front = pretrained.get_model_profile("pa-front")
     assert front.filename == "pth/instant_nurec_pa_front_1.1.0.pth"
     assert front.context_camera_ids == ("camera_front_wide_120fov",)
     assert (front.frame_width, front.frame_height) == (784, 448)
     assert front.n_frames_per_sample == 18
     assert front.supported_camera_counts == (1,)
+    assert front.decoder_kind == "pixel-aligned"
 
     multiview = pretrained.get_model_profile("pa-multiview")
     assert multiview.filename == "pth/instant_nurec_pa_multiview_1.1.0.pth"
@@ -69,6 +70,18 @@ def test_release_profiles_expose_front_and_multiview_contracts():
     assert (multiview.frame_width, multiview.frame_height) == (504, 280)
     assert multiview.n_frames_per_sample == 18
     assert multiview.supported_camera_counts == (1, 3, 5)
+    assert multiview.decoder_kind == "pixel-aligned"
+
+
+def test_point_query_front_profile_contract():
+    front = pretrained.get_model_profile("pq-front")
+
+    assert front.filename == "pth/instant_nurec_pq_road_1.0.0.pth"
+    assert front.decoder_kind == "point-query"
+    assert front.context_camera_ids == ("camera_front_wide_120fov",)
+    assert (front.frame_width, front.frame_height) == (784, 448)
+    assert front.n_frames_per_sample == 18
+    assert front.supported_camera_counts == (1,)
 
 
 def test_unknown_release_profile_is_rejected():
@@ -125,6 +138,18 @@ def test_download_multiview_uses_its_profile_filename(monkeypatch):
 
     assert out.endswith("instant_nurec_pa_multiview_1.1.0.pth")
     assert captured["filename"] == pretrained.MODEL_PROFILES["pa-multiview"].filename
+
+
+def test_download_point_query_uses_profile_filename(monkeypatch):
+    captured: dict = {}
+
+    fake_hf = types.ModuleType("huggingface_hub")
+    fake_hf.hf_hub_download = lambda **kw: captured.update(kw) or "/cached/pq.pth"
+    fake_hf.try_to_load_from_cache = lambda **kw: None
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+
+    assert pretrained.download_instant_nurec_pt("pq-front") == "/cached/pq.pth"
+    assert captured["filename"] == "pth/instant_nurec_pq_road_1.0.0.pth"
 
 
 def test_download_without_cache_dir_omits_cache_dir_kwarg(monkeypatch):

--- a/tests/test_pretrained.py
+++ b/tests/test_pretrained.py
@@ -51,6 +51,31 @@ def test_env_var_override_short_circuits_download(monkeypatch, tmp_path):
     assert pretrained.download_instant_nurec_pt() == str(fake_pt)
 
 
+def test_release_profiles_expose_front_and_multiview_contracts():
+    front = pretrained.get_model_profile("pa-front")
+    assert front.filename == "pth/instant_nurec_pa_front_1.1.0.pth"
+    assert front.context_camera_ids == ("camera_front_wide_120fov",)
+    assert (front.frame_width, front.frame_height) == (784, 448)
+    assert front.n_frames_per_sample == 18
+    assert front.supported_camera_counts == (1,)
+
+    multiview = pretrained.get_model_profile("pa-multiview")
+    assert multiview.filename == "pth/instant_nurec_pa_multiview_1.1.0.pth"
+    assert multiview.context_camera_ids == (
+        "camera_front_wide_120fov",
+        "camera_cross_left_120fov",
+        "camera_cross_right_120fov",
+    )
+    assert (multiview.frame_width, multiview.frame_height) == (504, 280)
+    assert multiview.n_frames_per_sample == 18
+    assert multiview.supported_camera_counts == (1, 3, 5)
+
+
+def test_unknown_release_profile_is_rejected():
+    with pytest.raises(ValueError, match="Unknown model variant"):
+        pretrained.get_model_profile("not-a-model")
+
+
 def test_env_var_pointing_at_missing_file_falls_through(monkeypatch, tmp_path):
     """If INSTANT_NUREC_FULL_PT points nowhere, we still reach hf_hub_download."""
     monkeypatch.setenv("INSTANT_NUREC_FULL_PT", str(tmp_path / "nope.pt"))
@@ -82,6 +107,24 @@ def test_download_forwards_explicit_cache_dir_kwarg(monkeypatch, tmp_path):
     assert captured["repo_id"] == pretrained.MODEL_REPO_ID
     assert captured["filename"] == pretrained.MODEL_FILENAME
     assert captured["cache_dir"] == str(tmp_path / "explicit")
+
+
+def test_download_multiview_uses_its_profile_filename(monkeypatch):
+    captured: dict = {}
+
+    def _fake_dl(**kw):
+        captured.update(kw)
+        return "/some/cached/path/instant_nurec_pa_multiview_1.1.0.pth"
+
+    fake_hf = types.ModuleType("huggingface_hub")
+    fake_hf.hf_hub_download = _fake_dl
+    fake_hf.try_to_load_from_cache = lambda **kw: None
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+
+    out = pretrained.download_instant_nurec_pt("pa-multiview")
+
+    assert out.endswith("instant_nurec_pa_multiview_1.1.0.pth")
+    assert captured["filename"] == pretrained.MODEL_PROFILES["pa-multiview"].filename
 
 
 def test_download_without_cache_dir_omits_cache_dir_kwarg(monkeypatch):

--- a/tests/test_systems_make.py
+++ b/tests/test_systems_make.py
@@ -49,12 +49,12 @@ from instant_nurec.model import (  # noqa: E402
 def test_resolve_returns_path_when_download_succeeds(monkeypatch, tmp_path):
     fake_pt = tmp_path / "instant_nurec_weights.pt"
     fake_pt.write_bytes(b"")
-    monkeypatch.setattr(pretrained, "download_instant_nurec_pt", lambda **kw: str(fake_pt))
+    monkeypatch.setattr(pretrained, "download_instant_nurec_pt", lambda *args, **kw: str(fake_pt))
     assert _resolve_model_pt_path() == str(fake_pt)
 
 
 def test_resolve_returns_none_when_download_raises(monkeypatch):
-    def _raise(**kwargs):
+    def _raise(*args, **kwargs):
         raise pretrained.PretrainedModelError("offline")
 
     monkeypatch.setattr(pretrained, "download_instant_nurec_pt", _raise)
@@ -65,13 +65,25 @@ def test_resolve_returns_none_when_download_raises(monkeypatch):
 def test_resolve_only_calls_downloader_once_per_invocation(monkeypatch):
     calls = {"n": 0}
 
-    def _fake(**kwargs):
+    def _fake(*args, **kwargs):
         calls["n"] += 1
         return "/tmp/something.pt"
 
     monkeypatch.setattr(pretrained, "download_instant_nurec_pt", _fake)
     _resolve_model_pt_path()
     assert calls["n"] == 1
+
+
+def test_resolve_forwards_multiview_variant(monkeypatch):
+    calls = []
+
+    def _fake(model_variant, **kwargs):
+        calls.append(model_variant)
+        return "/tmp/multiview.pth"
+
+    monkeypatch.setattr(pretrained, "download_instant_nurec_pt", _fake)
+    assert _resolve_model_pt_path("pa-multiview") == "/tmp/multiview.pth"
+    assert calls == ["pa-multiview"]
 
 
 # ---------- _validate_camera_ids ----------
@@ -168,10 +180,10 @@ def test_load_model_state_dict_rejects_legacy_traced_archive_before_torch_load(
 
 
 def test_make_raises_when_checkpoint_cannot_be_resolved(monkeypatch):
-    monkeypatch.setattr(model_mod, "_resolve_model_pt_path", lambda: None)
+    monkeypatch.setattr(model_mod, "_resolve_model_pt_path", lambda model_variant: None)
 
     with pytest.raises(ModelNotFoundError, match=pretrained.MODEL_FILENAME):
-        model_mod.make(SimpleNamespace())
+        model_mod.make(SimpleNamespace(release_profile="pa-front"))
 
 
 def test_make_builds_source_core_and_loads_weights(monkeypatch, tmp_path):
@@ -202,13 +214,22 @@ def test_make_builds_source_core_and_loads_weights(monkeypatch, tmp_path):
         camera_subsampler=SimpleNamespace(frame_height=448, frame_width=784),
     )
     config = SimpleNamespace(
+        release_profile="pa-front",
         model=model_config,
         dataset=SimpleNamespace(predict=dataset_config),
     )
 
-    monkeypatch.setattr(model_mod, "_resolve_model_pt_path", lambda: str(checkpoint))
+    monkeypatch.setattr(
+        model_mod,
+        "_resolve_model_pt_path",
+        lambda model_variant: calls.update(model_variant=model_variant) or str(checkpoint),
+    )
     monkeypatch.setattr(model_mod, "_preflight_validate_camera_ids", lambda cfg: calls.setdefault("preflight", cfg))
-    monkeypatch.setattr(model_mod, "_load_model_state_dict", lambda path: state_dict)
+    monkeypatch.setattr(
+        model_mod,
+        "_load_model_state_dict",
+        lambda path, **kwargs: state_dict,
+    )
     monkeypatch.setattr(model_mod, "KelvinStaticCore", FakeCore)
     monkeypatch.setattr(model_mod, "KelvinInferenceModel", FakeInference)
     monkeypatch.setattr(
@@ -221,6 +242,7 @@ def test_make_builds_source_core_and_loads_weights(monkeypatch, tmp_path):
 
     assert result is sentinel_system
     assert calls["preflight"] is config
+    assert calls["model_variant"] == "pa-front"
     assert calls["core_config"] is model_config
     assert calls["loaded"] is state_dict
     assert calls["strict"] is True

--- a/tests/test_systems_make.py
+++ b/tests/test_systems_make.py
@@ -86,6 +86,19 @@ def test_resolve_forwards_multiview_variant(monkeypatch):
     assert calls == ["pa-multiview"]
 
 
+def test_resolve_forwards_point_query_variant(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(
+        pretrained,
+        "download_instant_nurec_pt",
+        lambda model_variant, **kwargs: calls.append(model_variant) or "/tmp/pq.pth",
+    )
+
+    assert _resolve_model_pt_path("pq-front") == "/tmp/pq.pth"
+    assert calls == ["pq-front"]
+
+
 # ---------- _validate_camera_ids ----------
 
 


### PR DESCRIPTION
## Summary

- implement the ROAD-selective point-query decoder, grid tokenization, and sparse static export path
- add the `pq-front` input/checkpoint profile and enforce its fixed `camera_front_wide_120fov` contract
- use predicted semantic logits for opacity masking and ROAD query selection, without auxiliary semantic labels
- preserve static-scene semantics when tracks are available: only Gaussians associated with dynamic tracks are removed, while parked/unassociated `MOVABLE` Gaussians remain in the static export
- refresh the README with the paper release, demo, repository-scope clarification, and model-profile guidance

## Dependency

Depends on #3. This branch is based on the exact head of that PA-multiview PR; once #3 merges, this PR will reduce to the point-query and README changes only.

## Checkpoint

- Hugging Face: [`pth/instant_nurec_pq_road_1.0.0.pth`](https://huggingface.co/nvidia/instant-nurec/blob/530cb36cff8aa49738b641a99990343390f34da4/pth/instant_nurec_pq_road_1.0.0.pth)
- Hugging Face commit: `530cb36cff8aa49738b641a99990343390f34da4`
- SHA256: `827896e493eb96b1225363a3a37cb82ea411c6a764ded90a37a28ae58b8186a9`
- strict model load: 608 tensors, 0 missing, 0 unexpected

## Verification

- completed end-to-end `pq-front` inference on the public demo sequence and generated a valid 729,715-Gaussian PLY
- component-level point-query head and grid-token numerical checks pass exactly on identical inputs
- `.venv/bin/ruff check .`
- `.venv/bin/python -m pytest -q` -> 501 passed, 2 skipped
- `git diff --check`
- no `internal/` paths are included
