### PR TITLE
docs(support): add issue routing templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Create a bug report to help us improve InstantNuRec
+title: "[BUG]"
+labels: "bug"
+assignees: 'daehyoungko'
+
+---
+
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+**Describe the bug**
+Provide a clear and concise description of the problem.
+
+**Steps or command to reproduce**
+Provide a minimal reproducer, including the full InstantNuRec command and the
+input shape (a single NCore V4 sequence `.json` or a directory of sequences).
+Do not include proprietary data or credentials.
+
+**Expected behavior**
+Describe what you expected to happen.
+
+**Environment (please complete the following information)**
+- InstantNuRec version or commit:
+- Model checkpoint filename and source:
+- Installation method (`./setup.sh`, `uv sync`, or source):
+- Python version:
+- Operating system:
+- GPU model and VRAM:
+- NVIDIA driver, CUDA, and PyTorch versions:
+- Inference mode (`--merge` or per-chunk):
+
+**Logs and output**
+Include the full traceback and relevant command output. Attach `nvidia-smi`
+output when the problem may be GPU-, driver-, CUDA-, or memory-related.
+
+**Additional context**
+Add any other context that could help reproduce the problem.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# .github/ISSUE_TEMPLATE/config.yml - NuRec family
+#
+# GitHub Issues is reserved for code-level bugs, documentation requests,
+# and feature requests. Usage questions and security reports are routed via
+# the two contact links below.
+
+blank_issues_enabled: false
+
+contact_links:
+  - name: "💬 Submit a question (usage, how-to)"
+    url: https://forums.developer.nvidia.com/c/omniverse/platform/nurec/752
+    about: >
+      For usage questions and discussion, please post on the NVIDIA Developer
+      Forum (Omniverse / NuRec category). The support team monitors this
+      category and answers there.
+
+  - name: "🚨 Report a security vulnerability - NVIDIA Intigriti VDP"
+    url: https://app.intigriti.com/programs/nvidia/nvidiavdp/detail
+    about: >
+      Please do NOT file security issues publicly on GitHub. Use the NVIDIA
+      Vulnerability Disclosure Program form on Intigriti.

--- a/.github/ISSUE_TEMPLATE/documentation_request_template.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request_template.md
@@ -1,0 +1,39 @@
+---
+name: Documentation request
+about: Report incorrect or missing documentation for InstantNuRec
+title: "[DOC]"
+labels: "documentation"
+assignees: 'daehyoungko'
+
+---
+
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+## Report incorrect documentation
+
+**Location of incorrect documentation**
+Provide a link and section or line number when applicable.
+
+**What is incorrect or unclear?**
+Describe the problem and how it affected your InstantNuRec workflow.
+
+**How did you verify it?**
+List the commands, configuration, or code you used to check the documentation.
+
+**Suggested correction**
+Describe the correction you would make, if known.
+
+---
+
+## Request new documentation
+
+**What documentation is needed?**
+Describe the missing topic and where you expected to find it.
+
+**What task should it help users complete?**
+Describe the InstantNuRec workflow or outcome the documentation should cover.
+
+**Where have you already looked?**
+List the README sections, troubleshooting entries, or other references you
+checked.

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Suggest an idea for InstantNuRec
+title: "[FEA]"
+labels: "enhancement"
+assignees: 'daehyoungko'
+
+---
+
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+**Is your feature request related to a problem? Please describe.**
+Describe the InstantNuRec workflow or limitation that motivates the request.
+
+**Describe the solution you would like**
+Explain the proposed behavior and what a successful result would look like.
+
+**Describe alternatives you have considered**
+Describe any workarounds, downstream tools, or alternative approaches you have
+tried.
+
+**Additional context**
+Add relevant examples, command lines, output formats, or links to related
+implementations.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ per-scene refinement pipeline that produces a high-fidelity USDZ.
 
 ![InstantNuRec demo](docs/demo.gif)
 
+## Support
+
+For common errors and fixes (HF auth, driver / CUDA mismatch, OOM at
+chunk-prep, `--max-chunks` truncation), see
+[TROUBLESHOOTING.md](TROUBLESHOOTING.md).
+
+- **Usage questions and discussion:** post on the
+  [NVIDIA Developer Forum (Omniverse / NuRec)](https://forums.developer.nvidia.com/c/omniverse/platform/nurec/752).
+- **Code-level bugs, documentation issues, and feature requests:** file a
+  [GitHub issue](../../issues/new/choose) using the appropriate template. For
+  bugs, include the full traceback, `nvidia-smi`, and `python --version`.
+- **Security vulnerabilities:** use
+  [NVIDIA's Vulnerability Disclosure Program](https://app.intigriti.com/programs/nvidia/nvidiavdp/detail).
+  Do not file security issues publicly.
+
 ### Background
 
 Instant NuRec is a feed-forward reconstruction model that converts
@@ -294,14 +309,6 @@ The PLY you just wrote is usable directly as a static reconstruction.
 If you want a high-fidelity, fully-trained scene, feed the PLY into
 [NuRec](https://docs.nvidia.com/nurec/nurec/reconstruct-av-scene.html)
 as initialization for per-scene refinement.
-
-## Support
-
-For common errors and fixes (HF auth, driver / CUDA mismatch, OOM at
-chunk-prep, `--max-chunks` truncation), see
-[TROUBLESHOOTING.md](TROUBLESHOOTING.md). Anything not listed there:
-file a GitHub issue with the full traceback, `nvidia-smi`, and
-`python --version`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -306,17 +306,6 @@ If you want a high-fidelity, fully-trained scene, feed the PLY into
 [NuRec](https://docs.nvidia.com/nurec/nurec/reconstruct-av-scene.html)
 as initialization for per-scene refinement.
 
-## Support
-
-For common errors and fixes (HF auth, driver / CUDA mismatch, OOM at
-chunk-prep, `--max-chunks` truncation), see
-[TROUBLESHOOTING.md](TROUBLESHOOTING.md). Anything not listed there:
-file a [GitHub issue](../../issues/new/choose). For runtime bugs, include the
-full traceback, `nvidia-smi`, and `python --version`. Report security
-vulnerabilities through [NVIDIA's Vulnerability Disclosure
-Program](https://app.intigriti.com/programs/nvidia/nvidiavdp/detail); do not
-file security issues publicly.
-
 ## License
 
 This project is licensed under the Apache License 2.0. See [LICENSE.txt](LICENSE.txt)


### PR DESCRIPTION
## Summary

- add the NuRec support section to the README
- add issue forms for bug reports, documentation requests, and feature requests
- route questions and security reports to the designated support channels

## Verification

- `pytest`: 475 passed, 2 skipped
- `ruff check .`
- issue-template YAML and chooser configuration validation