### PR TITLE
docs: update InstantNuRec positioning and clip support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Project Page](https://img.shields.io/badge/Project-Page-green)](https://research.nvidia.com/labs/sil/projects/instant-nurec/) [![Paper](https://img.shields.io/badge/arXiv-Paper-b31b1b?logo=arxiv)](https://arxiv.org/pdf/2607.14203) [![License](https://img.shields.io/badge/License-Apache--2.0-orange)](LICENSE.txt) [![Model](https://img.shields.io/badge/HF-Model-yellow?logo=huggingface&style=flat-square)](https://huggingface.co/nvidia/instant-nurec) [![Data](https://img.shields.io/badge/NCore-0d9488?logo=database&logoColor=white&style=flat-square)](https://huggingface.co/datasets/nvidia/PhysicalAI-Autonomous-Vehicles-NCore)
 
-**NVIDIA**
+NVIDIA InstantNuRec is a feed-forward neural reconstruction model for autonomous vehicle simulation that turns a multi-camera driving log into a fully simulatable 3D Gaussian scene in a single forward pass. It emits a Gaussian primitive per pixel covering geometry, appearance, and motion, renderable in real time, and its output can initialize downstream Omniverse NuRec training for higher fidelity.
 
 ## Announcements
 
@@ -13,7 +13,7 @@
 
 ## Abstract
 
-3D simulation platforms are critical for autonomous driving because they enable end-to-end policy evaluation, thereby reducing development costs and improving safety. In recent years, neural simulation has become predominant, with methods such as NuRec playing a central role; however, these methods remain relatively slow and typically require per-scene tuning. In this work, we present Instant NuRec, a feed-forward neural reconstruction model that turns a short multi-view driving log into a fully simulatable 3D Gaussian Splatting (3DGS) world in a single forward pass. The model accepts multi-view input from a calibrated camera rig and emits a layered output consisting of static and dynamic 3DGS layers, a sky cubemap, and per-camera ISP corrections, while providing native support for non-pinhole camera models via 3DGUT. It reconstructs a 10–20-second multi-camera scene in roughly 1.5 seconds and achieves a PSNR on the Waymo Open Dataset that is 2.01 dB above the strongest evaluated baseline. Instant NuRec is deeply integrated into NuRec and is compatible with AlpaSim for closed-loop simulation.
+3D simulation platforms are critical for autonomous driving because they enable end-to-end policy evaluation, thereby reducing development costs and improving safety. In recent years, neural simulation has become predominant, with methods such as NuRec playing a central role; however, these methods remain relatively slow and typically require per-scene tuning. In this work, we present Instant NuRec, a feed-forward neural reconstruction model that turns a multi-view driving log into a fully simulatable 3D Gaussian Splatting (3DGS) world in a single forward pass. The model accepts multi-view input from a calibrated camera rig and emits a layered output consisting of static and dynamic 3DGS layers, a sky cubemap, and per-camera ISP corrections, while providing native support for non-pinhole camera models via 3DGUT. It reconstructs a 10–20-second multi-camera scene in roughly 1.5 seconds and achieves a PSNR on the Waymo Open Dataset that is 2.01 dB above the strongest evaluated baseline. Instant NuRec is deeply integrated into NuRec and is compatible with AlpaSim for closed-loop simulation.
 
 > **Repository scope:** This standalone CLI exports only the static scene
 > Gaussians to PLY. The abstract above describes the complete research model.


### PR DESCRIPTION
## What changed

- Added the proposed repository summary.
- Removed "short" from the opening and abstract so the copy reflects support for longer clips.
- Incorporates Bjoern's feedback that short-clip Gaussians are fused into one consistent set.

## Repository metadata to apply after review

- **About:** NVIDIA InstantNuRec is a feed-forward neural reconstruction model for autonomous vehicles that turns a multi-camera driving log into a simulatable 3D Gaussian scene in a single forward pass.
- **Topics:** nvidia, physical-ai, autonomous-vehicles, autonomous-driving, robotics, neural-reconstruction, nurec, gaussian-splatting, 3d-reconstruction, 3dgs, feed-forward, novel-view-synthesis, simulation, self-driving-car

GitHub About text and topics are repository settings, so they are listed here for maintainer review rather than changed in this branch.

## Validation

- `git diff --check`
- README-only change

Source copy: https://docs.google.com/spreadsheets/d/1IxLuj3hxhN5y3d0fmIxGh9n2LiSq2Su2cTe9qpdAOKI/edit?gid=823075834#gid=823075834
