### PR TITLE
feat: export sky and calibrated source-trajectory renders

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,19 @@ NVIDIA InstantNuRec is a feed-forward neural reconstruction model for autonomous
 
 3D simulation platforms are critical for autonomous driving because they enable end-to-end policy evaluation, thereby reducing development costs and improving safety. In recent years, neural simulation has become predominant, with methods such as NuRec playing a central role; however, these methods remain relatively slow and typically require per-scene tuning. In this work, we present Instant NuRec, a feed-forward neural reconstruction model that turns a multi-view driving log into a fully simulatable 3D Gaussian Splatting (3DGS) world in a single forward pass. The model accepts multi-view input from a calibrated camera rig and emits a layered output consisting of static and dynamic 3DGS layers, a sky cubemap, and per-camera ISP corrections, while providing native support for non-pinhole camera models via 3DGUT. It reconstructs a 10–20-second multi-camera scene in roughly 1.5 seconds and achieves a PSNR on the Waymo Open Dataset that is 2.01 dB above the strongest evaluated baseline. Instant NuRec is deeply integrated into NuRec and is compatible with AlpaSim for closed-loop simulation.
 
-> **Repository scope:** This standalone CLI exports only the static scene
-> Gaussians to PLY. The abstract above describes the complete research model.
+> **Repository scope:** This standalone CLI exports the static scene Gaussians
+> to PLY together with an observation-derived sky cubemap sidecar and optional
+> reference render. The abstract above describes the complete research model,
+> including layers that are not part of this static export path.
 
 ![InstantNuRec demo](docs/demo.gif)
 
 ## Pipeline Overview
 
 This repo goes from ncorev4 ingest → frame batch prep → forward pass
-→ 3D-Gaussian PLY export. The PLY output is usable directly as a
-static reconstruction, and can also serve as initialization for
-downstream NuRec training to reach higher fidelity.
+→ 3D-Gaussian PLY and sky-cubemap export. The PLY output is usable
+directly as a static reconstruction, and can also serve as initialization
+for downstream NuRec training to reach higher fidelity.
 
 Instant-NuRec and
 [NuRec](https://docs.nvidia.com/nurec/nurec/reconstruct-av-scene.html)
@@ -65,7 +67,7 @@ Instant NuRec leverages the following foundational technologies:
 
 ## Pipeline Overview
 
-NCore V4 Sequence ─► Frame Batching ─► Eager PyTorch Model ─► 3D Gaussians ─► PLY (per-chunk or merged)
+NCore V4 Sequence ─► Frame Batching ─► Eager PyTorch Model ─► 3D Gaussians + Sky ─► Export Bundle
 
 ## User Guide
 
@@ -90,8 +92,19 @@ source .venv/bin/activate
 ```
 
 `setup.sh` runs `uv sync --frozen`, which installs the locked dependency
-tree from `uv.lock` into `.venv/`. The only CUDA dependency is whatever
-the pinned `torch` wheel ships with.
+tree from `uv.lock` into `.venv/`. In this default installation, the only
+CUDA dependency is whatever the pinned `torch` wheel ships with.
+
+The optional sky-composited reference render uses `gsplat`, which is not
+installed by `setup.sh`. Install the render extra before using
+`--render-preview`:
+
+```bash
+uv sync --extra render
+```
+
+The PLY, sky sidecar, and cubemap quick-look image do not require this
+extra.
 
 This repo is native-Python only — no Docker required. If you want a
 container, use the standard
@@ -170,16 +183,98 @@ python run_inference.py \
     --merge
 ```
 
-For the default `pa-front` command above, success looks like a single PLY at
+For the default `pa-front` command above, success looks like one merged export
+bundle whose PLY is at
 `./demo_output/<run_id>/ply/pai_000da9de-.../pai_000da9de-....ply` —
 ~1.88 M Gaussians, kl-optimal voxelized from 2.87 M merged (3.18 M
 pre-merge across 2 chunks) to land in `[0.9 * --n-gaussians,
 --n-gaussians]` (default target 2 M). Omit `--merge` to write
-per-chunk PLYs instead (voxelization is bundled with merge and
+per-chunk bundles instead (voxelization is bundled with merge and
 runs only when the flag is set).
 
 To run another model on the same clip, select its profile, such as
 `--model pa-multiview` or `--model pq-front`.
+
+##### Sky outputs and rendered preview
+
+Every exported PLY has two sky files with the same stem. With `--merge`,
+the stem is `<sequence_id>`; without it, each stem is
+`<sequence_id>_chunk<N>`.
+
+| output | contents |
+| --- | --- |
+| `<stem>.ply` | Static 3D Gaussian scene. |
+| `<stem>.sky.npz` | World-aligned cubemap, visibility mask, per-camera affine matrices, face order, and format metadata. Keep this machine-readable sidecar next to the PLY. |
+| `<stem>.sky.png` | 3×2 cubemap-face layout for a quick visual check; this is an atlas, not a camera render. |
+| `<stem>.render.png` | First context frame with the cubemap alpha-composited behind the Gaussians and the camera affine correction applied. Written only with `--render-preview`. |
+
+The `<stem>.sky.npz` sidecar uses format version 1 and can be loaded with
+`numpy.load(path, allow_pickle=False)`. It contains exactly these keys, where
+`S` is the cubemap face size (448 for the current released profiles) and `C`
+is the number of distinct context-camera sensors:
+
+| key | shape | NumPy dtype | meaning |
+| --- | --- | --- | --- |
+| `format_version` | scalar `()` | `int32` | The integer `1`. |
+| `sky_cubemap` | `(6, S, S, 3)` | `float16` | World-aligned canonical RGB cubemap. Values are intentionally not clamped before the camera affine transform. |
+| `sky_cubemap_mask` | `(6, S, S, 1)` | `float16` | Feathered observation-coverage weights in `[0, 1]`. |
+| `affine_matrix` | `(C, 3, 4)` | `float32` | Per-sensor RGB affine transforms `[A | b]`. |
+| `affine_sensor_indices` | `(C,)` | `int64` | `unique_sensor_idx` corresponding to each affine row. |
+| `affine_sensor_ids` | `(C,)` | Unicode | NCore sensor ID corresponding to each affine row. |
+| `face_order` | `(6,)` | Unicode `<U6` | `("right", "left", "top", "bottom", "front", "back")`. |
+| `face_axes` | `(6,)` | Unicode `<U2` | `("+X", "-X", "-Y", "+Y", "+Z", "-Z")`. |
+| `uv_convention` | scalar `()` | Unicode | `"u_left_to_right_v_top_to_bottom"`. |
+| `coordinate_frame` | scalar `()` | Unicode `<U11` | `"ncore_world"`. |
+| `sky_source` | scalar `()` | Unicode | `"observed_rgb_semantics"`, `"observed_rgb_semantics_plus_fallback"`, or `"synthetic_fallback"`. |
+| `sky_observed_fraction` | scalar `()` | `float32` | Mean feathered observation-mask coverage. |
+
+Cubemap directions use the `ncore_world` `(x, y, z)` axes. For a nonzero
+direction, let `a = max(|x|, |y|, |z|)`; the dominant signed axis selects a
+face, and `(u, v)` are `grid_sample` coordinates in `[-1, 1]` (`+u` moves
+right across an image row and `+v` moves down across image rows):
+
+| index / face | dominant axis | `u` | `v` |
+| --- | --- | --- | --- |
+| `0` / `right` | `+X` | `-z/a` | `y/a` |
+| `1` / `left` | `-X` | `z/a` | `y/a` |
+| `2` / `top` | `-Y` | `x/a` | `z/a` |
+| `3` / `bottom` | `+Y` | `x/a` | `-z/a` |
+| `4` / `front` | `+Z` | `x/a` | `y/a` |
+| `5` / `back` | `-Z` | `-x/a` | `y/a` |
+
+The `<stem>.sky.png` quick-look lays these faces out as
+`[[left, front, right], [back, bottom, top]]`.
+
+Affine row `i` corresponds to `affine_sensor_indices[i]` and
+`affine_sensor_ids[i]`. Their order comes from the context rig's ordered camera
+calibrations, which follows the configured profile or repeated `--camera-id`
+order; the numeric sensor index is an identifier, not an array index.
+For a composited RGB color `c`, apply row `[A | b]` as
+`clamp(A @ c + b, 0, 1)`, after sky alpha compositing.
+
+To also produce the rendered preview:
+
+```bash
+uv sync --extra render
+python run_inference.py \
+    --model pa-front \
+    --ncore-path /path/to/sequence.json \
+    --output-dir /tmp/out \
+    --merge \
+    --render-preview
+```
+
+Standard 3DGS PLY has no field for an environment cubemap or per-camera
+ISP correction. Consequently, SuperSplat and `ply_viewer` display the
+Gaussian foreground from `<stem>.ply` but do not automatically show the
+sky from `<stem>.sky.npz`; a sidecar-aware renderer must composite it.
+
+`--render-preview` is a diagnostic reference-view renderer, not a full
+native-camera or novel-view renderer. It renders the Gaussian foreground
+with a simple-pinhole approximation at the exposure-end pose and writes
+only the first context frame associated with each exported PLY. Cubemap
+sampling still uses the original NCore rays, including their camera model
+and rolling-shutter geometry.
 
 ##### View your output
 
@@ -233,7 +328,9 @@ python run_inference.py \
     --output-dir /tmp/out
 ```
 
-Output layout: PLYs only, under `out_dir/<run_id>/ply/<sequence_id>/...ply`.
+Output bundles are written under
+`out_dir/<run_id>/ply/<sequence_id>/<stem>.*`; the optional
+`<stem>.render.png` appears only with `--render-preview`.
 
 #### CLI reference
 
@@ -241,11 +338,12 @@ Output layout: PLYs only, under `out_dir/<run_id>/ply/<sequence_id>/...ply`.
 | --- | --- | --- |
 | `--model` | `pa-front` | Input/checkpoint profile: `pa-front`, `pa-multiview`, or `pq-front`. |
 | `--ncore-path` | (required) | A `.json` file (single sequence) or a `.lst` manifest (one JSON path per line). |
-| `--output-dir` | (required) | Directory the pipeline writes PLYs into. |
+| `--output-dir` | (required) | Directory the pipeline writes PLY and sky-output bundles into. |
 | `--merge` | absent (false) | Boolean flag. When set, merges per-chunk primitives into a single frustum-ownership PLY per sequence (`<seq>.ply`) and runs kl-optimal voxelization (target count from `--n-gaussians`). Absent (default): per-chunk PLYs (`<seq>_chunk{N}.ply`), no voxelization. |
 | `--n-gaussians` | `2000000` | Target number of static Gaussians after voxelization. Only consulted when `--merge` is set. The voxel size is searched iteratively via bracketed binary search to land the count in `[0.9 * target, target]`. |
 | `--camera-id` | profile-dependent | Override a context camera. Repeat once per camera in canonical order. `pa-front` requires 1; `pa-multiview` supports 1, 3, or 5; `pq-front` is fixed to `camera_front_wide_120fov`. |
 | `--max-chunks` | `8` | Maximum number of time-chunks processed per clip. One chunk spans up to 13.5 s, so the default covers 108 s. Longer clips are truncated and a `WARNING` logs the required value. |
+| `--render-preview` | absent (false) | Write `<stem>.render.png` for the first context frame of each exported PLY, with the sky composited behind the Gaussians. Requires `uv sync --extra render`; foreground projection is a simple-pinhole approximation. |
 | `--log-level` | `INFO` | `DEBUG` / `INFO` / `WARNING` / `ERROR` / `CRITICAL`. |
 
 #### Environment variables
@@ -271,10 +369,10 @@ instant-nurec/
 │   │   ├── backbone/               # multi-view encoder, dense/PQ decoders, sky decoder
 │   │   ├── blocks/                 # attention, embeddings, DPT, camera encoding
 │   │   ├── kelvin.py               # dense full-model composition
-│   │   ├── static_core.py          # eager PLY-reconstruction heads
+│   │   ├── static_core.py          # eager static + observed-sky reconstruction heads
 │   │   ├── inference.py            # masking + primitive packaging
 │   │   └── system.py               # predict-loop harness
-│   ├── predict/                    # predict loop + PLY export + merge
+│   ├── predict/                    # predict loop + PLY/sky export + preview + merge
 │   ├── primitives/                 # KelvinInstantNuRecPrimitive
 │   └── utils/                      # batch / geometry / sensors / nn-extensions
 ├── tests/                          # branch-coverage tests

--- a/README.md
+++ b/README.md
@@ -95,16 +95,21 @@ source .venv/bin/activate
 tree from `uv.lock` into `.venv/`. In this default installation, the only
 CUDA dependency is whatever the pinned `torch` wheel ships with.
 
-The optional sky-composited reference render uses `gsplat`, which is not
+The optional calibrated sky-composited renders use `gsplat`, which is not
 installed by `setup.sh`. Install the render extra before using
-`--render-preview`:
+`--render-preview` or `--render-video`:
 
 ```bash
 uv sync --extra render
 ```
 
+The first calibrated render JIT-compiles the pinned public CUDA kernels for
+the active PyTorch/CUDA/GPU target and can take several minutes; subsequent
+runs reuse the cache.
+
 The PLY, sky sidecar, and cubemap quick-look image do not require this
-extra.
+extra. Full-video export also requires `ffmpeg` with the `libx264` encoder on
+`PATH`.
 
 This repo is native-Python only — no Docker required. If you want a
 container, use the standard
@@ -207,6 +212,7 @@ the stem is `<sequence_id>`; without it, each stem is
 | `<stem>.sky.npz` | World-aligned cubemap, visibility mask, per-camera affine matrices, face order, and format metadata. Keep this machine-readable sidecar next to the PLY. |
 | `<stem>.sky.png` | 3×2 cubemap-face layout for a quick visual check; this is an atlas, not a camera render. |
 | `<stem>.render.png` | First context frame with the cubemap alpha-composited behind the Gaussians and the camera affine correction applied. Written only with `--render-preview`. |
+| `<stem>.render.mp4` | Every original frame from the first context camera, rendered at the profile resolution with its calibrated projection, exposure start/end trajectory, rolling shutter, sky, and camera affine. Written only with `--merge --render-video`. |
 
 The `<stem>.sky.npz` sidecar uses format version 1 and can be loaded with
 `numpy.load(path, allow_pickle=False)`. It contains exactly these keys, where
@@ -252,7 +258,7 @@ order; the numeric sensor index is an identifier, not an array index.
 For a composited RGB color `c`, apply row `[A | b]` as
 `clamp(A @ c + b, 0, 1)`, after sky alpha compositing.
 
-To also produce the rendered preview:
+To also produce a calibrated still preview and full source-trajectory video:
 
 ```bash
 uv sync --extra render
@@ -261,7 +267,8 @@ python run_inference.py \
     --ncore-path /path/to/sequence.json \
     --output-dir /tmp/out \
     --merge \
-    --render-preview
+    --render-preview \
+    --render-video
 ```
 
 Standard 3DGS PLY has no field for an environment cubemap or per-camera
@@ -269,12 +276,19 @@ ISP correction. Consequently, SuperSplat and `ply_viewer` display the
 Gaussian foreground from `<stem>.ply` but do not automatically show the
 sky from `<stem>.sky.npz`; a sidecar-aware renderer must composite it.
 
-`--render-preview` is a diagnostic reference-view renderer, not a full
-native-camera or novel-view renderer. It renders the Gaussian foreground
-with a simple-pinhole approximation at the exposure-end pose and writes
-only the first context frame associated with each exported PLY. Cubemap
-sampling still uses the original NCore rays, including their camera model
-and rolling-shutter geometry.
+Both render outputs currently support NCore F-theta cameras and use their
+calibrated per-pixel world rays, including the original projection and
+interpolated exposure start/end rolling-shutter poses. `--render-preview`
+writes the first context frame associated with each exported PLY.
+`--render-video` reopens the source sequence and streams every original frame
+from the first configured context camera without loading the full ray sequence
+into memory. It requires `--merge`, because a complete trajectory should be
+rendered against one complete merged scene. The video path currently accepts
+one resolved NCore sequence per invocation and fails with the required
+`--max-chunks` value if the configured cap would truncate its reconstruction.
+These are source-trajectory checks, not arbitrary novel-view renders. Other
+camera models and F-theta cameras with an external windshield-distortion model
+are rejected explicitly rather than silently approximated.
 
 ##### View your output
 
@@ -330,7 +344,8 @@ python run_inference.py \
 
 Output bundles are written under
 `out_dir/<run_id>/ply/<sequence_id>/<stem>.*`; the optional
-`<stem>.render.png` appears only with `--render-preview`.
+`<stem>.render.png` appears only with `--render-preview`, and
+`<stem>.render.mp4` appears only with `--merge --render-video`.
 
 #### CLI reference
 
@@ -343,7 +358,8 @@ Output bundles are written under
 | `--n-gaussians` | `2000000` | Target number of static Gaussians after voxelization. Only consulted when `--merge` is set. The voxel size is searched iteratively via bracketed binary search to land the count in `[0.9 * target, target]`. |
 | `--camera-id` | profile-dependent | Override a context camera. Repeat once per camera in canonical order. `pa-front` requires 1; `pa-multiview` supports 1, 3, or 5; `pq-front` is fixed to `camera_front_wide_120fov`. |
 | `--max-chunks` | `8` | Maximum number of time-chunks processed per clip. One chunk spans up to 13.5 s, so the default covers 108 s. Longer clips are truncated and a `WARNING` logs the required value. |
-| `--render-preview` | absent (false) | Write `<stem>.render.png` for the first context frame of each exported PLY, with the sky composited behind the Gaussians. Requires `uv sync --extra render`; foreground projection is a simple-pinhole approximation. |
+| `--render-preview` | absent (false) | Write `<stem>.render.png` for the first context frame of each exported PLY, using the calibrated NCore F-theta projection, exposure trajectory, and sky. Requires `uv sync --extra render`. |
+| `--render-video` | absent (false) | Write `<stem>.render.mp4` from every original frame of the first context camera, using calibrated NCore F-theta rays, rolling-shutter poses, sky, and camera affine. Requires one resolved sequence, `--merge`, enough `--max-chunks` for full coverage, `uv sync --extra render`, and `ffmpeg` with `libx264`. |
 | `--log-level` | `INFO` | `DEBUG` / `INFO` / `WARNING` / `ERROR` / `CRITICAL`. |
 
 #### Environment variables

--- a/THIRD_PARTY_LICENSE.txt
+++ b/THIRD_PARTY_LICENSE.txt
@@ -790,3 +790,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ================================================================================
+
+19. gsplat 1.5.3 (https://github.com/nerfstudio-project/gsplat)
+
+Apache License 2.0
+
+Copyright 2025 Nerfstudio Team
+
+This component is licensed under the Apache License, Version 2.0. The complete
+Apache License 2.0 terms are reproduced in section 2 of this file.
+
+================================================================================

--- a/instant_nurec/cli.py
+++ b/instant_nurec/cli.py
@@ -127,8 +127,19 @@ def make_parser() -> argparse.ArgumentParser:
         action="store_true",
         help=(
             "Render the first context frame of each output chunk as a PNG, "
+            "using its calibrated NCore F-theta model and rolling-shutter poses and "
             "compositing the observation-derived sky behind the Gaussians. "
             "Install with `uv sync --extra render` first."
+        ),
+    )
+    parser.add_argument(
+        "--render-video",
+        action="store_true",
+        help=(
+            "Render every original frame from the first context camera as an H.264 MP4, "
+            "using the source F-theta calibration, exposure trajectory, and sky. Requires "
+            "one resolved sequence, --merge, enough --max-chunks for full coverage, "
+            "`uv sync --extra render`, and ffmpeg with libx264."
         ),
     )
     parser.add_argument(
@@ -145,11 +156,24 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     logging.basicConfig(level=getattr(logging, args.log_level.upper()))
 
-    if args.render_preview:
+    if args.render_video and not args.merge:
+        parser.error("--render-video requires --merge so one complete scene is rendered")
+    if args.max_chunks <= 0:
+        parser.error("--max-chunks must be greater than zero")
+
+    if args.render_preview or args.render_video:
         from instant_nurec.predict.render_preview import require_gsplat
 
         try:
             require_gsplat()
+        except RuntimeError as exc:
+            parser.error(str(exc))
+
+    if args.render_video:
+        from instant_nurec.predict.render_video import require_ffmpeg
+
+        try:
+            require_ffmpeg()
         except RuntimeError as exc:
             parser.error(str(exc))
 
@@ -159,7 +183,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         NCoreInstantNuRecDatasetConfig,
         InstantNuRecSplitsConfig,
     )
-    from instant_nurec.config_schema.instantnurec import InstantNuRecConfig
+    from instant_nurec.config_schema.instantnurec import (
+        GaussiansInstantNuRecSystemConfig,
+        InstantNuRecConfig,
+    )
     from instant_nurec.config_schema.models import (
         KelvinDPTDecoderConfig,
         KelvinModelConfig,
@@ -170,6 +197,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     from instant_nurec.predict.run import run_predict
 
     json_paths = resolve_ncore_paths(args.ncore_path)
+    if args.render_video and len(json_paths) != 1:
+        parser.error(
+            "--render-video currently requires exactly one resolved NCore sequence "
+            "so all requested chunks are merged into one complete scene"
+        )
     profile = get_model_profile(args.model)
     camera_ids = list(args.camera_ids or profile.context_camera_ids)
     allowed_camera_counts = profile.supported_camera_counts
@@ -189,6 +221,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     config = InstantNuRecConfig(
         out_dir=str(args.output_dir),
         release_profile=args.model,
+        system=(
+            GaussiansInstantNuRecSystemConfig(predict_batch_size=args.max_chunks)
+            if args.render_video
+            else GaussiansInstantNuRecSystemConfig()
+        ),
         model=KelvinModelConfig(
             decoder=decoder_config,
         ),
@@ -214,6 +251,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 target_n_gaussians=args.n_gaussians,
             ),
             render_preview=args.render_preview,
+            render_video=args.render_video,
         ),
     )
     run_predict(config)

--- a/instant_nurec/cli.py
+++ b/instant_nurec/cli.py
@@ -70,7 +70,7 @@ def make_parser() -> argparse.ArgumentParser:
         "--output-dir",
         type=Path,
         required=True,
-        help="Directory for PLY output.",
+        help="Directory for PLY and sky-output bundles.",
     )
     parser.add_argument(
         "--merge",
@@ -123,6 +123,15 @@ def make_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--render-preview",
+        action="store_true",
+        help=(
+            "Render the first context frame of each output chunk as a PNG, "
+            "compositing the observation-derived sky behind the Gaussians. "
+            "Install with `uv sync --extra render` first."
+        ),
+    )
+    parser.add_argument(
         "--log-level",
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
         default="INFO",
@@ -132,8 +141,17 @@ def make_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    args = make_parser().parse_args(argv)
+    parser = make_parser()
+    args = parser.parse_args(argv)
     logging.basicConfig(level=getattr(logging, args.log_level.upper()))
+
+    if args.render_preview:
+        from instant_nurec.predict.render_preview import require_gsplat
+
+        try:
+            require_gsplat()
+        except RuntimeError as exc:
+            parser.error(str(exc))
 
     # Lazy imports keep argparse-only invocations (e.g. --help) cheap.
     from instant_nurec.config_schema.dataset import (
@@ -195,6 +213,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 enable_voxelization=args.merge,
                 target_n_gaussians=args.n_gaussians,
             ),
+            render_preview=args.render_preview,
         ),
     )
     run_predict(config)

--- a/instant_nurec/config_schema/models.py
+++ b/instant_nurec/config_schema/models.py
@@ -29,6 +29,13 @@ class PrimitiveExportPreprocessConfig(BaseConfigSchema):
     density_prune_threshold: float = Field(
         default=0.01, description="Density threshold for pruning Gaussians in each chunk."
     )
+    infill_road_color: bool = Field(
+        default=True,
+        description=(
+            "Fill cubemap directions without observed SKY pixels with a "
+            "representative color from density-pruned ROAD Gaussians."
+        ),
+    )
 
 
 class GaussiansActivationConfig(BaseConfigSchema):

--- a/instant_nurec/config_schema/predict.py
+++ b/instant_nurec/config_schema/predict.py
@@ -64,7 +64,16 @@ class PredictConfig(BaseConfigSchema):
     render_preview: bool = Field(
         default=False,
         description=(
-            "Render the first context camera frame for each exported chunk, "
+            "Render the first context camera frame for each exported chunk with its calibrated "
+            "NCore F-theta geometry, "
             "including the observation-derived sky cubemap. Requires the render extra."
+        ),
+    )
+    render_video: bool = Field(
+        default=False,
+        description=(
+            "Render all original frames from the first context camera with its calibrated "
+            "NCore F-theta trajectory, including the observation-derived sky cubemap. Requires "
+            "one complete merged sequence, the render extra, and ffmpeg."
         ),
     )

--- a/instant_nurec/config_schema/predict.py
+++ b/instant_nurec/config_schema/predict.py
@@ -61,3 +61,10 @@ class PredictConfig(BaseConfigSchema):
     primitive_merge: PrimitiveMergeConfig = Field(
         default_factory=PrimitiveMergeConfig, description="Configuration for primitive merging"
     )
+    render_preview: bool = Field(
+        default=False,
+        description=(
+            "Render the first context camera frame for each exported chunk, "
+            "including the observation-derived sky cubemap. Requires the render extra."
+        ),
+    )

--- a/instant_nurec/datasets/instantnurec_ncore.py
+++ b/instant_nurec/datasets/instantnurec_ncore.py
@@ -15,6 +15,7 @@
 
 import dataclasses
 import logging
+import math
 
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -174,6 +175,30 @@ class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
         from instant_nurec.datasets.instantnurec_base import CameraSubsampler
 
         return CameraSubsampler(frame_width=self._frame_width, frame_height=self._frame_height)
+
+    def _subsample_camera_model_parameters(
+        self,
+        camera_sensor: ncore.data.CameraSensorProtocol,
+        camera_subsampler: CameraSubsampler,
+    ) -> ncore.data.ConcreteCameraModelParametersUnion:
+        """Copy and resize/crop a source camera calibration for inference."""
+
+        camera_model_parameters = dataclasses.replace(camera_sensor.model_parameters)
+
+        # Some camera models have bad linear_cde values. Fix only the copy so
+        # the source NCore calibration remains untouched.
+        if isinstance(camera_model_parameters, ncore.data.FThetaCameraModelParameters) and np.all(
+            camera_model_parameters.linear_cde == 0.0
+        ):
+            camera_model_parameters.linear_cde = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+
+        if isinstance(camera_model_parameters, ncore.data.FThetaCameraModelParameters):
+            camera_model_parameters.max_angle = min(
+                np.deg2rad(self.camera_max_fov_deg) / 2.0,
+                camera_model_parameters.max_angle,
+            )
+
+        return camera_subsampler.apply_camera_parameters(camera_model_parameters)
 
     def __len__(self) -> int:
         return len(self.ncore_json_paths) * self.num_samples_per_sequence
@@ -373,21 +398,7 @@ class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
         current_unique_frame_idx: int = 0
         for camera_id in frame_batch_camera_ids:
             camera_sensor = camera_sensors[camera_id]
-            camera_model_parameters_copy = dataclasses.replace(camera_sensor.model_parameters)
-
-            # Some camera models have bad linear_cde values, manually fix them without overwriting originals
-            if isinstance(camera_model_parameters_copy, ncore.data.FThetaCameraModelParameters) and np.all(
-                camera_model_parameters_copy.linear_cde == 0.0
-            ):
-                camera_model_parameters_copy.linear_cde = np.array([1.0, 0.0, 0.0], dtype=np.float32)
-
-            if isinstance(camera_model_parameters_copy, ncore.data.FThetaCameraModelParameters):
-                # (This would make boundary pixels of omnidirectional cameras to be classified as invalid)
-                camera_model_parameters_copy.max_angle = min(
-                    np.deg2rad(self.camera_max_fov_deg) / 2.0, camera_model_parameters_copy.max_angle
-                )
-
-            camera_model_parameters = camera_subsampler.apply_camera_parameters(camera_model_parameters_copy)
+            camera_model_parameters = self._subsample_camera_model_parameters(camera_sensor, camera_subsampler)
             all_camera_model_parameters[camera_id] = camera_model_parameters
             frame_timestamps_us_list = []
             for frame_idx in frame_batch[str(camera_id)]:
@@ -517,6 +528,186 @@ class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
             T_rig_worlds_with_timestamps_us=T_rig_worlds_with_timestamps_us,
             sequence_loader=sequence_loader,
             camera_sensors=camera_sensors,
+        )
+
+    def load_full_camera_rig(
+        self,
+        ncore_json_path: str | UPath,
+        reference_rig: RigTrajectories,
+        camera_id: str | None = None,
+    ) -> RigTrajectories:
+        """Load every source exposure for one context camera as a lightweight rig.
+
+        The returned rig reuses the supplied reference rig's aligned world
+        trajectory and coordinate conversion, but rebuilds the selected camera
+        calibration from the source NCore sequence using the exact resize/crop
+        transform used for model inference. Only calibration, poses, and frame
+        start/end timestamps are materialized; images and per-pixel rays remain
+        lazy so callers can render one frame at a time.
+        """
+
+        context_camera_lookup = {str(context_camera): context_camera for context_camera in self.all_context_camera_ids}
+        if camera_id is None:
+            if len(context_camera_lookup) != 1:
+                raise ValueError(
+                    "camera_id is required when more than one context camera is configured; "
+                    f"available cameras: {sorted(context_camera_lookup)}"
+                )
+            selected_camera = next(iter(context_camera_lookup.values()))
+        else:
+            try:
+                selected_camera = context_camera_lookup[camera_id]
+            except KeyError as exc:
+                raise ValueError(
+                    f"Camera {camera_id!r} is not a configured context camera; "
+                    f"available cameras: {sorted(context_camera_lookup)}"
+                ) from exc
+
+        selected_camera_id = str(selected_camera)
+        if selected_camera_id not in reference_rig.camera_calibrations:
+            raise ValueError(f"Reference rig has no calibration for context camera {selected_camera_id!r}")
+        reference_calibration = reference_rig.camera_calibrations[selected_camera_id]
+        reference_trajectories = [
+            trajectory
+            for trajectory in reference_rig.rig_trajectories
+            if trajectory.sequence_id == reference_calibration.sequence_id
+        ]
+        if len(reference_trajectories) != 1:
+            raise ValueError(
+                "Expected exactly one reference trajectory for camera "
+                f"{selected_camera_id!r}, found {len(reference_trajectories)}"
+            )
+        reference_trajectory = reference_trajectories[0]
+
+        source_path = ncore_json_path if isinstance(ncore_json_path, UPath) else parse_universal_path(ncore_json_path)
+        if not source_path.exists():
+            raise InstantNuRecDataError(f"{source_path} does not exist.")
+        loaders_sensors = self._get_loaders_and_sensors(source_path, self.all_context_camera_ids)
+        camera_sensor = loaders_sensors.camera_sensors[selected_camera]
+
+        frame_start_timestamps_us = np.asarray(
+            camera_sensor.get_frames_timestamps_us(ncore.data.FrameTimepoint.START),
+            dtype=np.int64,
+        )
+        frame_end_timestamps_us = np.asarray(
+            camera_sensor.get_frames_timestamps_us(ncore.data.FrameTimepoint.END),
+            dtype=np.int64,
+        )
+        if frame_start_timestamps_us.ndim != 1 or frame_end_timestamps_us.ndim != 1:
+            raise ValueError("Source camera frame timestamps must be one-dimensional")
+        if frame_start_timestamps_us.shape != frame_end_timestamps_us.shape:
+            raise ValueError(
+                "Source camera START/END timestamp counts differ: "
+                f"{len(frame_start_timestamps_us)} != {len(frame_end_timestamps_us)}"
+            )
+        if len(frame_start_timestamps_us) == 0:
+            raise ValueError(f"Source camera {selected_camera_id!r} has no frames")
+        if np.any(frame_end_timestamps_us < frame_start_timestamps_us):
+            raise ValueError("Source camera frame END timestamps must not precede START timestamps")
+
+        # Full-video output must not outrun the scene reconstruction. Mirror the
+        # sampler's interval/chunk calculation across every configured context
+        # camera and fail explicitly when --max-chunks would truncate the clip.
+        rig_timestamps_us = np.asarray(loaders_sensors.T_rig_worlds_with_timestamps_us[1])
+        sequence_start_timestamp_us = int(rig_timestamps_us.min())
+        sequence_end_timestamp_us = int(rig_timestamps_us.max())
+        for context_camera in self.all_context_camera_ids:
+            if context_camera == selected_camera:
+                context_end_timestamps_us = frame_end_timestamps_us
+            else:
+                context_end_timestamps_us = np.asarray(
+                    loaders_sensors.camera_sensors[context_camera].get_frames_timestamps_us(
+                        ncore.data.FrameTimepoint.END
+                    ),
+                    dtype=np.int64,
+                )
+            if context_end_timestamps_us.ndim != 1 or len(context_end_timestamps_us) == 0:
+                raise ValueError(f"Context camera {context_camera!s} has no one-dimensional END timestamps")
+            sequence_start_timestamp_us = max(
+                sequence_start_timestamp_us,
+                int(context_end_timestamps_us.min()) - 100_000,
+            )
+            sequence_end_timestamp_us = min(
+                sequence_end_timestamp_us,
+                int(context_end_timestamps_us.max()) + 100_000,
+            )
+        if sequence_end_timestamp_us < sequence_start_timestamp_us:
+            raise ValueError("Context-camera and rig-pose timestamp ranges do not overlap")
+        max_chunk_timespan_us = (
+            self.config.frame_batch_sampler.max_frame_gap_timestamp_us * self._n_frames_per_sample
+        )
+        required_chunks = max(
+            1,
+            math.ceil(
+                (sequence_end_timestamp_us - sequence_start_timestamp_us) / max_chunk_timespan_us
+            ),
+        )
+        if required_chunks > self.num_samples_per_sequence:
+            raise ValueError(
+                "Full calibrated video requires a complete reconstructed scene, but "
+                f"--max-chunks={self.num_samples_per_sequence} covers only the first part of this clip. "
+                f"Rerun with --max-chunks {required_chunks}."
+            )
+
+        frame_timestamps_us = torch.from_numpy(
+            np.stack([frame_start_timestamps_us, frame_end_timestamps_us], axis=1)
+        ).to(device=reference_trajectory.T_rig_world_timestamps_us.device)
+
+        # Keep interpolation valid at every exposure boundary. Some source
+        # sequences start/end just outside the nominal rig-pose range; constant
+        # endpoint padding matches the inference loader's trajectory policy.
+        full_T_rig_worlds = reference_trajectory.T_rig_worlds
+        full_T_rig_world_timestamps_us = reference_trajectory.T_rig_world_timestamps_us
+        sensor_min_timestamp_us = int(frame_start_timestamps_us.min()) - 1
+        sensor_max_timestamp_us = int(frame_end_timestamps_us.max()) + 1
+        if sensor_min_timestamp_us < int(full_T_rig_world_timestamps_us[0].item()):
+            full_T_rig_worlds = torch.cat([full_T_rig_worlds[:1], full_T_rig_worlds], dim=0)
+            full_T_rig_world_timestamps_us = torch.cat(
+                [
+                    full_T_rig_world_timestamps_us.new_tensor([sensor_min_timestamp_us]),
+                    full_T_rig_world_timestamps_us,
+                ],
+                dim=0,
+            )
+        if sensor_max_timestamp_us > int(full_T_rig_world_timestamps_us[-1].item()):
+            full_T_rig_worlds = torch.cat([full_T_rig_worlds, full_T_rig_worlds[-1:]], dim=0)
+            full_T_rig_world_timestamps_us = torch.cat(
+                [
+                    full_T_rig_world_timestamps_us,
+                    full_T_rig_world_timestamps_us.new_tensor([sensor_max_timestamp_us]),
+                ],
+                dim=0,
+            )
+
+        camera_subsampler = self._build_camera_subsampler()
+        camera_model_parameters = self._subsample_camera_model_parameters(camera_sensor, camera_subsampler)
+        source_T_sensor_rig = np.asarray(unpack_optional(camera_sensor.T_sensor_rig))
+        camera_calibration = RigTrajectories.CameraCalibration(
+            sequence_id=reference_calibration.sequence_id,
+            unique_sensor_idx=reference_calibration.unique_sensor_idx,
+            T_sensor_rig=to_torch(
+                source_T_sensor_rig,
+                device=reference_calibration.T_sensor_rig.device,
+                dtype=reference_calibration.T_sensor_rig.dtype,
+            ),
+            camera_model_parameters=camera_model_parameters,
+        )
+        full_trajectory = RigTrajectories.RigTrajectory(
+            sequence_id=reference_trajectory.sequence_id,
+            cameras_frame_timestamps_us={selected_camera_id: frame_timestamps_us},
+            T_rig_worlds=full_T_rig_worlds,
+            T_rig_world_timestamps_us=full_T_rig_world_timestamps_us,
+        )
+        logger.info(
+            "Loaded %d source frames for render camera %s without images or rays.",
+            len(frame_timestamps_us),
+            selected_camera_id,
+        )
+        return RigTrajectories(
+            T_world_base=reference_rig.T_world_base,
+            world_to_scene=reference_rig.world_to_scene,
+            rig_trajectories=[full_trajectory],
+            camera_calibrations=OrderedDict([(selected_camera_id, camera_calibration)]),
         )
 
     def __getitem__(self, batch_idx: int) -> InstantNuRecDataBatch:

--- a/instant_nurec/model/inference.py
+++ b/instant_nurec/model/inference.py
@@ -17,10 +17,10 @@
 
 Applies semantic + optional cuboid-track-based dynamic-mask refinement
 to the per-pixel outputs and packages them into
-``KelvinInstantNuRecPrimitive``. Sky cubemap and dynamic-layer slots
-are filled with zero placeholders to satisfy the primitive invariants
-and the chunk-merge code path; ``export_ply.py`` reads only
-``static_layer``.
+``KelvinInstantNuRecPrimitive``. Released checkpoints omit the learned
+sky head, so :class:`KelvinStaticCore` derives a cubemap from canonical RGB
+and predicted SKY pixels. Dynamic-layer slots remain empty in this static
+PLY compatibility path.
 """
 
 from __future__ import annotations
@@ -45,13 +45,6 @@ from instant_nurec.utils.misc import unpack_optional
 from instant_nurec.utils.motion import warp_points_with_cuboid_tracks
 from instant_nurec.utils.sensor import to_simple_pinhole_model_parameters
 from instant_nurec.utils.types import TrackFlags
-
-
-# Cubemap placeholder size: small enough to keep memory negligible, large
-# enough that the merge code's per-pixel arithmetic produces well-defined
-# results. The merged cubemap is computed but never written -- ``export_ply.py``
-# only reads ``static_layer``.
-_PLACEHOLDER_SKY_CUBEMAP_SIZE = 16
 
 
 class KelvinInferenceModel(nn.Module):
@@ -220,10 +213,6 @@ class KelvinInferenceModel(nn.Module):
             rgb=torch.zeros(0, 3, device=device),
         )
 
-    def _placeholder_sky_cubemap(self, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
-        s = _PLACEHOLDER_SKY_CUBEMAP_SIZE
-        return torch.zeros(6, s, s, 3, device=device, dtype=dtype)
-
     def reconstruct(
         self,
         context: list[DataAndRenderingBatch],
@@ -244,6 +233,8 @@ class KelvinInferenceModel(nn.Module):
                 normals = static_output.normals
                 affine = static_output.affine_matrix
                 source_indices = static_output.source_indices
+                sky_cubemap = static_output.sky_cubemap
+                sky_cubemap_mask = static_output.sky_cubemap_mask
             else:
                 (
                     gs_xyz,
@@ -254,6 +245,8 @@ class KelvinInferenceModel(nn.Module):
                     semantic_argmax,
                     normals,
                     affine,
+                    sky_cubemap,
+                    sky_cubemap_mask,
                 ) = static_output
                 source_indices = None
 
@@ -284,9 +277,8 @@ class KelvinInferenceModel(nn.Module):
                 KelvinInstantNuRecPrimitive(
                     static_layer=static_layer,
                     dynamic_layers=[self._empty_dynamic_layer(static_layer.positions.device)],
-                    sky_cubemap=self._placeholder_sky_cubemap(
-                        static_layer.positions.device, static_layer.positions.dtype
-                    ),
+                    sky_cubemap=sky_cubemap[0],
+                    sky_cubemap_mask=sky_cubemap_mask[0],
                     affine_matrix=affine[0],  # (1, n_cams, 3, 4) -> (n_cams, 3, 4)
                 )
             )

--- a/instant_nurec/model/static_core.py
+++ b/instant_nurec/model/static_core.py
@@ -37,6 +37,7 @@ from instant_nurec.model.backbone.decoders import KelvinDPTDecoder, KelvinPointQ
 from instant_nurec.model.backbone.encoders import KelvinDAv3Encoder
 from instant_nurec.model.post_processing import PerCameraAffinePostProcessing
 from instant_nurec.config_schema.models import KelvinModelConfig, KelvinPointQueryCADecoderConfig
+from instant_nurec.utils.cubemap import build_observed_sky_cubemap_with_mask
 
 
 @dataclass(kw_only=True, slots=True)
@@ -58,12 +59,15 @@ class KelvinPointQueryStaticOutput:
     normals: torch.Tensor
     affine_matrix: torch.Tensor
     source_indices: torch.Tensor
+    sky_cubemap: torch.Tensor
+    sky_cubemap_mask: torch.Tensor
 
 
 class KelvinStaticCore(nn.Module):
     """Static Gaussian reconstruction heads used by public inference."""
 
-    # Class indices for KelvinSemanticClass.{EGO,SKY,MOVABLE}.
+    # Class indices for KelvinSemanticClass.{EGO,SKY,ROAD,MOVABLE}.
+    _SEMANTIC_ROAD: int = 3
     _SEMANTIC_EGO: int = 1
     _SEMANTIC_SKY: int = 2
     _SEMANTIC_MOVABLE: int = 4
@@ -83,6 +87,7 @@ class KelvinStaticCore(nn.Module):
             init_token_scale=0.02,
         )
         self.scene_rescale = inference_config.scene_rescale
+        self.sky_cubemap_size = inference_config.sky.cubemap_size
 
     @torch.autocast("cuda", enabled=False)
     def forward(
@@ -103,6 +108,8 @@ class KelvinStaticCore(nn.Module):
             torch.Tensor,  # semantic_argmax    (B, V, H, W)   int64
             torch.Tensor,  # normals            (B, V, H, W, 3)
             torch.Tensor,  # affine             (B, n_affine_tokens, 3, 4)
+            torch.Tensor,  # sky_cubemap        (B, 6, S, S, 3)
+            torch.Tensor,  # sky_cubemap_mask   (B, 6, S, S, 1)
         ]
         | KelvinPointQueryStaticOutput
     ):
@@ -169,6 +176,23 @@ class KelvinStaticCore(nn.Module):
         )
         context_rgb = self.decoder.gaussian_activations.rgb(context_rgb)
         context_world_normal = torch.nn.functional.normalize(context_world_normal, dim=-1)
+        semantic_argmax = torch.argmax(context_semantic_logits, dim=-1)  # (B, V, H, W)
+
+        # Public checkpoints intentionally omit the learned ``sky.*`` head.
+        # Build the renderable cubemap from the dense decoder's canonical RGB
+        # and SKY semantics instead; this uses only released weights.
+        observed_sky = [
+            build_observed_sky_cubemap_with_mask(
+                self.sky_cubemap_size,
+                rays[bidx, ..., 3:],
+                context_rgb[bidx],
+                semantic_argmax[bidx] == self._SEMANTIC_SKY,
+                semantic_argmax[bidx] == self._SEMANTIC_ROAD,
+            )
+            for bidx in range(B)
+        ]
+        sky_cubemap = torch.stack([item[0] for item in observed_sky], dim=0)
+        sky_cubemap_mask = torch.stack([item[1] for item in observed_sky], dim=0)
 
         # Point-query replaces the dense Gaussian head with sparse queries.
         point_query_output = None
@@ -200,7 +224,6 @@ class KelvinStaticCore(nn.Module):
             gs_opacity = self.decoder.gaussian_activations.opacity(gs_opacity) * (gs_valid_mask > 0.5).float().detach()
             gs_world_quaternion = self.decoder.gaussian_activations.rotation(gs_world_quaternion)
             gs_xyz = rays[..., :3] + rays[..., 3:] * gs_distance  # (B, V, H, W, 3)
-            semantic_argmax = torch.argmax(context_semantic_logits, dim=-1)  # (B, V, H, W)
 
         # ----- Per-camera affine post-processing -----
         encoded_deepest_tokens = rearrange(encoded_deepest, "B V h w C -> B (V h w) C")
@@ -222,6 +245,8 @@ class KelvinStaticCore(nn.Module):
                 normals=point_query_output.normals,
                 affine_matrix=affine_matrix,
                 source_indices=point_query_output.source_indices,
+                sky_cubemap=sky_cubemap,
+                sky_cubemap_mask=sky_cubemap_mask,
             )
 
         return (
@@ -233,4 +258,6 @@ class KelvinStaticCore(nn.Module):
             semantic_argmax,
             context_world_normal,
             affine_matrix,
+            sky_cubemap,
+            sky_cubemap_mask,
         )

--- a/instant_nurec/model/system.py
+++ b/instant_nurec/model/system.py
@@ -34,6 +34,7 @@ from instant_nurec.predict.export_ply import export_ply
 from instant_nurec.predict.export_sky import export_sky
 from instant_nurec.predict.primitive_merge import KelvinPrimitiveMerge
 from instant_nurec.predict.render_preview import render_reference_preview
+from instant_nurec.predict.render_video import render_reference_video
 from instant_nurec.primitives.base import BaseInstantNuRecPrimitive
 from instant_nurec.primitives.kelvin_primitive import KelvinInstantNuRecPrimitive
 from instant_nurec.utils.batch import DataAndRenderingBatch, InstantNuRecDataBatch
@@ -133,13 +134,6 @@ class GaussiansInstantNuRecSystem(nn.Module):
                 / meta["sequence_id"]
                 / f"{meta['sequence_id']}{chunk_suffix}.ply"
             )
-            render_stats = None
-            if getattr(self.predict_config, "render_preview", False):
-                render_stats = render_reference_preview(
-                    cast(KelvinInstantNuRecPrimitive, primitive),
-                    context,
-                    path.with_suffix(".render.png"),
-                )
             export_ply(
                 primitives=primitive,
                 rig_trajectories=rig,
@@ -152,12 +146,46 @@ class GaussiansInstantNuRecSystem(nn.Module):
             print(f"Wrote 3DGS PLY ({n:,} gaussians): {path.resolve()}", flush=True)
             print(f"Wrote sky sidecar: {sidecar_path.resolve()}", flush=True)
             print(f"Wrote sky preview: {preview_path.resolve()}", flush=True)
+
+            render_stats = None
+            if getattr(self.predict_config, "render_preview", False):
+                render_stats = render_reference_preview(
+                    cast(KelvinInstantNuRecPrimitive, primitive),
+                    context,
+                    path.with_suffix(".render.png"),
+                )
+            video_stats = None
+            if getattr(self.predict_config, "render_video", False):
+                predict_dataset = self.datamodule.predict_dataset
+                if predict_dataset is None:
+                    raise RuntimeError("Predict dataset is unavailable while exporting the calibrated video")
+                camera_id = predict_dataset.config.context_camera_ids[0]
+                full_camera_rig = predict_dataset.load_full_camera_rig(
+                    meta["ncore_json_path"],
+                    rig,
+                    camera_id=camera_id,
+                )
+                video_stats = render_reference_video(
+                    cast(KelvinInstantNuRecPrimitive, primitive),
+                    full_camera_rig,
+                    path.with_suffix(".render.mp4"),
+                )
             if render_stats is not None:
                 print(
                     "Wrote sky-composited render "
                     f"(background={render_stats.background_fraction:.1%}, "
                     f"sky contribution={render_stats.sky_contribution_mean:.4f}): "
                     f"{render_stats.path.resolve()}",
+                    flush=True,
+                )
+            if video_stats is not None:
+                print(
+                    "Wrote calibrated source-trajectory video "
+                    f"({video_stats.frame_count:,} frames, {video_stats.fps:.3f} fps, "
+                    f"{video_stats.duration_seconds:.2f}s, "
+                    f"background={video_stats.background_fraction:.1%}, "
+                    f"sky contribution={video_stats.sky_contribution_mean:.4f}): "
+                    f"{video_stats.path.resolve()}",
                     flush=True,
                 )
 

--- a/instant_nurec/model/system.py
+++ b/instant_nurec/model/system.py
@@ -17,9 +17,9 @@ from __future__ import annotations
 
 import gc
 import logging
-import os
 
 from pathlib import Path
+from typing import cast
 
 import torch
 
@@ -31,9 +31,12 @@ from instant_nurec.config_schema.instantnurec import GaussiansInstantNuRecSystem
 from instant_nurec.datasets.datamodule import InstantNuRecDataModule
 from instant_nurec.model.inference import KelvinInferenceModel
 from instant_nurec.predict.export_ply import export_ply
+from instant_nurec.predict.export_sky import export_sky
 from instant_nurec.predict.primitive_merge import KelvinPrimitiveMerge
+from instant_nurec.predict.render_preview import render_reference_preview
 from instant_nurec.primitives.base import BaseInstantNuRecPrimitive
-from instant_nurec.utils.batch import InstantNuRecDataBatch
+from instant_nurec.primitives.kelvin_primitive import KelvinInstantNuRecPrimitive
+from instant_nurec.utils.batch import DataAndRenderingBatch, InstantNuRecDataBatch
 from instant_nurec.utils.types import RigTrajectories
 
 
@@ -116,21 +119,47 @@ class GaussiansInstantNuRecSystem(nn.Module):
         if out_batch.meta is None or out_batch.context_rig is None:
             return
 
-        def export_chunk(primitive: BaseInstantNuRecPrimitive, rig: RigTrajectories, meta: dict, chunk_suffix: str) -> None:
-            path = os.path.join(
-                self.out_dir,
-                self.run_id,
-                "ply",
-                meta["sequence_id"],
-                meta["sequence_id"] + chunk_suffix + ".ply",
+        def export_chunk(
+            primitive: BaseInstantNuRecPrimitive,
+            context: DataAndRenderingBatch,
+            rig: RigTrajectories,
+            meta: dict,
+            chunk_suffix: str,
+        ) -> None:
+            path = (
+                Path(self.out_dir)
+                / self.run_id
+                / "ply"
+                / meta["sequence_id"]
+                / f"{meta['sequence_id']}{chunk_suffix}.ply"
             )
+            render_stats = None
+            if getattr(self.predict_config, "render_preview", False):
+                render_stats = render_reference_preview(
+                    cast(KelvinInstantNuRecPrimitive, primitive),
+                    context,
+                    path.with_suffix(".render.png"),
+                )
             export_ply(
                 primitives=primitive,
                 rig_trajectories=rig,
-                path=Path(path),
+                path=path,
+            )
+            sidecar_path, preview_path = export_sky(
+                cast(KelvinInstantNuRecPrimitive, primitive), rig, path
             )
             n = primitive.static_layer.densities.numel()
-            print(f"Wrote 3DGS PLY ({n:,} gaussians): {Path(path).resolve()}", flush=True)
+            print(f"Wrote 3DGS PLY ({n:,} gaussians): {path.resolve()}", flush=True)
+            print(f"Wrote sky sidecar: {sidecar_path.resolve()}", flush=True)
+            print(f"Wrote sky preview: {preview_path.resolve()}", flush=True)
+            if render_stats is not None:
+                print(
+                    "Wrote sky-composited render "
+                    f"(background={render_stats.background_fraction:.1%}, "
+                    f"sky contribution={render_stats.sky_contribution_mean:.4f}): "
+                    f"{render_stats.path.resolve()}",
+                    flush=True,
+                )
 
         for chunk_idx in range(n_chunks):
             meta = out_batch.meta[chunk_idx]
@@ -138,6 +167,7 @@ class GaussiansInstantNuRecSystem(nn.Module):
             chunk_suffix = "" if self.predict_config.primitive_merge.enabled else f"_chunk{chunk_idx}"
             export_chunk(
                 primitives_list[chunk_idx],
+                out_batch.context[chunk_idx],
                 out_batch.context_rig[chunk_idx],
                 meta,
                 chunk_suffix,

--- a/instant_nurec/predict/export_sky.py
+++ b/instant_nurec/predict/export_sky.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Export the non-Gaussian sky state that cannot be stored in a 3DGS PLY."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from PIL import Image
+
+from instant_nurec.primitives.kelvin_primitive import KelvinInstantNuRecPrimitive
+from instant_nurec.utils.cubemap import layout_sky_cubemap, rotate_sky_cubemap
+from instant_nurec.utils.types import RigTrajectories
+
+
+SKY_SIDECAR_VERSION = 1
+SKY_FACE_ORDER = ("right", "left", "top", "bottom", "front", "back")
+SKY_FACE_AXES = ("+X", "-X", "-Y", "+Y", "+Z", "-Z")
+
+
+def sky_sidecar_path(ply_path: Path) -> Path:
+    return ply_path.with_suffix(".sky.npz")
+
+
+def sky_preview_path(ply_path: Path) -> Path:
+    return ply_path.with_suffix(".sky.png")
+
+
+def export_sky(
+    primitives: KelvinInstantNuRecPrimitive,
+    rig_trajectories: RigTrajectories,
+    ply_path: Path,
+) -> tuple[Path, Path]:
+    """Write a world-aligned cubemap sidecar and a human-readable preview.
+
+    Standard Gaussian-splatting PLY files have no environment-map or camera
+    ISP fields. The ``.sky.npz`` file therefore travels next to the PLY and
+    stores both, without pickle objects, for the renderer.
+    """
+
+    world_rotation = rig_trajectories.T_world_base[:3, :3].to(
+        device=primitives.device(), dtype=torch.float32
+    )
+    cubemap = rotate_sky_cubemap(primitives.sky_cubemap, world_rotation)
+    cubemap = cubemap.detach().float().cpu()
+    mask = primitives.sky_cubemap_mask
+    if mask is None:
+        mask = torch.zeros_like(cubemap[..., :1])
+    else:
+        mask = rotate_sky_cubemap(mask, world_rotation)
+        mask = mask.detach().float().cpu().clamp(0.0, 1.0)
+    affine = primitives.affine_matrix.detach().float().cpu()
+    affine_sensor_ids = tuple(rig_trajectories.camera_calibrations.keys())
+    affine_sensor_indices = tuple(
+        calibration.unique_sensor_idx
+        for calibration in rig_trajectories.camera_calibrations.values()
+    )
+    if len(affine_sensor_ids) != len(affine):
+        raise ValueError(
+            "Affine matrix rows must match ordered camera calibrations: "
+            f"got {len(affine)} rows and {len(affine_sensor_ids)} calibrations"
+        )
+    observed_fraction = float(mask.mean())
+    if not bool(mask.max() > 0):
+        sky_source = "synthetic_fallback"
+    elif bool(mask.min() >= 1):
+        sky_source = "observed_rgb_semantics"
+    else:
+        sky_source = "observed_rgb_semantics_plus_fallback"
+
+    sidecar_path = sky_sidecar_path(ply_path)
+    preview_path = sky_preview_path(ply_path)
+    sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(
+        sidecar_path,
+        format_version=np.asarray(SKY_SIDECAR_VERSION, dtype=np.int32),
+        sky_cubemap=cubemap.numpy().astype(np.float16),
+        sky_cubemap_mask=mask.numpy().astype(np.float16),
+        affine_matrix=affine.numpy().astype(np.float32),
+        affine_sensor_indices=np.asarray(affine_sensor_indices, dtype=np.int64),
+        affine_sensor_ids=np.asarray(affine_sensor_ids),
+        face_order=np.asarray(SKY_FACE_ORDER),
+        face_axes=np.asarray(SKY_FACE_AXES),
+        uv_convention=np.asarray("u_left_to_right_v_top_to_bottom"),
+        coordinate_frame=np.asarray("ncore_world"),
+        sky_source=np.asarray(sky_source),
+        sky_observed_fraction=np.asarray(observed_fraction, dtype=np.float32),
+    )
+
+    preview = layout_sky_cubemap(cubemap.clamp(0.0, 1.0))
+    preview_u8 = (preview * 255.0).round().to(torch.uint8).numpy()
+    Image.fromarray(preview_u8, mode="RGB").save(preview_path)
+    return sidecar_path, preview_path

--- a/instant_nurec/predict/primitive_merge.py
+++ b/instant_nurec/predict/primitive_merge.py
@@ -340,12 +340,29 @@ class KelvinPrimitiveMerge:
 
     def _merge_sky_cubemaps(
         self,
-        sky_cubemaps: list[torch.Tensor],
+        primitives: list[KelvinInstantNuRecPrimitive],
         batch: InstantNuRecDataBatch,
         batch_rig_transforms: list[torch.Tensor],
-    ) -> torch.Tensor:
+        floor_weight: float = 0.01,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         del batch, batch_rig_transforms
-        return torch.stack(sky_cubemaps, dim=0).mean(dim=0)
+        weighted_sum = torch.zeros_like(primitives[0].sky_cubemap)
+        weight_sum = torch.zeros_like(weighted_sum)
+        merged_mask = torch.zeros_like(weighted_sum[..., :1])
+        for chunk_idx, primitive in enumerate(primitives):
+            mask = primitive.sky_cubemap_mask
+            if mask is None:
+                logger.warning(
+                    "Chunk %d has no sky cubemap mask; using floor weight %.4g only.",
+                    chunk_idx,
+                    floor_weight,
+                )
+                mask = torch.zeros_like(primitive.sky_cubemap[..., :1])
+            weights = mask + floor_weight
+            weighted_sum += primitive.sky_cubemap * weights
+            weight_sum += weights
+            merged_mask = torch.maximum(merged_mask, mask)
+        return weighted_sum / weight_sum.clamp_min(1e-8), merged_mask
 
     @torch.autocast(device_type="cuda", enabled=False)
     def _merge_affine_matrices(self, affine_matrices: list[torch.Tensor]) -> tuple[torch.Tensor, list[torch.Tensor]]:
@@ -400,14 +417,15 @@ class KelvinPrimitiveMerge:
         for b_idx, y_inv_matrix in enumerate(y_inv_matrices):
             all_primitives[b_idx].color_transform(y_inv_matrix)
 
-        merged_sky_cubemap = self._merge_sky_cubemaps(
-            [p.sky_cubemap for p in all_primitives], batch, batch_rig_transforms
+        merged_sky_cubemap, merged_sky_cubemap_mask = self._merge_sky_cubemaps(
+            all_primitives, batch, batch_rig_transforms
         )
 
         merged_primitive = KelvinInstantNuRecPrimitive(
             static_layer=KelvinStaticLayer.concatenate(all_static_layers),
             dynamic_layers=[KelvinDynamicLayer.concatenate(all_dynamic_layers)],
             sky_cubemap=merged_sky_cubemap,
+            sky_cubemap_mask=merged_sky_cubemap_mask,
             affine_matrix=merged_affine_matrix,
         )
         return merged_primitive

--- a/instant_nurec/predict/render_preview.py
+++ b/instant_nurec/predict/render_preview.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import inspect
+
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -17,7 +19,6 @@ from instant_nurec.utils.batch import DataAndRenderingBatch
 from instant_nurec.utils.cubemap import sample_sky_cubemap
 from instant_nurec.utils.geometry import tquat_to_se3_matrix
 from instant_nurec.utils.misc import unpack_optional
-from instant_nurec.utils.sensor import to_simple_pinhole_model_parameters
 
 
 @dataclass(frozen=True, slots=True)
@@ -36,9 +37,17 @@ def require_gsplat():
         from gsplat import rasterization
     except (ImportError, OSError) as exc:  # pragma: no cover - depends on optional install
         raise RuntimeError(
-            "Sky preview rendering requires gsplat. Install it with "
-            "`uv sync --extra render`, then rerun with --render-preview."
+            "Calibrated rendering requires gsplat. Install it with "
+            "`uv sync --extra render`, then rerun the render command."
         ) from exc
+    parameters = inspect.signature(rasterization).parameters.values()
+    if "rays" not in inspect.signature(rasterization).parameters and not any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters
+    ):
+        raise RuntimeError(
+            "The installed gsplat lacks calibrated world-ray rendering. Run "
+            "`uv sync --extra render --reinstall-package gsplat` to install the pinned upstream fix."
+        )
     return rasterization
 
 
@@ -75,21 +84,90 @@ def _camera_affine_index(context: DataAndRenderingBatch, frame_index: int) -> in
     return ordered_sensor_indices.index(camera.meta[frame_index].unique_sensor_idx)
 
 
-def render_reference_preview(
+def _looks_like_ftheta(parameters: object) -> bool:
+    return all(
+        hasattr(parameters, name)
+        for name in (
+            "reference_poly",
+            "pixeldist_to_angle_poly",
+            "angle_to_pixeldist_poly",
+            "max_angle",
+            "linear_cde",
+            "principal_point",
+            "shutter_type",
+        )
+    )
+
+
+def _ftheta_gsplat_parameters(parameters: object) -> tuple[object, object, object]:
+    """Convert NCore F-theta parameters to public gsplat's host types."""
+
+    external_distortion = getattr(parameters, "external_distortion_parameters", None)
+    if external_distortion is None:
+        external_distortion = getattr(parameters, "external_distortion", None)
+    if external_distortion is not None:
+        raise NotImplementedError(
+            "F-theta rendering with external windshield distortion is not "
+            "supported by this public calibrated-render path."
+        )
+
+    try:
+        from gsplat.rendering import (
+            FThetaCameraDistortionParameters,
+            FThetaPolynomialType,
+            RollingShutterType,
+        )
+    except (ImportError, OSError) as exc:  # pragma: no cover - depends on optional install
+        raise RuntimeError(
+            "Sky preview rendering requires gsplat. Install it with "
+            "`uv sync --extra render`, then rerun with --render-preview."
+        ) from exc
+
+    reference_name = getattr(
+        parameters.reference_poly,
+        "name",
+        str(parameters.reference_poly).rsplit(".", maxsplit=1)[-1],
+    )
+    shutter_name = getattr(
+        parameters.shutter_type,
+        "name",
+        str(parameters.shutter_type).rsplit(".", maxsplit=1)[-1],
+    )
+    try:
+        reference_poly = FThetaPolynomialType[reference_name]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported F-theta reference polynomial: {parameters.reference_poly!r}") from exc
+    try:
+        rolling_shutter = RollingShutterType[shutter_name]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported camera shutter type: {parameters.shutter_type!r}") from exc
+
+    ftheta_coeffs = FThetaCameraDistortionParameters(
+        reference_poly=reference_poly,
+        pixeldist_to_angle_poly=tuple(float(value) for value in parameters.pixeldist_to_angle_poly),
+        angle_to_pixeldist_poly=tuple(float(value) for value in parameters.angle_to_pixeldist_poly),
+        max_angle=float(parameters.max_angle),
+        linear_cde=tuple(float(value) for value in parameters.linear_cde),
+    )
+    return ftheta_coeffs, rolling_shutter, RollingShutterType.GLOBAL
+
+
+@torch.inference_mode()
+def render_composited_frame(
     primitive: KelvinInstantNuRecPrimitive,
     context: DataAndRenderingBatch,
-    path: Path,
     *,
     frame_index: int = 0,
-) -> RenderPreviewStats:
-    """Render one context frame and composite the primitive's sky cubemap.
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Render and composite one context frame without writing it to disk.
 
     ``gsplat`` is imported lazily so the default reconstruction/PLY workflow
     keeps its original dependency footprint. Install the ``render`` extra to
     enable this function.
-    """
 
-    rasterization = require_gsplat()
+    Returns the composed RGB image, foreground opacity, and sampled sky image
+    as device-resident tensors.
+    """
 
     rendering = unpack_optional(unpack_optional(context.rendering).camera)
     camera_data = unpack_optional(context.data.camera)
@@ -99,22 +177,33 @@ def render_reference_preview(
     device = primitive.device()
     rays = rendering.rays[frame_index]
     height, width = rays.shape[:2]
-    pinhole = to_simple_pinhole_model_parameters(rendering.sensor_model_parameters[frame_index])
-    fx, fy = (float(value) for value in pinhole.focal_length)
-    cx, cy = (float(value) for value in pinhole.principal_point)
+    world_rays = rays.to(device=device, dtype=torch.float32).contiguous()
+    sensor_parameters = rendering.sensor_model_parameters[frame_index]
+    if not _looks_like_ftheta(sensor_parameters):
+        raise NotImplementedError(
+            "Calibrated rendering currently supports NCore F-theta cameras only; "
+            f"got {type(sensor_parameters).__name__}."
+        )
+
+    rasterization = require_gsplat()
+    ftheta_coeffs, rolling_shutter, global_shutter = _ftheta_gsplat_parameters(sensor_parameters)
+    focal = float(sensor_parameters.angle_to_pixeldist_poly[1])
+    cx, cy = (float(value) for value in sensor_parameters.principal_point)
     intrinsics = torch.tensor(
-        [[fx, 0.0, cx], [0.0, fy, cy], [0.0, 0.0, 1.0]],
+        [[focal, 0.0, cx], [0.0, focal, cy], [0.0, 0.0, 1.0]],
         dtype=torch.float32,
         device=device,
     )
-    # Match public inference, which encodes the exposure-end pose. The
-    # foreground projection remains a simple-pinhole approximation; sky rays
-    # themselves retain the NCore camera model and rolling-shutter geometry.
-    camera_to_world = tquat_to_se3_matrix(
+    camera_to_world_start = tquat_to_se3_matrix(
+        rendering.poses_tquat_startend[frame_index, 0],
+        unbatch=True,
+    ).to(device=device, dtype=torch.float32)
+    camera_to_world_end = tquat_to_se3_matrix(
         rendering.poses_tquat_startend[frame_index, 1],
         unbatch=True,
     ).to(device=device, dtype=torch.float32)
-    world_to_camera = torch.linalg.inv(camera_to_world)
+    world_to_camera = torch.linalg.inv(camera_to_world_start)
+    world_to_camera_end = torch.linalg.inv(camera_to_world_end)
 
     static = primitive.static_layer
     rendered_rgb, rendered_alpha, _ = rasterization(
@@ -127,22 +216,47 @@ def render_reference_preview(
         Ks=intrinsics.unsqueeze(0),
         width=width,
         height=height,
-        near_plane=0.01,
-        far_plane=1000.0,
+        near_plane=0.2,
+        far_plane=torch.finfo(torch.float32).max,
         sh_degree=None,
         render_mode="RGB",
-        camera_model="pinhole",
-        packed=True,
+        camera_model="ftheta",
+        packed=False,
+        with_ut=True,
+        with_eval3d=True,
+        global_z_order=False,
+        rays=world_rays.unsqueeze(0),
+        ftheta_coeffs=ftheta_coeffs,
+        rolling_shutter=rolling_shutter,
+        viewmats_rs=(world_to_camera_end.unsqueeze(0) if rolling_shutter != global_shutter else None),
     )
     foreground = rendered_rgb[0, ..., :3]
     opacity = rendered_alpha[0, ..., 0]
     sky = sample_sky_cubemap(
         primitive.sky_cubemap,
-        rays[..., 3:].to(device=device, dtype=torch.float32),
+        world_rays[..., 3:],
     )
     affine_index = _camera_affine_index(context, frame_index)
     affine = primitive.affine_matrix[affine_index].float()
     composed = composite_sky_and_affine(foreground, opacity, sky, affine)
+    return composed, opacity, sky
+
+
+def render_reference_preview(
+    primitive: KelvinInstantNuRecPrimitive,
+    context: DataAndRenderingBatch,
+    path: Path,
+    *,
+    frame_index: int = 0,
+) -> RenderPreviewStats:
+    """Render one composited context frame and save it as a PNG."""
+
+    composed, opacity, sky = render_composited_frame(
+        primitive,
+        context,
+        frame_index=frame_index,
+    )
+    height, width = composed.shape[:2]
 
     path.parent.mkdir(parents=True, exist_ok=True)
     pixels = (composed.detach().cpu() * 255.0).round().to(torch.uint8).numpy()

--- a/instant_nurec/predict/render_preview.py
+++ b/instant_nurec/predict/render_preview.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reference-view Gaussian rendering with cubemap sky compositing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+
+from PIL import Image
+
+from instant_nurec.primitives.kelvin_primitive import KelvinInstantNuRecPrimitive
+from instant_nurec.utils.batch import DataAndRenderingBatch
+from instant_nurec.utils.cubemap import sample_sky_cubemap
+from instant_nurec.utils.geometry import tquat_to_se3_matrix
+from instant_nurec.utils.misc import unpack_optional
+from instant_nurec.utils.sensor import to_simple_pinhole_model_parameters
+
+
+@dataclass(frozen=True, slots=True)
+class RenderPreviewStats:
+    path: Path
+    width: int
+    height: int
+    background_fraction: float
+    sky_contribution_mean: float
+
+
+def require_gsplat():
+    """Import and return gsplat's rasterizer before reconstruction starts."""
+
+    try:
+        from gsplat import rasterization
+    except (ImportError, OSError) as exc:  # pragma: no cover - depends on optional install
+        raise RuntimeError(
+            "Sky preview rendering requires gsplat. Install it with "
+            "`uv sync --extra render`, then rerun with --render-preview."
+        ) from exc
+    return rasterization
+
+
+def composite_sky_and_affine(
+    foreground_rgb: torch.Tensor,
+    opacity: torch.Tensor,
+    sky_rgb: torch.Tensor,
+    affine_matrix: torch.Tensor,
+) -> torch.Tensor:
+    """Match Kelvin rendering: alpha-composite sky, then apply camera ISP."""
+
+    if foreground_rgb.shape != sky_rgb.shape or foreground_rgb.shape[-1] != 3:
+        raise ValueError(
+            "foreground_rgb and sky_rgb must have identical (..., 3) shapes, "
+            f"got {tuple(foreground_rgb.shape)} and {tuple(sky_rgb.shape)}"
+        )
+    if opacity.shape not in (foreground_rgb.shape[:-1], (*foreground_rgb.shape[:-1], 1)):
+        raise ValueError(f"Opacity shape {tuple(opacity.shape)} does not match RGB {tuple(foreground_rgb.shape)}")
+    if affine_matrix.shape != (3, 4):
+        raise ValueError(f"Expected affine matrix (3, 4), got {tuple(affine_matrix.shape)}")
+
+    alpha = opacity.unsqueeze(-1) if opacity.ndim == foreground_rgb.ndim - 1 else opacity
+    composed = foreground_rgb + (1.0 - alpha) * sky_rgb
+    composed = torch.einsum("...p,qp->...q", composed, affine_matrix[:, :3])
+    return (composed + affine_matrix[:, 3]).clamp(0.0, 1.0)
+
+
+def _camera_affine_index(context: DataAndRenderingBatch, frame_index: int) -> int:
+    camera = unpack_optional(context.data.camera)
+    ordered_sensor_indices: list[int] = []
+    for meta in camera.meta:
+        if meta.unique_sensor_idx not in ordered_sensor_indices:
+            ordered_sensor_indices.append(meta.unique_sensor_idx)
+    return ordered_sensor_indices.index(camera.meta[frame_index].unique_sensor_idx)
+
+
+def render_reference_preview(
+    primitive: KelvinInstantNuRecPrimitive,
+    context: DataAndRenderingBatch,
+    path: Path,
+    *,
+    frame_index: int = 0,
+) -> RenderPreviewStats:
+    """Render one context frame and composite the primitive's sky cubemap.
+
+    ``gsplat`` is imported lazily so the default reconstruction/PLY workflow
+    keeps its original dependency footprint. Install the ``render`` extra to
+    enable this function.
+    """
+
+    rasterization = require_gsplat()
+
+    rendering = unpack_optional(unpack_optional(context.rendering).camera)
+    camera_data = unpack_optional(context.data.camera)
+    if not 0 <= frame_index < camera_data.b:
+        raise IndexError(f"frame_index {frame_index} is outside [0, {camera_data.b})")
+
+    device = primitive.device()
+    rays = rendering.rays[frame_index]
+    height, width = rays.shape[:2]
+    pinhole = to_simple_pinhole_model_parameters(rendering.sensor_model_parameters[frame_index])
+    fx, fy = (float(value) for value in pinhole.focal_length)
+    cx, cy = (float(value) for value in pinhole.principal_point)
+    intrinsics = torch.tensor(
+        [[fx, 0.0, cx], [0.0, fy, cy], [0.0, 0.0, 1.0]],
+        dtype=torch.float32,
+        device=device,
+    )
+    # Match public inference, which encodes the exposure-end pose. The
+    # foreground projection remains a simple-pinhole approximation; sky rays
+    # themselves retain the NCore camera model and rolling-shutter geometry.
+    camera_to_world = tquat_to_se3_matrix(
+        rendering.poses_tquat_startend[frame_index, 1],
+        unbatch=True,
+    ).to(device=device, dtype=torch.float32)
+    world_to_camera = torch.linalg.inv(camera_to_world)
+
+    static = primitive.static_layer
+    rendered_rgb, rendered_alpha, _ = rasterization(
+        means=static.positions.float(),
+        quats=static.rotations.float(),
+        scales=static.scales.float(),
+        opacities=static.densities[:, 0].float(),
+        colors=static.rgb.float(),
+        viewmats=world_to_camera.unsqueeze(0),
+        Ks=intrinsics.unsqueeze(0),
+        width=width,
+        height=height,
+        near_plane=0.01,
+        far_plane=1000.0,
+        sh_degree=None,
+        render_mode="RGB",
+        camera_model="pinhole",
+        packed=True,
+    )
+    foreground = rendered_rgb[0, ..., :3]
+    opacity = rendered_alpha[0, ..., 0]
+    sky = sample_sky_cubemap(
+        primitive.sky_cubemap,
+        rays[..., 3:].to(device=device, dtype=torch.float32),
+    )
+    affine_index = _camera_affine_index(context, frame_index)
+    affine = primitive.affine_matrix[affine_index].float()
+    composed = composite_sky_and_affine(foreground, opacity, sky, affine)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pixels = (composed.detach().cpu() * 255.0).round().to(torch.uint8).numpy()
+    Image.fromarray(pixels, mode="RGB").save(path)
+    sky_contribution = ((1.0 - opacity[..., None]) * sky).mean().item()
+    return RenderPreviewStats(
+        path=path,
+        width=width,
+        height=height,
+        background_fraction=(1.0 - opacity).mean().item(),
+        sky_contribution_mean=sky_contribution,
+    )

--- a/instant_nurec/predict/render_video.py
+++ b/instant_nurec/predict/render_video.py
@@ -1,0 +1,303 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stream a calibrated source-camera trajectory to an H.264 video."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+
+from tqdm import tqdm
+
+from instant_nurec.predict.render_preview import render_composited_frame
+from instant_nurec.primitives.kelvin_primitive import KelvinInstantNuRecPrimitive
+from instant_nurec.utils.batch import (
+    CameraFrameLabels,
+    CameraFreePoseViewGeometry,
+    DataAndRenderingBatch,
+    DataBatch,
+    FrameMeta,
+    RenderingBatch,
+)
+from instant_nurec.utils.types import RigTrajectories
+
+
+@dataclass(frozen=True, slots=True)
+class RenderVideoStats:
+    path: Path
+    width: int
+    height: int
+    frame_count: int
+    fps: float
+    duration_seconds: float
+    background_fraction: float
+    sky_contribution_mean: float
+
+
+def require_ffmpeg() -> str:
+    """Return an ffmpeg with libx264 or fail before reconstruction begins."""
+
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        raise RuntimeError(
+            "Full calibrated video rendering requires ffmpeg on PATH. Install ffmpeg, "
+            "then rerun with --merge --render-video."
+        )
+    probe = subprocess.run(
+        [ffmpeg, "-hide_banner", "-loglevel", "error", "-encoders"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if probe.returncode != 0:
+        message = probe.stderr.strip() or "no error output"
+        raise RuntimeError(f"Could not query ffmpeg encoders: {message}")
+    if "libx264" not in probe.stdout:
+        raise RuntimeError("Full calibrated video rendering requires an ffmpeg build with the libx264 encoder.")
+    return ffmpeg
+
+
+def infer_source_fps(frame_timestamps_startend_us: torch.Tensor) -> float:
+    """Infer fixed-rate playback from the median source-frame cadence."""
+
+    if frame_timestamps_startend_us.ndim != 2 or frame_timestamps_startend_us.shape[1] != 2:
+        raise ValueError(
+            f"Expected source timestamps with shape (frames, 2), got {tuple(frame_timestamps_startend_us.shape)}"
+        )
+    if len(frame_timestamps_startend_us) < 2:
+        raise ValueError("At least two source frames are required to render a video")
+    starts = frame_timestamps_startend_us[:, 0].to(dtype=torch.float64, device="cpu")
+    cadence_us = torch.diff(starts)
+    if bool((cadence_us <= 0).any()):
+        raise ValueError("Source camera frame timestamps must be strictly increasing")
+    return 1_000_000.0 / float(cadence_us.median().item())
+
+
+def _ffmpeg_command(
+    ffmpeg: str,
+    *,
+    width: int,
+    height: int,
+    fps: float,
+    output_path: Path,
+) -> list[str]:
+    return [
+        ffmpeg,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-f",
+        "rawvideo",
+        "-pixel_format",
+        "rgb24",
+        "-video_size",
+        f"{width}x{height}",
+        "-framerate",
+        f"{fps:.8f}",
+        "-i",
+        "pipe:0",
+        "-an",
+        "-c:v",
+        "libx264",
+        "-preset",
+        "medium",
+        "-crf",
+        "18",
+        "-pix_fmt",
+        "yuv420p",
+        "-movflags",
+        "+faststart",
+        str(output_path),
+    ]
+
+
+def _reserve_partial_path(path: Path) -> Path:
+    """Reserve a unique output path beside the final video."""
+
+    with tempfile.NamedTemporaryFile(
+        prefix=f".{path.stem}.",
+        suffix=".partial.mp4",
+        dir=path.parent,
+        delete=False,
+    ) as partial_file:
+        return Path(partial_file.name)
+
+
+def _ffmpeg_error(returncode: int, stderr_log) -> RuntimeError:
+    stderr_log.flush()
+    stderr_log.seek(0)
+    stderr = stderr_log.read().decode("utf-8", errors="replace").strip()
+    return RuntimeError(f"ffmpeg exited with status {returncode}: {stderr or 'no error output'}")
+
+
+def _close_stdin(process: subprocess.Popen) -> None:
+    if process.stdin is None or process.stdin.closed:
+        return
+    try:
+        process.stdin.close()
+    except (BrokenPipeError, OSError):
+        pass
+
+
+def _stop_process(process: subprocess.Popen) -> None:
+    if process.poll() is not None:
+        _close_stdin(process)
+        return
+    process.kill()
+    _close_stdin(process)
+    try:
+        process.wait()
+    except OSError:
+        pass
+
+
+def _single_camera_sequence(
+    rig: RigTrajectories,
+) -> tuple[str, RigTrajectories.CameraCalibration, torch.Tensor]:
+    if len(rig.camera_calibrations) != 1:
+        raise ValueError(
+            f"Full video rendering expects exactly one camera calibration, got {list(rig.camera_calibrations)}"
+        )
+    sensor_id, calibration = next(iter(rig.camera_calibrations.items()))
+    candidates = [
+        trajectory for trajectory in rig.rig_trajectories if trajectory.sequence_id == calibration.sequence_id
+    ]
+    if len(candidates) != 1:
+        raise ValueError(f"Expected one trajectory for render camera {sensor_id!r}, found {len(candidates)}")
+    return sensor_id, calibration, candidates[0].cameras_frame_timestamps_us[sensor_id]
+
+
+def _frame_context(
+    geometry: CameraFreePoseViewGeometry,
+    *,
+    unique_sensor_idx: int,
+    unique_frame_idx: int,
+    device: torch.device,
+) -> DataAndRenderingBatch:
+    camera = DataBatch.Camera(
+        meta=[
+            FrameMeta(
+                unique_sensor_idx=unique_sensor_idx,
+                unique_frame_idx=unique_frame_idx,
+            )
+        ],
+        labels=CameraFrameLabels(),
+    ).to(device)
+    rendering = geometry.to_rendering_data(camera)
+    return DataAndRenderingBatch(
+        data=DataBatch(camera=camera),
+        rendering=RenderingBatch(camera=rendering),
+    )
+
+
+@torch.inference_mode()
+def render_reference_video(
+    primitive: KelvinInstantNuRecPrimitive,
+    full_camera_rig: RigTrajectories,
+    path: Path,
+) -> RenderVideoStats:
+    """Render every source exposure while keeping only one frame's rays live."""
+
+    ffmpeg = require_ffmpeg()
+    sensor_id, calibration, timestamps = _single_camera_sequence(full_camera_rig)
+    fps = infer_source_fps(timestamps)
+    frame_count = len(timestamps)
+    device = primitive.device()
+    geometry = CameraFreePoseViewGeometry.from_rig_trajectories(full_camera_rig).to(device=device)
+    frame_range = geometry.sensor_ids_to_frame_range[sensor_id]
+    if len(frame_range) != frame_count:
+        raise ValueError(f"Geometry frame count {len(frame_range)} does not match source timestamps {frame_count}")
+
+    width, height = (int(value) for value in calibration.camera_model_parameters.resolution)
+    if width % 2 or height % 2:
+        raise ValueError(f"H.264 yuv420p output requires even dimensions, got {width}x{height}")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    partial_path = _reserve_partial_path(path)
+    process: subprocess.Popen | None = None
+    completed = False
+    background_sum = 0.0
+    sky_contribution_sum = 0.0
+    with tempfile.TemporaryFile(mode="w+b") as stderr_log:
+        try:
+            process = subprocess.Popen(
+                _ffmpeg_command(
+                    ffmpeg,
+                    width=width,
+                    height=height,
+                    fps=fps,
+                    output_path=partial_path,
+                ),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.DEVNULL,
+                stderr=stderr_log,
+            )
+            if process.stdin is None:  # pragma: no cover - subprocess contract
+                raise RuntimeError("Failed to open ffmpeg input pipe")
+
+            try:
+                for unique_frame_idx in tqdm(
+                    frame_range,
+                    total=frame_count,
+                    desc="Rendering calibrated video",
+                    unit="frame",
+                ):
+                    context = _frame_context(
+                        geometry,
+                        unique_sensor_idx=calibration.unique_sensor_idx,
+                        unique_frame_idx=unique_frame_idx,
+                        device=device,
+                    )
+                    composed, opacity, sky = render_composited_frame(primitive, context)
+                    if composed.shape != (height, width, 3):
+                        raise ValueError(
+                            f"Rendered frame has shape {tuple(composed.shape)}, expected {(height, width, 3)}"
+                        )
+                    pixels = (
+                        composed.mul(255.0)
+                        .round_()
+                        .clamp_(0.0, 255.0)
+                        .to(dtype=torch.uint8, device="cpu")
+                        .contiguous()
+                        .numpy()
+                    )
+                    process.stdin.write(pixels.tobytes())
+                    background_sum += float((1.0 - opacity).mean().item())
+                    sky_contribution_sum += float(((1.0 - opacity[..., None]) * sky).mean().item())
+
+                process.stdin.close()
+            except BrokenPipeError as exc:
+                returncode = process.wait()
+                raise _ffmpeg_error(returncode, stderr_log) from exc
+
+            returncode = process.wait()
+            if returncode != 0:
+                raise _ffmpeg_error(returncode, stderr_log)
+            partial_path.replace(path)
+            completed = True
+        finally:
+            if process is not None:
+                _stop_process(process)
+            if not completed:
+                partial_path.unlink(missing_ok=True)
+
+    duration_seconds = frame_count / fps
+    return RenderVideoStats(
+        path=path,
+        width=width,
+        height=height,
+        frame_count=frame_count,
+        fps=fps,
+        duration_seconds=duration_seconds,
+        background_fraction=background_sum / frame_count,
+        sky_contribution_mean=sky_contribution_sum / frame_count,
+    )

--- a/instant_nurec/primitives/kelvin_primitive.py
+++ b/instant_nurec/primitives/kelvin_primitive.py
@@ -337,6 +337,7 @@ class KelvinInstantNuRecPrimitive(BaseInstantNuRecPrimitive):
 
     # Sky attributes
     sky_cubemap: torch.Tensor
+    sky_cubemap_mask: torch.Tensor | None
 
     # Post-processing attributes
     affine_matrix: torch.Tensor
@@ -347,10 +348,12 @@ class KelvinInstantNuRecPrimitive(BaseInstantNuRecPrimitive):
         dynamic_layers: list[KelvinDynamicLayer],
         sky_cubemap: torch.Tensor,
         affine_matrix: torch.Tensor,
+        sky_cubemap_mask: torch.Tensor | None = None,
     ):
         self.static_layer = static_layer
         self.dynamic_layers = dynamic_layers
         self.sky_cubemap = sky_cubemap
+        self.sky_cubemap_mask = sky_cubemap_mask
         self.affine_matrix = affine_matrix
         self._post_init_validation()
 
@@ -360,6 +363,10 @@ class KelvinInstantNuRecPrimitive(BaseInstantNuRecPrimitive):
         assert self.sky_cubemap.shape == (6, cubemap_size, cubemap_size, 3), (
             "Sky cubemap must have shape (6, height, width, 3)"
         )
+        if self.sky_cubemap_mask is not None:
+            assert self.sky_cubemap_mask.shape == (6, cubemap_size, cubemap_size, 1), (
+                "Sky cubemap mask must have shape (6, height, width, 1)"
+            )
         assert self.affine_matrix.ndim == 3, "Affine matrix must have shape (n_cameras, 3, 4)"
         assert self.affine_matrix.shape[1:] == (3, 4), "Affine matrix must have shape (n_cameras, 3, 4)"
 
@@ -379,7 +386,7 @@ class KelvinInstantNuRecPrimitive(BaseInstantNuRecPrimitive):
         config: PrimitiveExportPreprocessConfig,
         context_rig: RigTrajectories | None = None,
     ) -> Self:
-        """Filter static and dynamic layers by density threshold; do not apply rigid transform (merge does that)."""
+        """Prune Gaussian layers and prepare the observed-sky cubemap."""
         del context_batch, context_rig  # unused (Celsius's project_to_z_offset path was Kelvin-irrelevant)
         static_mask = self.static_layer.densities[:, 0] > config.density_prune_threshold
         new_static_layer = self.static_layer.mask(static_mask)
@@ -387,10 +394,29 @@ class KelvinInstantNuRecPrimitive(BaseInstantNuRecPrimitive):
         for dynamic_layer in self.dynamic_layers:
             dynamic_mask = dynamic_layer.max_densities[:, 0] > config.density_prune_threshold
             new_dynamic_layers.append(dynamic_layer.mask(dynamic_mask))
+
+        sky_cubemap = self.sky_cubemap
+        if config.infill_road_color and self.sky_cubemap_mask is not None:
+            if new_static_layer.semantic_class is None:
+                logger.warning("ROAD sky infill requested, but static Gaussians have no semantic classes")
+            else:
+                road_mask = new_static_layer.semantic_class[:, 0] == int(KelvinSemanticClass.ROAD)
+                if road_mask.any():
+                    road_colors = new_static_layer.rgb[road_mask].float()
+                    median_color = road_colors.median(dim=0).values
+                    representative_index = (road_colors - median_color).square().sum(dim=-1).argmin()
+                    road_color = road_colors[representative_index]
+                    sky_cubemap = (
+                        self.sky_cubemap * self.sky_cubemap_mask
+                        + road_color.reshape(1, 1, 1, 3) * (1.0 - self.sky_cubemap_mask)
+                    )
+                else:
+                    logger.warning("ROAD sky infill requested, but no ROAD Gaussians survived density pruning")
         return self.__class__(
             static_layer=new_static_layer,
             dynamic_layers=new_dynamic_layers,
-            sky_cubemap=self.sky_cubemap,
+            sky_cubemap=sky_cubemap,
+            sky_cubemap_mask=self.sky_cubemap_mask,
             affine_matrix=self.affine_matrix,
         )
 
@@ -400,6 +426,11 @@ class KelvinInstantNuRecPrimitive(BaseInstantNuRecPrimitive):
             static_layer=self.static_layer.rigid_transform(T_new),
             dynamic_layers=[layer.rigid_transform(T_new) for layer in self.dynamic_layers],
             sky_cubemap=rotate_sky_cubemap(self.sky_cubemap, T_new[:3, :3]),
+            sky_cubemap_mask=(
+                rotate_sky_cubemap(self.sky_cubemap_mask, T_new[:3, :3])
+                if self.sky_cubemap_mask is not None
+                else None
+            ),
             affine_matrix=self.affine_matrix,
         )
 
@@ -411,4 +442,3 @@ class KelvinInstantNuRecPrimitive(BaseInstantNuRecPrimitive):
         for layer in self.dynamic_layers:
             layer.rgb = layer.rgb @ y[:3, :3].T + y[:3, 3]
         self.sky_cubemap = self.sky_cubemap @ y[:3, :3].T + y[:3, 3]
-

--- a/instant_nurec/utils/cubemap.py
+++ b/instant_nurec/utils/cubemap.py
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
+
 import torch
+import torch.nn.functional as F
 
 from einops import rearrange
 
@@ -42,6 +45,262 @@ def cubemap_ray_directions(size: int, device: torch.device) -> torch.Tensor:
     back_dirs = torch.stack([-xx, yy, -zz], dim=-1)
 
     return torch.stack([right_dirs, left_dirs, top_dirs, bottom_dirs, front_dirs, back_dirs], dim=0)
+
+
+def directions_to_cubemap_face_uv(directions: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Map directions to the Instant NuRec cubemap face and ``(u, v)``.
+
+    The returned UV coordinates use the ``[-1, 1]`` convention consumed by
+    :func:`torch.nn.functional.grid_sample`. Face order matches
+    :func:`cubemap_ray_directions`: ``+X, -X, -Y, +Y, +Z, -Z``.
+    """
+
+    if directions.shape[-1] != 3:
+        raise ValueError(f"Cubemap directions must end in three channels, got {tuple(directions.shape)}")
+    flat = directions.reshape(-1, 3).float()
+    abs_xyz = flat.abs()
+    dominant_axis = abs_xyz.argmax(dim=-1)
+    dominant = abs_xyz.gather(-1, dominant_axis.unsqueeze(-1)).squeeze(-1)
+    positive = flat.gather(-1, dominant_axis.unsqueeze(-1)).squeeze(-1) > 0
+    face = torch.where(
+        dominant_axis == 0,
+        torch.where(positive, torch.zeros_like(dominant_axis), torch.ones_like(dominant_axis)),
+        torch.where(
+            dominant_axis == 1,
+            torch.where(positive, torch.full_like(dominant_axis, 3), torch.full_like(dominant_axis, 2)),
+            torch.where(positive, torch.full_like(dominant_axis, 4), torch.full_like(dominant_axis, 5)),
+        ),
+    )
+
+    x, y, z = flat.unbind(-1)
+    inv_dominant = dominant.clamp_min(1e-12).reciprocal()
+    u_by_face = torch.stack(
+        [
+            -z * inv_dominant,
+            z * inv_dominant,
+            x * inv_dominant,
+            x * inv_dominant,
+            x * inv_dominant,
+            -x * inv_dominant,
+        ],
+        dim=-1,
+    )
+    v_by_face = torch.stack(
+        [
+            y * inv_dominant,
+            y * inv_dominant,
+            z * inv_dominant,
+            -z * inv_dominant,
+            y * inv_dominant,
+            y * inv_dominant,
+        ],
+        dim=-1,
+    )
+    uv = torch.stack(
+        [
+            u_by_face.gather(-1, face.unsqueeze(-1)).squeeze(-1),
+            v_by_face.gather(-1, face.unsqueeze(-1)).squeeze(-1),
+        ],
+        dim=-1,
+    )
+    return face.reshape(directions.shape[:-1]), uv.reshape(*directions.shape[:-1], 2)
+
+
+def sample_sky_cubemap(cubemap: torch.Tensor, directions: torch.Tensor) -> torch.Tensor:
+    """Bilinearly sample an Instant NuRec cubemap for arbitrary directions."""
+
+    if cubemap.ndim != 4 or cubemap.shape[0] != 6 or cubemap.shape[1] != cubemap.shape[2]:
+        raise ValueError(f"Expected cubemap shape (6, H, H, C), got {tuple(cubemap.shape)}")
+    face, uv = directions_to_cubemap_face_uv(directions)
+    flat_face = face.reshape(-1)
+    flat_uv = uv.reshape(-1, 2)
+    channels = cubemap.shape[-1]
+    textures = cubemap.permute(0, 3, 1, 2).contiguous()
+    sampled = torch.empty((len(flat_face), channels), dtype=cubemap.dtype, device=cubemap.device)
+    for face_index in range(6):
+        mask = flat_face == face_index
+        if mask.any():
+            grid = flat_uv[mask].unsqueeze(0).unsqueeze(0)
+            values = F.grid_sample(
+                textures[face_index : face_index + 1],
+                grid,
+                mode="bilinear",
+                padding_mode="border",
+                align_corners=False,
+            )
+            sampled[mask] = values[0, :, 0].T
+    return sampled.reshape(*directions.shape[:-1], channels)
+
+
+def soften_cubemap_mask(
+    mask: torch.Tensor,
+    *,
+    dilation_kernel: int = 31,
+    gaussian_sigma: float = 8.0,
+) -> torch.Tensor:
+    """Dilate and feather a per-face cubemap mask.
+
+    The operation intentionally treats the six faces as an image batch. This
+    matches Kelvin predict preprocessing: a broad dilation first covers small
+    projection gaps, then a separable Gaussian produces the sky/road blend.
+    """
+
+    if mask.ndim != 4 or mask.shape[0] != 6 or mask.shape[-1] != 1:
+        raise ValueError(f"Expected cubemap mask shape (6, H, W, 1), got {tuple(mask.shape)}")
+    if mask.shape[1] != mask.shape[2]:
+        raise ValueError(f"Expected square cubemap faces, got {tuple(mask.shape[1:3])}")
+    if dilation_kernel <= 0 or dilation_kernel % 2 == 0:
+        raise ValueError("dilation_kernel must be a positive odd integer")
+    if gaussian_sigma <= 0:
+        raise ValueError("gaussian_sigma must be positive")
+
+    face_mask = mask.permute(0, 3, 1, 2).float()
+    face_mask = F.max_pool2d(
+        face_mask,
+        kernel_size=dilation_kernel,
+        stride=1,
+        padding=dilation_kernel // 2,
+    )
+
+    radius = max(1, math.ceil(3.0 * gaussian_sigma))
+    coordinates = torch.arange(-radius, radius + 1, device=mask.device, dtype=torch.float32)
+    kernel = torch.exp(-0.5 * (coordinates / gaussian_sigma).square())
+    kernel /= kernel.sum()
+    horizontal = kernel.reshape(1, 1, 1, -1)
+    vertical = kernel.reshape(1, 1, -1, 1)
+    face_mask = F.conv2d(
+        F.pad(face_mask, (radius, radius, 0, 0), mode="replicate"),
+        horizontal,
+    )
+    face_mask = F.conv2d(
+        F.pad(face_mask, (0, 0, radius, radius), mode="replicate"),
+        vertical,
+    )
+    return face_mask.permute(0, 2, 3, 1).clamp_(0.0, 1.0).contiguous()
+
+
+@torch.no_grad()
+def build_observed_sky_cubemap_with_mask(
+    size: int,
+    directions: torch.Tensor,
+    rgb: torch.Tensor,
+    sky_mask: torch.Tensor,
+    road_mask: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build a self-contained sky texture from decoder observations.
+
+    Released Kelvin Front/Varying weights do not contain the learned sky head,
+    but the dense decoder still predicts both canonical RGB and a SKY semantic
+    mask for every source ray. Those observations are accumulated into the
+    cubemap once during reconstruction. The returned softened mask is retained
+    on the primitive so export preprocessing can apply Kelvin's ROAD-Gaussian
+    infill after density pruning.
+    """
+
+    if size <= 0:
+        raise ValueError("Cubemap size must be positive")
+    if directions.shape != rgb.shape or directions.shape[-1] != 3:
+        raise ValueError(
+            f"Directions and RGB must have identical (..., 3) shape, got {directions.shape} and {rgb.shape}"
+        )
+    if sky_mask.shape != directions.shape[:-1]:
+        raise ValueError(f"Sky mask shape {sky_mask.shape} does not match rays {directions.shape[:-1]}")
+    if road_mask is not None and road_mask.shape != sky_mask.shape:
+        raise ValueError(f"Road mask shape {road_mask.shape} does not match sky mask {sky_mask.shape}")
+
+    flat_directions = F.normalize(directions.reshape(-1, 3).float(), dim=-1)
+    flat_rgb = rgb.reshape(-1, 3).float().clamp(0.0, 1.0)
+    flat_sky_mask = sky_mask.reshape(-1).bool()
+    finite = torch.isfinite(flat_directions).all(dim=-1) & torch.isfinite(flat_rgb).all(dim=-1)
+    flat_sky_mask &= finite
+
+    default_road = torch.tensor([0.16, 0.17, 0.18], device=flat_rgb.device)
+    road_color = default_road
+    if road_mask is not None:
+        road_colors = flat_rgb[road_mask.reshape(-1).bool() & finite]
+        if len(road_colors):
+            road_colors = road_colors[:: max(1, len(road_colors) // 100_000)]
+            median = road_colors.median(dim=0).values
+            road_color = road_colors[(road_colors - median).square().sum(dim=-1).argmin()]
+
+    cube_directions = cubemap_ray_directions(size, device=flat_rgb.device).float()
+    cube_up = cube_directions[..., 2:3]
+    if flat_sky_mask.any():
+        observed_colors = flat_rgb[flat_sky_mask]
+        observed_up = flat_directions[flat_sky_mask, 2:3]
+        mean_color = observed_colors.mean(dim=0)
+        mean_up = observed_up.mean()
+        centered_up = observed_up - mean_up
+        variance = centered_up.square().mean().clamp_min(1e-4)
+        slope = (centered_up * (observed_colors - mean_color)).mean(dim=0) / variance
+        slope = slope.clamp(-0.5, 0.5)
+        fitted_sky = (mean_color + (cube_up - mean_up) * slope).clamp(0.0, 1.0)
+    else:
+        horizon = torch.tensor([0.48, 0.58, 0.70], device=flat_rgb.device)
+        zenith = torch.tensor([0.20, 0.38, 0.62], device=flat_rgb.device)
+        fitted_sky = torch.lerp(horizon, zenith, cube_up.clamp(0.0, 1.0))
+
+    # The base cubemap remains sky-like in every direction. Kelvin export
+    # preprocessing is responsible for replacing non-sky texels with the
+    # representative color selected from the *pruned Gaussian ROAD class*.
+    fallback = fitted_sky
+    if not flat_sky_mask.any():
+        fallback = torch.where(
+            cube_up >= 0,
+            fallback,
+            road_color.view(1, 1, 1, 3),
+        )
+        empty_mask = torch.zeros((6, size, size, 1), dtype=torch.float32, device=flat_rgb.device)
+        return fallback.contiguous(), empty_mask
+
+    sky_directions = flat_directions[flat_sky_mask]
+    sky_colors = flat_rgb[flat_sky_mask]
+    face, uv = directions_to_cubemap_face_uv(sky_directions)
+    texel = (((uv + 1.0) * (0.5 * size)).floor()).long().clamp(0, size - 1)
+    linear_index = face.reshape(-1).long() * (size * size) + texel[:, 1] * size + texel[:, 0]
+    sums = torch.zeros((6 * size * size, 3), dtype=torch.float32, device=flat_rgb.device)
+    counts = torch.zeros((6 * size * size, 1), dtype=torch.float32, device=flat_rgb.device)
+    sums.scatter_add_(0, linear_index[:, None].expand(-1, 3), sky_colors)
+    counts.scatter_add_(0, linear_index[:, None], torch.ones_like(linear_index, dtype=torch.float32)[:, None])
+    observed = (sums / counts.clamp_min(1.0)).reshape(6, size, size, 3)
+    observed_mask = (counts > 0).reshape(6, size, size, 1)
+    cubemap = torch.where(observed_mask, observed, fallback).contiguous()
+    return cubemap, soften_cubemap_mask(observed_mask)
+
+
+@torch.no_grad()
+def build_observed_sky_cubemap(
+    size: int,
+    directions: torch.Tensor,
+    rgb: torch.Tensor,
+    sky_mask: torch.Tensor,
+    road_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compatibility wrapper returning only the observation-derived cubemap."""
+
+    cubemap, _ = build_observed_sky_cubemap_with_mask(
+        size,
+        directions,
+        rgb,
+        sky_mask,
+        road_mask,
+    )
+    return cubemap
+
+
+def layout_sky_cubemap(cubemap: torch.Tensor) -> torch.Tensor:
+    """Arrange the six faces as ``[[left, front, right], [back, bottom, top]]``."""
+
+    if cubemap.ndim != 4 or cubemap.shape[0] != 6 or cubemap.shape[1] != cubemap.shape[2]:
+        raise ValueError(f"Expected cubemap shape (6, H, H, C), got {tuple(cubemap.shape)}")
+    right, left, top, bottom, front, back = cubemap.unbind(0)
+    return torch.cat(
+        [
+            torch.cat([left, front, right], dim=1),
+            torch.cat([back, bottom, top], dim=1),
+        ],
+        dim=0,
+    )
 
 
 @torch.compile
@@ -177,7 +436,5 @@ def rotate_sky_cubemap(cubemap: torch.Tensor, rotation: torch.Tensor) -> torch.T
             out[mask] = sampled[0, :, 0].T
 
     return out.reshape(6, H, H, C)
-
-
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,11 @@ dependencies = [
     "zarr==2.18.2",
 ]
 
+[project.optional-dependencies]
+render = [
+    "gsplat==1.5.3",
+]
+
 [project.scripts]
 instant-nurec = "instant_nurec.cli:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,16 @@ format = "flat"
 torch = { index = "pytorch-cu128" }
 torchvision = { index = "pytorch-cu128" }
 torch-scatter = { index = "pyg-torch-2.7.0-cu128" }
+# This public upstream commit fixes F-theta projection culling at the FP32
+# Newton noise floor and exposes explicit world-ray 3DGUT rendering.  Both are
+# required to render NCore calibration and rolling-shutter trajectories without
+# falling back to a pinhole approximation.
+gsplat = { git = "https://github.com/nerfstudio-project/gsplat.git", rev = "a337c3dcaca733ddc3e16bdc156c536aaf5e19ba" }
+
+[tool.uv.extra-build-variables]
+# Match the PyPI install mode: package the CUDA sources and JIT-compile only
+# the kernels used on the installed PyTorch/CUDA runtime.
+gsplat = { BUILD_NO_CUDA = "1" }
 
 [tool.ruff]
 target-version = "py311"

--- a/run.sh
+++ b/run.sh
@@ -17,6 +17,9 @@
 
 # Thin wrapper around ``python run_inference.py`` that validates the user's
 # ``--ncore-path`` and ``--output-dir`` arguments before invoking the CLI.
+# Each PLY export also writes ``.sky.npz`` and ``.sky.png`` files;
+# ``--render-preview`` additionally writes ``.render.png`` and requires the
+# optional render dependencies installed by ``uv sync --extra render``.
 
 set -euo pipefail
 
@@ -46,7 +49,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$NCORE_PATH" ]] || [[ -z "$OUTPUT_DIR" ]]; then
-    echo "usage: $0 [--model pa-front|pa-multiview] --ncore-path <path> --output-dir <path> [--merge] [--n-gaussians N] [--log-level ...]" >&2
+    echo "usage: $0 [--model pa-front|pa-multiview|pq-front] --ncore-path <path> --output-dir <path> [--merge] [--n-gaussians N] [--render-preview] [--log-level ...]" >&2
     exit 64
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -18,8 +18,9 @@
 # Thin wrapper around ``python run_inference.py`` that validates the user's
 # ``--ncore-path`` and ``--output-dir`` arguments before invoking the CLI.
 # Each PLY export also writes ``.sky.npz`` and ``.sky.png`` files;
-# ``--render-preview`` additionally writes ``.render.png`` and requires the
-# optional render dependencies installed by ``uv sync --extra render``.
+# ``--render-preview`` additionally writes ``.render.png``; ``--render-video``
+# writes ``.render.mp4`` and also requires ``--merge`` and ffmpeg with libx264.
+# Both require the optional dependencies installed by ``uv sync --extra render``.
 
 set -euo pipefail
 
@@ -49,7 +50,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$NCORE_PATH" ]] || [[ -z "$OUTPUT_DIR" ]]; then
-    echo "usage: $0 [--model pa-front|pa-multiview|pq-front] --ncore-path <path> --output-dir <path> [--merge] [--n-gaussians N] [--render-preview] [--log-level ...]" >&2
+    echo "usage: $0 [--model pa-front|pa-multiview|pq-front] --ncore-path <path> --output-dir <path> [--merge] [--n-gaussians N] [--render-preview] [--render-video] [--log-level ...]" >&2
     exit 64
 fi
 

--- a/run_inference.py
+++ b/run_inference.py
@@ -20,11 +20,14 @@ Invocation::
 
     python run_inference.py --model <pa-front|pa-multiview|pq-front> \
         --ncore-path <path> --output-dir <path> [--merge] [--n-gaussians N] \
-        [--render-preview]
+        [--render-preview] [--render-video]
 
 Each exported PLY has adjacent ``.sky.npz`` and ``.sky.png`` outputs.
 ``--render-preview`` additionally writes ``.render.png`` and requires
 ``uv sync --extra render``.
+``--render-video`` additionally writes ``.render.mp4`` from every source
+camera frame and requires ``--merge``, the render extra, and ``ffmpeg`` with
+``libx264``.
 
 Defers to ``instant_nurec.cli.main``.
 """

--- a/run_inference.py
+++ b/run_inference.py
@@ -19,7 +19,12 @@
 Invocation::
 
     python run_inference.py --model <pa-front|pa-multiview|pq-front> \
-        --ncore-path <path> --output-dir <path> [--merge] [--n-gaussians N]
+        --ncore-path <path> --output-dir <path> [--merge] [--n-gaussians N] \
+        [--render-preview]
+
+Each exported PLY has adjacent ``.sky.npz`` and ``.sky.png`` outputs.
+``--render-preview`` additionally writes ``.render.png`` and requires
+``uv sync --extra render``.
 
 Defers to ``instant_nurec.cli.main``.
 """

--- a/setup.sh
+++ b/setup.sh
@@ -19,7 +19,8 @@
 #
 # Bootstraps a venv and installs the locked dependency tree via ``uv sync``.
 # The default workflow does not install the optional gsplat reference renderer;
-# use ``uv sync --extra render`` before passing ``--render-preview``.
+# use ``uv sync --extra render`` before passing ``--render-preview`` or
+# ``--render-video``.
 # ``run_inference.py`` is the canonical entrypoint.
 
 set -euo pipefail
@@ -61,4 +62,9 @@ first context frame with the sky composited behind the Gaussians:
 
     uv sync --extra render
     ./run.sh --ncore-path /path/to/sequence.json --output-dir /tmp/out --render-preview
+
+To render every original frame along the calibrated source trajectory (ffmpeg
+with libx264 must be installed):
+
+    ./run.sh --ncore-path /path/to/sequence.json --output-dir /tmp/out --merge --render-video
 EOF

--- a/setup.sh
+++ b/setup.sh
@@ -18,7 +18,8 @@
 # InstantNuRec Kelvin predict — environment setup.
 #
 # Bootstraps a venv and installs the locked dependency tree via ``uv sync``.
-# The only CUDA dependency is whatever ``torch`` ships with the cu128 wheel.
+# The default workflow does not install the optional gsplat reference renderer;
+# use ``uv sync --extra render`` before passing ``--render-preview``.
 # ``run_inference.py`` is the canonical entrypoint.
 
 set -euo pipefail
@@ -49,9 +50,15 @@ Activate the venv with:
 
 Run inference with:
 
-    ./run.sh --ncore-path /path/to/ncorev4 --output-dir /tmp/out [--merge] [--n-gaussians N]
+    ./run.sh --ncore-path /path/to/sequence.json --output-dir /tmp/out [--merge] [--n-gaussians N]
 
 Or directly:
 
-    python run_inference.py --ncore-path /path/to/ncorev4 --output-dir /tmp/out [--merge] [--n-gaussians N]
+    python run_inference.py --ncore-path /path/to/sequence.json --output-dir /tmp/out [--merge] [--n-gaussians N]
+
+Each PLY also has .sky.npz and .sky.png outputs. To additionally render the
+first context frame with the sky composited behind the Gaussians:
+
+    uv sync --extra render
+    ./run.sh --ncore-path /path/to/sequence.json --output-dir /tmp/out --render-preview
 EOF

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -143,6 +143,15 @@ def test_parser_merge_flag_sets_true() -> None:
     assert args.merge is True
 
 
+def test_parser_render_preview_flag_sets_true() -> None:
+    from instant_nurec.cli import make_parser
+
+    args = make_parser().parse_args(
+        ["--ncore-path", "/x", "--output-dir", "/y", "--render-preview"]
+    )
+    assert args.render_preview is True
+
+
 def test_parser_merge_no_longer_takes_choice_argument() -> None:
     """The old `--merge {none, frustum-ownership}` form must error so we
     don't silently treat 'frustum-ownership' as a positional argument."""
@@ -207,6 +216,59 @@ def test_main_no_merge_constructs_config_with_disabled_merge(
     assert cfg.dataset.predict.context_camera_ids == ["camera_front_wide_120fov"]
     assert cfg.dataset.predict.camera_subsampler.frame_width == 784
     assert cfg.dataset.predict.camera_subsampler.frame_height == 448
+
+
+def test_main_render_preview_preflights_dependency_and_sets_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    fake_run_predict = _install_runtime_stubs(monkeypatch)
+    json_path = _make_json_path(tmp_path)
+    from instant_nurec.cli import main
+    from instant_nurec.predict import render_preview
+
+    preflight = MagicMock(return_value=object())
+    monkeypatch.setattr(render_preview, "require_gsplat", preflight)
+
+    assert main(
+        [
+            "--ncore-path",
+            str(json_path),
+            "--output-dir",
+            "/o",
+            "--render-preview",
+        ]
+    ) == 0
+
+    preflight.assert_called_once_with()
+    assert fake_run_predict.call_args.args[0].predict.render_preview is True
+
+
+def test_main_render_preview_reports_missing_dependency_before_inference(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fake_run_predict = _install_runtime_stubs(monkeypatch)
+    json_path = _make_json_path(tmp_path)
+    from instant_nurec.cli import main
+    from instant_nurec.predict import render_preview
+
+    def fail_preflight():
+        raise RuntimeError("install the render extra")
+
+    monkeypatch.setattr(render_preview, "require_gsplat", fail_preflight)
+
+    with pytest.raises(SystemExit, match="2"):
+        main(
+            [
+                "--ncore-path",
+                str(json_path),
+                "--output-dir",
+                "/o",
+                "--render-preview",
+            ]
+        )
+
+    assert "install the render extra" in capsys.readouterr().err
+    fake_run_predict.assert_not_called()
 
 
 def test_main_multiview_uses_release_profile(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -152,6 +152,15 @@ def test_parser_render_preview_flag_sets_true() -> None:
     assert args.render_preview is True
 
 
+def test_parser_render_video_flag_sets_true() -> None:
+    from instant_nurec.cli import make_parser
+
+    args = make_parser().parse_args(
+        ["--ncore-path", "/x", "--output-dir", "/y", "--render-video"]
+    )
+    assert args.render_video is True
+
+
 def test_parser_merge_no_longer_takes_choice_argument() -> None:
     """The old `--merge {none, frustum-ownership}` form must error so we
     don't silently treat 'frustum-ownership' as a positional argument."""
@@ -268,6 +277,132 @@ def test_main_render_preview_reports_missing_dependency_before_inference(
         )
 
     assert "install the render extra" in capsys.readouterr().err
+    fake_run_predict.assert_not_called()
+
+
+def test_main_render_video_requires_merge_before_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fake_run_predict = _install_runtime_stubs(monkeypatch)
+    json_path = _make_json_path(tmp_path)
+    from instant_nurec.cli import main
+
+    with pytest.raises(SystemExit, match="2"):
+        main(
+            [
+                "--ncore-path",
+                str(json_path),
+                "--output-dir",
+                "/o",
+                "--render-video",
+            ]
+        )
+
+    assert "--render-video requires --merge" in capsys.readouterr().err
+    fake_run_predict.assert_not_called()
+
+
+def test_main_render_video_preflights_dependencies_and_sets_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_run_predict = _install_runtime_stubs(monkeypatch)
+    json_path = _make_json_path(tmp_path)
+    from instant_nurec.cli import main
+    from instant_nurec.predict import render_preview, render_video
+
+    gsplat_preflight = MagicMock(return_value=object())
+    ffmpeg_preflight = MagicMock(return_value="/usr/bin/ffmpeg")
+    monkeypatch.setattr(render_preview, "require_gsplat", gsplat_preflight)
+    monkeypatch.setattr(render_video, "require_ffmpeg", ffmpeg_preflight)
+
+    assert main(
+        [
+            "--ncore-path",
+            str(json_path),
+            "--output-dir",
+            "/o",
+            "--merge",
+            "--render-video",
+            "--max-chunks",
+            "12",
+        ]
+    ) == 0
+
+    gsplat_preflight.assert_called_once_with()
+    ffmpeg_preflight.assert_called_once_with()
+    cfg = fake_run_predict.call_args.args[0]
+    assert cfg.predict.render_video is True
+    assert cfg.predict.primitive_merge.enabled is True
+    assert cfg.system.predict_batch_size == 12
+    assert cfg.dataset.predict.frame_batch_sampler.n_samples_per_sequence == 12
+
+
+def test_main_render_video_rejects_multiple_resolved_sequences(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fake_run_predict = _install_runtime_stubs(monkeypatch)
+    first = _make_json_path(tmp_path)
+    second = tmp_path / "second.json"
+    second.write_text("{}")
+    sequence_list = tmp_path / "sequences.lst"
+    sequence_list.write_text(f"{first}\n{second}\n")
+    from instant_nurec.cli import main
+    from instant_nurec.predict import render_preview, render_video
+
+    monkeypatch.setattr(render_preview, "require_gsplat", lambda: object())
+    monkeypatch.setattr(render_video, "require_ffmpeg", lambda: "/usr/bin/ffmpeg")
+
+    with pytest.raises(SystemExit, match="2"):
+        main(
+            [
+                "--ncore-path",
+                str(sequence_list),
+                "--output-dir",
+                "/o",
+                "--merge",
+                "--render-video",
+            ]
+        )
+
+    assert "requires exactly one resolved NCore sequence" in capsys.readouterr().err
+    fake_run_predict.assert_not_called()
+
+
+def test_main_render_video_reports_missing_ffmpeg_before_inference(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fake_run_predict = _install_runtime_stubs(monkeypatch)
+    json_path = _make_json_path(tmp_path)
+    from instant_nurec.cli import main
+    from instant_nurec.predict import render_preview, render_video
+
+    monkeypatch.setattr(render_preview, "require_gsplat", lambda: object())
+
+    def fail_ffmpeg():
+        raise RuntimeError("install ffmpeg")
+
+    monkeypatch.setattr(render_video, "require_ffmpeg", fail_ffmpeg)
+
+    with pytest.raises(SystemExit, match="2"):
+        main(
+            [
+                "--ncore-path",
+                str(json_path),
+                "--output-dir",
+                "/o",
+                "--merge",
+                "--render-video",
+            ]
+        )
+
+    assert "install ffmpeg" in capsys.readouterr().err
     fake_run_predict.assert_not_called()
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -123,6 +123,8 @@ def test_predict_config_defaults():
     cfg = PredictConfig()
     assert isinstance(cfg.primitive_merge, PrimitiveMergeConfig)
     assert cfg.primitive_merge.enabled is False
+    assert cfg.render_preview is False
+    assert cfg.render_video is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cubemap.py
+++ b/tests/test_cubemap.py
@@ -138,6 +138,125 @@ def test_cubemap_ray_directions_face_centers_align_with_dominant_axis():
 
 
 # ---------------------------------------------------------------------------
+# Cubemap sampling and observation-derived sky
+# ---------------------------------------------------------------------------
+
+
+def test_face_mapping_and_sampling_round_trip():
+    import torch
+
+    from instant_nurec.utils.cubemap import (
+        cubemap_ray_directions,
+        directions_to_cubemap_face_uv,
+        sample_sky_cubemap,
+    )
+
+    directions = cubemap_ray_directions(8, torch.device("cpu"))
+    face, uv = directions_to_cubemap_face_uv(directions)
+    assert face.shape == (6, 8, 8)
+    assert uv.shape == (6, 8, 8, 2)
+    for face_index in range(6):
+        assert torch.all(face[face_index] == face_index)
+
+    colors = torch.tensor(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [1.0, 1.0, 0.0],
+            [1.0, 0.0, 1.0],
+            [0.0, 1.0, 1.0],
+        ]
+    )
+    cubemap = colors[:, None, None, :].expand(6, 8, 8, 3).contiguous()
+    sampled = sample_sky_cubemap(cubemap, directions)
+    torch.testing.assert_close(sampled, cubemap)
+
+
+def test_observed_sky_uses_sky_pixels_and_finite_fallback():
+    import torch
+
+    from instant_nurec.utils.cubemap import build_observed_sky_cubemap
+
+    directions = torch.tensor(
+        [
+            [0.0, 0.0, 1.0],
+            [0.0, 0.0, -1.0],
+            [1.0, 0.0, 0.2],
+        ]
+    )
+    rgb = torch.tensor(
+        [
+            [0.20, 0.45, 0.90],
+            [0.12, 0.14, 0.16],
+            [0.22, 0.48, 0.88],
+        ]
+    )
+    cubemap = build_observed_sky_cubemap(
+        8,
+        directions,
+        rgb,
+        sky_mask=torch.tensor([True, False, True]),
+        road_mask=torch.tensor([False, True, False]),
+    )
+
+    assert cubemap.shape == (6, 8, 8, 3)
+    # +Z is face 4; the directly observed center texel retains source sky RGB.
+    torch.testing.assert_close(cubemap[4, 4, 4], rgb[0])
+    # ROAD infill is deliberately deferred until after Gaussian density
+    # pruning; the observation-derived base cube only needs a finite fallback.
+    assert torch.isfinite(cubemap).all()
+
+
+def test_observed_sky_returns_softened_visibility_mask():
+    import torch
+
+    from instant_nurec.utils.cubemap import build_observed_sky_cubemap_with_mask
+
+    directions = torch.tensor(
+        [
+            [0.0, 0.0, 1.0],
+            [0.1, 0.0, 0.99],
+            [0.0, 0.0, -1.0],
+        ]
+    )
+    rgb = torch.tensor(
+        [
+            [0.20, 0.45, 0.90],
+            [0.22, 0.48, 0.88],
+            [0.12, 0.14, 0.16],
+        ]
+    )
+    cubemap, mask = build_observed_sky_cubemap_with_mask(
+        64,
+        directions,
+        rgb,
+        sky_mask=torch.tensor([True, True, False]),
+        road_mask=torch.tensor([False, False, True]),
+    )
+
+    assert cubemap.shape == (6, 64, 64, 3)
+    assert mask.shape == (6, 64, 64, 1)
+    assert 0.0 <= float(mask.min()) <= float(mask.max()) <= 1.0
+    assert mask[4, 32, 32, 0] > 0.9
+    assert torch.isfinite(mask).all()
+
+
+def test_soften_cubemap_mask_dilates_then_feathers():
+    import torch
+
+    from instant_nurec.utils.cubemap import soften_cubemap_mask
+
+    mask = torch.zeros(6, 64, 64, 1)
+    mask[0, 32, 32, 0] = 1.0
+    softened = soften_cubemap_mask(mask)
+
+    assert softened[0, 32, 32, 0] > 0.9
+    assert 0.0 < softened[0, 32, 52, 0] < 1.0
+    assert softened[1:].count_nonzero() == 0
+
+
+# ---------------------------------------------------------------------------
 # rotate_sky_cubemap
 # ---------------------------------------------------------------------------
 

--- a/tests/test_export_sky.py
+++ b/tests/test_export_sky.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections import OrderedDict
+
+import numpy as np
+import pytest
+import torch
+
+from PIL import Image
+
+from instant_nurec.predict.export_sky import SKY_FACE_AXES, SKY_FACE_ORDER, export_sky
+from instant_nurec.primitives.kelvin_primitive import (
+    KelvinDynamicLayer,
+    KelvinInstantNuRecPrimitive,
+    KelvinStaticLayer,
+)
+from instant_nurec.utils.types import FrameConversion, RigTrajectories
+
+
+def _primitive() -> KelvinInstantNuRecPrimitive:
+    static = KelvinStaticLayer(
+        positions=torch.zeros(1, 3),
+        rotations=torch.tensor([[1.0, 0.0, 0.0, 0.0]]),
+        scales=torch.ones(1, 3),
+        densities=torch.full((1, 1), 0.5),
+        rgb=torch.full((1, 3), 0.25),
+    )
+    dynamic = KelvinDynamicLayer(
+        rotations=torch.empty(0, 4),
+        scales=torch.empty(0, 3),
+        rgb=torch.empty(0, 3),
+        max_densities=torch.empty(0, 1),
+        keyframe_positions=torch.empty(0, 3, 3),
+        keyframe_timestamps_us=torch.empty(0, 3, dtype=torch.int64),
+    )
+    cubemap = torch.linspace(0.0, 1.0, 6 * 4 * 4 * 3).reshape(6, 4, 4, 3)
+    mask = torch.ones(6, 4, 4, 1)
+    return KelvinInstantNuRecPrimitive(
+        static_layer=static,
+        dynamic_layers=[dynamic],
+        sky_cubemap=cubemap,
+        sky_cubemap_mask=mask,
+        affine_matrix=torch.eye(3, 4).unsqueeze(0),
+    )
+
+
+def _rig(T_world_base: torch.Tensor | None = None) -> RigTrajectories:
+    camera_calibrations = OrderedDict(
+        [
+            (
+                "camera_front",
+                RigTrajectories.CameraCalibration(
+                    sequence_id="main",
+                    unique_sensor_idx=7,
+                    T_sensor_rig=torch.eye(4),
+                    camera_model_parameters=object(),  # type: ignore[arg-type]
+                ),
+            )
+        ]
+    )
+    return RigTrajectories(
+        T_world_base=(
+            torch.eye(4, dtype=torch.float64) if T_world_base is None else T_world_base
+        ),
+        world_to_scene=FrameConversion(matrix=np.eye(4, dtype=np.float32)),
+        rig_trajectories=[],
+        camera_calibrations=camera_calibrations,
+    )
+
+
+def test_export_sky_writes_safe_sidecar_and_preview(tmp_path) -> None:
+    ply_path = tmp_path / "scene.ply"
+
+    sidecar_path, preview_path = export_sky(_primitive(), _rig(), ply_path)
+
+    assert sidecar_path == tmp_path / "scene.sky.npz"
+    assert preview_path == tmp_path / "scene.sky.png"
+    with np.load(sidecar_path, allow_pickle=False) as bundle:
+        assert bundle["sky_cubemap"].shape == (6, 4, 4, 3)
+        assert bundle["sky_cubemap"].dtype == np.float16
+        assert bundle["sky_cubemap_mask"].shape == (6, 4, 4, 1)
+        assert bundle["affine_matrix"].shape == (1, 3, 4)
+        assert bundle["affine_sensor_indices"].tolist() == [7]
+        assert bundle["affine_sensor_ids"].tolist() == ["camera_front"]
+        assert tuple(bundle["face_order"].tolist()) == SKY_FACE_ORDER
+        assert tuple(bundle["face_axes"].tolist()) == SKY_FACE_AXES
+        assert bundle["uv_convention"].item() == "u_left_to_right_v_top_to_bottom"
+        assert bundle["coordinate_frame"].item() == "ncore_world"
+        assert bundle["sky_source"].item() == "observed_rgb_semantics"
+        assert bundle["sky_observed_fraction"].item() == pytest.approx(1.0)
+    with Image.open(preview_path) as preview:
+        assert preview.size == (12, 8)
+        assert preview.mode == "RGB"
+
+
+def test_export_sky_rotates_only_environment_state_to_world(tmp_path) -> None:
+    primitive = _primitive()
+    T_world_base = torch.tensor(
+        [
+            [-1.0, 0.0, 0.0, 2.0],
+            [0.0, -1.0, 0.0, 3.0],
+            [0.0, 0.0, 1.0, 4.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ],
+        dtype=torch.float64,
+    )
+
+    sidecar_path, _ = export_sky(primitive, _rig(T_world_base), tmp_path / "scene.ply")
+
+    expected = primitive.rigid_transform(T_world_base.float()).sky_cubemap
+    with np.load(sidecar_path, allow_pickle=False) as bundle:
+        torch.testing.assert_close(
+            torch.from_numpy(bundle["sky_cubemap"].astype(np.float32)),
+            expected,
+            atol=5e-4,
+            rtol=5e-4,
+        )
+
+
+def test_export_sky_preserves_canonical_values_outside_display_range(tmp_path) -> None:
+    primitive = _primitive()
+    primitive.sky_cubemap[0, 0, 0] = torch.tensor([-0.25, 1.25, 2.0])
+
+    sidecar_path, preview_path = export_sky(primitive, _rig(), tmp_path / "scene.ply")
+
+    with np.load(sidecar_path, allow_pickle=False) as bundle:
+        np.testing.assert_allclose(
+            bundle["sky_cubemap"][0, 0, 0].astype(np.float32),
+            [-0.25, 1.25, 2.0],
+        )
+    with Image.open(preview_path) as preview:
+        pixels = np.asarray(preview)
+        assert pixels.min() == 0
+        assert pixels.max() == 255

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -33,10 +33,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 
-from instant_nurec.model.inference import (  # noqa: E402
-    _PLACEHOLDER_SKY_CUBEMAP_SIZE,
-    KelvinInferenceModel,
-)
+from instant_nurec.model.inference import KelvinInferenceModel  # noqa: E402
 from instant_nurec.model.static_core import KelvinPointQueryStaticOutput  # noqa: E402
 from instant_nurec.primitives.kelvin_primitive import (  # noqa: E402
     KelvinDynamicLayer,
@@ -79,7 +76,20 @@ class _FakeStaticCore(torch.nn.Module):
         normals = torch.full((B, V, H, W, 3), 0.1)
         affine = torch.zeros(B, self.n_cams, 3, 4)
         affine[..., :3] = torch.eye(3)
-        return gs_xyz, gs_rotations, gs_scales, gs_densities, gs_rgb, semantic, normals, affine
+        sky_cubemap = torch.full((B, 6, 8, 8, 3), 0.25)
+        sky_cubemap_mask = torch.ones(B, 6, 8, 8, 1)
+        return (
+            gs_xyz,
+            gs_rotations,
+            gs_scales,
+            gs_densities,
+            gs_rgb,
+            semantic,
+            normals,
+            affine,
+            sky_cubemap,
+            sky_cubemap_mask,
+        )
 
 
 class _FakePointQueryStaticCore(_FakeStaticCore):
@@ -87,7 +97,7 @@ class _FakePointQueryStaticCore(_FakeStaticCore):
 
     def forward(self, rgb, c2w, fov, rays, distance_to_depth_scale, camera_idxs):
         dense = super().forward(rgb, c2w, fov, rays, distance_to_depth_scale, camera_idxs)
-        xyz, rotations, scales, densities, color, semantic, normals, affine = dense
+        xyz, rotations, scales, densities, color, semantic, normals, affine, sky_cubemap, sky_mask = dense
         source_indices = torch.tensor([[0, 5, 9]], dtype=torch.int64)
         return KelvinPointQueryStaticOutput(
             positions=xyz.reshape(self.B, -1, 3)[:, source_indices[0]],
@@ -99,6 +109,8 @@ class _FakePointQueryStaticCore(_FakeStaticCore):
             normals=normals.reshape(self.B, -1, 3)[:, source_indices[0]],
             affine_matrix=affine,
             source_indices=source_indices,
+            sky_cubemap=sky_cubemap,
+            sky_cubemap_mask=sky_mask,
         )
 
 
@@ -324,15 +336,15 @@ def test_sparse_dynamic_mask_gathers_aligned_source_rays_and_timestamps(monkeypa
     assert torch.equal(dynamic_mask, torch.tensor([True, False]))
 
 
-def test_reconstruct_uses_placeholder_sky_cubemap_shape():
+def test_reconstruct_preserves_observation_derived_sky_cubemap():
     V, H, W = 2, 4, 4
     core = _FakeStaticCore(B=1, V=V, H=H, W=W, n_cams=1)
     adapter = _make_adapter(core)
     out = adapter.reconstruct([_fake_batch(V, H, W)], cuboid_tracks=None)
     sky = out[0].sky_cubemap
-    s = _PLACEHOLDER_SKY_CUBEMAP_SIZE
-    assert sky.shape == (6, s, s, 3)
-    assert torch.all(sky == 0)
+    assert sky.shape == (6, 8, 8, 3)
+    assert torch.all(sky == 0.25)
+    assert torch.all(out[0].sky_cubemap_mask == 1)
 
 
 def test_reconstruct_affine_matrix_shape_squeezed_to_per_camera():
@@ -386,7 +398,7 @@ def test_prepare_context_passthrough():
     assert adapter.prepare_context(context) is context
 
 
-# ---------- _empty_dynamic_layer / _placeholder_sky_cubemap ----------
+# ---------- _empty_dynamic_layer ----------
 
 
 def test_empty_dynamic_layer_has_zero_gaussians_with_correct_dtypes():
@@ -395,14 +407,6 @@ def test_empty_dynamic_layer_has_zero_gaussians_with_correct_dtypes():
     assert len(layer) == 0
     assert layer.keyframe_timestamps_us.dtype == torch.int64
     assert layer.rotations.dtype == torch.float32
-
-
-def test_placeholder_sky_cubemap_dtype_and_shape():
-    adapter = _make_adapter(_FakeStaticCore(1, 1, 1, 1, 1))
-    cube = adapter._placeholder_sky_cubemap(torch.device("cpu"), torch.float64)
-    assert cube.shape == (6, _PLACEHOLDER_SKY_CUBEMAP_SIZE, _PLACEHOLDER_SKY_CUBEMAP_SIZE, 3)
-    assert cube.dtype == torch.float64
-    assert torch.all(cube == 0)
 
 
 def test_pytest_collected(monkeypatch):

--- a/tests/test_instantnurec_ncore.py
+++ b/tests/test_instantnurec_ncore.py
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import ncore.data
+import numpy as np
+import pytest
+import torch
+
+from instant_nurec.config_schema.dataset import NCoreInstantNuRecDatasetConfig
+from instant_nurec.datasets.instantnurec_ncore import NCoreInstantNuRecDataset
+from instant_nurec.utils.types import FrameConversion, RigTrajectories
+
+
+CAMERA_ID = "camera_front_wide_120fov"
+
+
+@dataclass
+class _FakeCameraParameters:
+    name: str
+
+
+class _FakeCameraSensor:
+    def __init__(self, starts: np.ndarray, ends: np.ndarray) -> None:
+        self.model_parameters = _FakeCameraParameters("native-ftheta")
+        self.T_sensor_rig = np.array(
+            [
+                [1.0, 0.0, 0.0, 1.5],
+                [0.0, 1.0, 0.0, -0.25],
+                [0.0, 0.0, 1.0, 0.75],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
+            dtype=np.float32,
+        )
+        self._starts = starts
+        self._ends = ends
+        self.timestamp_calls: list[ncore.data.FrameTimepoint] = []
+
+    def get_frames_timestamps_us(self, timepoint: ncore.data.FrameTimepoint) -> np.ndarray:
+        self.timestamp_calls.append(timepoint)
+        if timepoint == ncore.data.FrameTimepoint.START:
+            return self._starts
+        if timepoint == ncore.data.FrameTimepoint.END:
+            return self._ends
+        raise AssertionError(f"Unexpected frame timepoint: {timepoint}")
+
+    def get_frame_image_array(self, frame_idx: int) -> np.ndarray:
+        raise AssertionError(f"load_full_camera_rig must not load image {frame_idx}")
+
+
+def _dataset(source_path, *, cameras: list[str] | None = None) -> NCoreInstantNuRecDataset:
+    cameras = [CAMERA_ID] if cameras is None else cameras
+    return NCoreInstantNuRecDataset(
+        NCoreInstantNuRecDatasetConfig(
+            ncore_json_paths=[str(source_path)],
+            context_camera_ids=cameras,
+            supervision_camera_ids=cameras,
+        ),
+        frame_width=784,
+        frame_height=448,
+        n_frames_per_sample=18,
+    )
+
+
+def _reference_rig() -> RigTrajectories:
+    poses = torch.eye(4, dtype=torch.float64).repeat(3, 1, 1)
+    poses[:, 0, 3] = torch.tensor([4.0, 5.0, 6.0], dtype=torch.float64)
+    world_to_scene = np.eye(4, dtype=np.float32)
+    world_to_scene[:3, 3] = np.array([2.0, 3.0, 4.0], dtype=np.float32)
+    T_world_base = torch.eye(4, dtype=torch.float64)
+    T_world_base[:3, 3] = torch.tensor([-1.0, -2.0, -3.0], dtype=torch.float64)
+    trajectory = RigTrajectories.RigTrajectory(
+        sequence_id="context-main",
+        cameras_frame_timestamps_us={CAMERA_ID: torch.tensor([[10, 20]], dtype=torch.int64)},
+        T_rig_worlds=poses,
+        T_rig_world_timestamps_us=torch.tensor([0, 100_000, 200_000], dtype=torch.int64),
+    )
+    calibration = RigTrajectories.CameraCalibration(
+        sequence_id="context-main",
+        unique_sensor_idx=0,
+        T_sensor_rig=torch.eye(4, dtype=torch.float32),
+        camera_model_parameters=_FakeCameraParameters("sampled-reference"),  # type: ignore[arg-type]
+    )
+    return RigTrajectories(
+        T_world_base=T_world_base,
+        world_to_scene=FrameConversion(matrix=world_to_scene),
+        rig_trajectories=[trajectory],
+        camera_calibrations=OrderedDict([(CAMERA_ID, calibration)]),
+    )
+
+
+def test_load_full_camera_rig_keeps_all_exposures_without_images_or_rays(tmp_path, monkeypatch) -> None:
+    source_path = tmp_path / "sequence.json"
+    source_path.write_text("{}")
+    dataset = _dataset(source_path)
+    reference_rig = _reference_rig()
+    sensor = _FakeCameraSensor(
+        starts=np.array([25_542, 58_876, 92_210], dtype=np.int64),
+        ends=np.array([56_101, 89_435, 122_769], dtype=np.int64),
+    )
+    transformed_parameters = _FakeCameraParameters("inference-resize-crop")
+    seen: dict[str, object] = {}
+
+    def fake_load(source, camera_ids):
+        seen["source"] = source
+        seen["camera_ids"] = camera_ids
+        return SimpleNamespace(
+            camera_sensors={camera_ids[0]: sensor},
+            T_rig_worlds_with_timestamps_us=(
+                np.tile(np.eye(4, dtype=np.float64), (3, 1, 1)),
+                np.array([0, 100_000, 200_000], dtype=np.int64),
+            ),
+        )
+
+    class _FakeSubsampler:
+        def apply_camera_parameters(self, parameters):
+            seen["calibration_input"] = parameters
+            return transformed_parameters
+
+    monkeypatch.setattr(dataset, "_get_loaders_and_sensors", fake_load)
+    monkeypatch.setattr(dataset, "_build_camera_subsampler", _FakeSubsampler)
+
+    full_rig = dataset.load_full_camera_rig(str(source_path), reference_rig)
+
+    assert str(seen["source"]).endswith("sequence.json")
+    assert [str(camera) for camera in seen["camera_ids"]] == [CAMERA_ID]
+    assert sensor.timestamp_calls == [ncore.data.FrameTimepoint.START, ncore.data.FrameTimepoint.END]
+    assert seen["calibration_input"] == _FakeCameraParameters("native-ftheta")
+    assert seen["calibration_input"] is not sensor.model_parameters
+
+    assert full_rig.T_world_base is reference_rig.T_world_base
+    assert full_rig.world_to_scene is reference_rig.world_to_scene
+    assert list(full_rig.camera_calibrations) == [CAMERA_ID]
+    full_calibration = full_rig.camera_calibrations[CAMERA_ID]
+    assert full_calibration.sequence_id == "context-main"
+    assert full_calibration.unique_sensor_idx == 0
+    assert full_calibration.camera_model_parameters is transformed_parameters
+    torch.testing.assert_close(full_calibration.T_sensor_rig, torch.from_numpy(sensor.T_sensor_rig))
+
+    assert len(full_rig.rig_trajectories) == 1
+    full_trajectory = full_rig.rig_trajectories[0]
+    reference_trajectory = reference_rig.rig_trajectories[0]
+    assert full_trajectory.T_rig_worlds is reference_trajectory.T_rig_worlds
+    assert full_trajectory.T_rig_world_timestamps_us is reference_trajectory.T_rig_world_timestamps_us
+    torch.testing.assert_close(
+        full_trajectory.cameras_frame_timestamps_us[CAMERA_ID],
+        torch.tensor(
+            [[25_542, 56_101], [58_876, 89_435], [92_210, 122_769]],
+            dtype=torch.int64,
+        ),
+    )
+
+
+def test_load_full_camera_rig_requires_camera_for_multicamera_dataset(tmp_path) -> None:
+    source_path = tmp_path / "sequence.json"
+    source_path.write_text("{}")
+    dataset = _dataset(source_path, cameras=[CAMERA_ID, "camera_cross_left_120fov"])
+
+    with pytest.raises(ValueError, match="camera_id is required"):
+        dataset.load_full_camera_rig(str(source_path), _reference_rig())
+
+
+def test_load_full_camera_rig_rejects_mismatched_exposure_counts(tmp_path, monkeypatch) -> None:
+    source_path = tmp_path / "sequence.json"
+    source_path.write_text("{}")
+    dataset = _dataset(source_path)
+    sensor = _FakeCameraSensor(
+        starts=np.array([10, 20], dtype=np.int64),
+        ends=np.array([15], dtype=np.int64),
+    )
+
+    def fake_load(source, camera_ids):
+        del source
+        return SimpleNamespace(
+            camera_sensors={camera_ids[0]: sensor},
+            T_rig_worlds_with_timestamps_us=(
+                np.tile(np.eye(4, dtype=np.float64), (3, 1, 1)),
+                np.array([0, 100_000, 200_000], dtype=np.int64),
+            ),
+        )
+
+    monkeypatch.setattr(dataset, "_get_loaders_and_sensors", fake_load)
+
+    with pytest.raises(ValueError, match="START/END timestamp counts differ"):
+        dataset.load_full_camera_rig(str(source_path), _reference_rig())
+
+
+def test_load_full_camera_rig_pads_pose_coverage_at_source_boundaries(tmp_path, monkeypatch) -> None:
+    source_path = tmp_path / "sequence.json"
+    source_path.write_text("{}")
+    dataset = _dataset(source_path)
+    reference_rig = _reference_rig()
+    sensor = _FakeCameraSensor(
+        starts=np.array([-50, 250_000], dtype=np.int64),
+        ends=np.array([0, 250_100], dtype=np.int64),
+    )
+
+    def fake_load(source, camera_ids):
+        del source
+        return SimpleNamespace(
+            camera_sensors={camera_ids[0]: sensor},
+            T_rig_worlds_with_timestamps_us=(
+                np.tile(np.eye(4, dtype=np.float64), (3, 1, 1)),
+                np.array([0, 100_000, 200_000], dtype=np.int64),
+            ),
+        )
+
+    monkeypatch.setattr(dataset, "_get_loaders_and_sensors", fake_load)
+    monkeypatch.setattr(
+        dataset,
+        "_subsample_camera_model_parameters",
+        lambda camera_sensor, camera_subsampler: camera_sensor.model_parameters,
+    )
+
+    full_rig = dataset.load_full_camera_rig(str(source_path), reference_rig)
+    trajectory = full_rig.rig_trajectories[0]
+
+    torch.testing.assert_close(
+        trajectory.T_rig_world_timestamps_us,
+        torch.tensor([-51, 0, 100_000, 200_000, 250_101], dtype=torch.int64),
+    )
+    torch.testing.assert_close(trajectory.T_rig_worlds[0], reference_rig.rig_trajectories[0].T_rig_worlds[0])
+    torch.testing.assert_close(trajectory.T_rig_worlds[-1], reference_rig.rig_trajectories[0].T_rig_worlds[-1])
+
+
+def test_load_full_camera_rig_rejects_truncated_reconstruction(tmp_path, monkeypatch) -> None:
+    source_path = tmp_path / "sequence.json"
+    source_path.write_text("{}")
+    dataset = _dataset(source_path)
+    sensor = _FakeCameraSensor(
+        starts=np.array([0, 120_000_000], dtype=np.int64),
+        ends=np.array([30_000, 120_030_000], dtype=np.int64),
+    )
+
+    def fake_load(source, camera_ids):
+        del source
+        return SimpleNamespace(
+            camera_sensors={camera_ids[0]: sensor},
+            T_rig_worlds_with_timestamps_us=(
+                np.tile(np.eye(4, dtype=np.float64), (2, 1, 1)),
+                np.array([0, 120_030_000], dtype=np.int64),
+            ),
+        )
+
+    monkeypatch.setattr(dataset, "_get_loaders_and_sensors", fake_load)
+
+    with pytest.raises(ValueError, match=r"Rerun with --max-chunks 9"):
+        dataset.load_full_camera_rig(str(source_path), _reference_rig())

--- a/tests/test_kelvin_primitive.py
+++ b/tests/test_kelvin_primitive.py
@@ -17,7 +17,13 @@
 
 import torch
 
-from instant_nurec.primitives.kelvin_primitive import KelvinStaticLayer
+from instant_nurec.config_schema.models import PrimitiveExportPreprocessConfig
+from instant_nurec.primitives.kelvin_primitive import (
+    KelvinDynamicLayer,
+    KelvinInstantNuRecPrimitive,
+    KelvinSemanticClass,
+    KelvinStaticLayer,
+)
 
 
 def _identity_quat_wxyz(n: int) -> torch.Tensor:
@@ -121,3 +127,47 @@ class TestKelvinStaticLayerVoxelize:
         # With confidence=ones, weights are uniform softmax(1) -> 0.5 each.
         torch.testing.assert_close(out.densities, torch.tensor([[0.5]]), atol=1e-5, rtol=1e-5)
         torch.testing.assert_close(out.rgb, torch.tensor([[0.5, 0.5, 0.0]]), atol=1e-5, rtol=1e-5)
+
+
+def test_preprocess_fills_unobserved_cubemap_with_pruned_road_color() -> None:
+    static = _make_layer(torch.zeros(4, 3), with_semantic=True)
+    static.semantic_class[:] = KelvinSemanticClass.ROAD
+    static.densities = torch.tensor([[0.9], [0.9], [0.9], [0.1]])
+    static.rgb = torch.tensor(
+        [
+            [0.1, 0.1, 0.1],
+            [0.2, 0.2, 0.2],
+            [0.9, 0.9, 0.9],
+            [0.0, 1.0, 0.0],
+        ]
+    )
+    dynamic = KelvinDynamicLayer(
+        rotations=torch.empty(0, 4),
+        scales=torch.empty(0, 3),
+        rgb=torch.empty(0, 3),
+        max_densities=torch.empty(0, 1),
+        keyframe_positions=torch.empty(0, 3, 3),
+        keyframe_timestamps_us=torch.empty(0, 3, dtype=torch.int64),
+    )
+    sky = torch.full((6, 4, 4, 3), 0.8)
+    mask = torch.zeros(6, 4, 4, 1)
+    mask[:, :2] = 1.0
+    primitive = KelvinInstantNuRecPrimitive(
+        static_layer=static,
+        dynamic_layers=[dynamic],
+        sky_cubemap=sky,
+        sky_cubemap_mask=mask,
+        affine_matrix=torch.eye(3, 4).unsqueeze(0),
+    )
+
+    output = primitive.preprocess_for_export(
+        None,  # type: ignore[arg-type]
+        PrimitiveExportPreprocessConfig(density_prune_threshold=0.5, infill_road_color=True),
+    )
+
+    assert len(output.static_layer) == 3
+    torch.testing.assert_close(output.sky_cubemap[:, :2], torch.full((6, 2, 4, 3), 0.8))
+    torch.testing.assert_close(
+        output.sky_cubemap[:, 2:],
+        torch.tensor([0.2, 0.2, 0.2]).expand(6, 2, 4, 3),
+    )

--- a/tests/test_primitive_merge.py
+++ b/tests/test_primitive_merge.py
@@ -73,6 +73,47 @@ def _make_primitive(positions: torch.Tensor) -> KelvinInstantNuRecPrimitive:
     )
 
 
+def test_merge_sky_cubemaps_prefers_observed_texels() -> None:
+    first = _make_primitive(torch.zeros(1, 3))
+    second = _make_primitive(torch.zeros(1, 3))
+    first.sky_cubemap.fill_(1.0)
+    second.sky_cubemap.zero_()
+    first.sky_cubemap_mask = torch.zeros(6, 4, 4, 1)
+    second.sky_cubemap_mask = torch.zeros(6, 4, 4, 1)
+    first.sky_cubemap_mask[:, :2] = 1.0
+    second.sky_cubemap_mask[:, 2:] = 1.0
+    merger = KelvinPrimitiveMerge(PrimitiveMergeConfig())
+
+    cubemap, mask = merger._merge_sky_cubemaps(
+        [first, second],
+        None,  # type: ignore[arg-type]
+        [],
+    )
+
+    torch.testing.assert_close(cubemap[:, :2], torch.full((6, 2, 4, 3), 1.01 / 1.02))
+    torch.testing.assert_close(cubemap[:, 2:], torch.full((6, 2, 4, 3), 0.01 / 1.02))
+    torch.testing.assert_close(mask, torch.ones_like(mask))
+
+
+def test_merge_sky_cubemaps_averages_fallbacks_without_masks(caplog) -> None:
+    first = _make_primitive(torch.zeros(1, 3))
+    second = _make_primitive(torch.zeros(1, 3))
+    first.sky_cubemap.fill_(0.2)
+    second.sky_cubemap.fill_(0.8)
+    merger = KelvinPrimitiveMerge(PrimitiveMergeConfig())
+
+    with caplog.at_level(logging.WARNING, logger="instant_nurec.predict.primitive_merge"):
+        cubemap, mask = merger._merge_sky_cubemaps(
+            [first, second],
+            None,  # type: ignore[arg-type]
+            [],
+        )
+
+    torch.testing.assert_close(cubemap, torch.full_like(cubemap, 0.5))
+    torch.testing.assert_close(mask, torch.zeros_like(mask))
+    assert sum("has no sky cubemap mask" in record.message for record in caplog.records) == 2
+
+
 class TestMaybeVoxelizeStaticLayer:
     """Branch coverage for the iterative voxelization search.
 

--- a/tests/test_render_preview.py
+++ b/tests/test_render_preview.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import sys
 
-from pathlib import Path
+from enum import Enum
 from types import ModuleType, SimpleNamespace
 
 import pytest
@@ -19,6 +19,74 @@ from instant_nurec.primitives.kelvin_primitive import KelvinInstantNuRecPrimitiv
 
 def _identity_affine() -> torch.Tensor:
     return torch.eye(3, 4)
+
+
+class _FakeFThetaPolynomialType(Enum):
+    PIXELDIST_TO_ANGLE = 0
+    ANGLE_TO_PIXELDIST = 1
+
+
+class _FakeRollingShutterType(Enum):
+    ROLLING_TOP_TO_BOTTOM = 0
+    ROLLING_LEFT_TO_RIGHT = 1
+    ROLLING_BOTTOM_TO_TOP = 2
+    ROLLING_RIGHT_TO_LEFT = 3
+    GLOBAL = 4
+
+
+class _FakeFThetaCameraDistortionParameters:
+    def __init__(self, **kwargs: object) -> None:
+        self.__dict__.update(kwargs)
+
+
+def _ftheta_parameters(*, external_distortion: object | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        reference_poly=SimpleNamespace(name="PIXELDIST_TO_ANGLE"),
+        pixeldist_to_angle_poly=(0.0, 0.01, 0.0, 0.0, 0.0, 0.0),
+        angle_to_pixeldist_poly=(0.0, 100.0, 0.0, 0.0, 0.0, 0.0),
+        max_angle=1.25,
+        linear_cde=(1.0, 0.01, -0.02),
+        principal_point=(1.25, 0.75),
+        shutter_type=SimpleNamespace(name="ROLLING_TOP_TO_BOTTOM"),
+        external_distortion_parameters=external_distortion,
+    )
+
+
+def _render_inputs(
+    sensor_parameters: object,
+) -> tuple[KelvinInstantNuRecPrimitive, SimpleNamespace, torch.Tensor, torch.Tensor]:
+    rays = torch.arange(1 * 2 * 3 * 6, dtype=torch.float32).reshape(1, 2, 3, 6)
+    poses = torch.zeros(1, 2, 7)
+    poses[..., 6] = 1.0
+    poses[0, 0, :3] = torch.tensor([1.0, 2.0, 3.0])
+    poses[0, 1, :3] = torch.tensor([4.0, 5.0, 6.0])
+    rendering = SimpleNamespace(
+        rays=rays,
+        poses_tquat_startend=poses,
+        sensor_model_parameters=[sensor_parameters],
+    )
+    context = SimpleNamespace(
+        data=SimpleNamespace(
+            camera=SimpleNamespace(
+                b=1,
+                meta=[SimpleNamespace(unique_sensor_idx=0)],
+            )
+        ),
+        rendering=SimpleNamespace(camera=rendering),
+    )
+    primitive = KelvinInstantNuRecPrimitive(
+        static_layer=KelvinStaticLayer(
+            positions=torch.zeros(1, 3),
+            densities=torch.full((1, 1), 0.5),
+            rotations=torch.tensor([[1.0, 0.0, 0.0, 0.0]]),
+            scales=torch.ones(1, 3),
+            rgb=torch.tensor([[0.2, 0.2, 0.2]]),
+        ),
+        dynamic_layers=[],
+        sky_cubemap=torch.zeros(6, 2, 2, 3),
+        affine_matrix=torch.eye(3, 4).unsqueeze(0),
+    )
+    return primitive, context, rays, poses
 
 
 def test_transparent_foreground_reveals_sky() -> None:
@@ -58,101 +126,109 @@ def test_affine_is_applied_after_sky_compositing() -> None:
     torch.testing.assert_close(output, torch.tensor([[[0.3, 0.4, 0.45]]]))
 
 
-def test_reference_preview_uses_end_pose_frame_rays_and_sensor_affine(
+def test_composited_frame_uses_calibrated_ftheta_rolling_shutter_and_exact_rays(
     monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
 ) -> None:
-    rays = torch.arange(2 * 2 * 3 * 6, dtype=torch.float32).reshape(2, 2, 3, 6)
-    poses = torch.zeros(2, 2, 7)
-    poses[..., 6] = 1.0
-    poses[0, 0, :3] = torch.tensor([1.0, 2.0, 3.0])
-    poses[0, 1, :3] = torch.tensor([4.0, 5.0, 6.0])
-    poses[1, 0, :3] = torch.tensor([10.0, 11.0, 12.0])
-    poses[1, 1, :3] = torch.tensor([20.0, 21.0, 22.0])
-    rendering = SimpleNamespace(
-        rays=rays,
-        poses_tquat_startend=poses,
-        sensor_model_parameters=[object(), object()],
-    )
-    camera_data = SimpleNamespace(
-        b=2,
-        meta=[SimpleNamespace(unique_sensor_idx=9), SimpleNamespace(unique_sensor_idx=3)],
-    )
-    context = SimpleNamespace(
-        data=SimpleNamespace(camera=camera_data),
-        rendering=SimpleNamespace(camera=rendering),
-    )
-
-    static = KelvinStaticLayer(
-        positions=torch.zeros(1, 3),
-        densities=torch.full((1, 1), 0.5),
-        rotations=torch.tensor([[1.0, 0.0, 0.0, 0.0]]),
-        scales=torch.ones(1, 3),
-        rgb=torch.tensor([[1.5, -0.5, 0.25]]),
-    )
-    primitive = KelvinInstantNuRecPrimitive(
-        static_layer=static,
-        dynamic_layers=[],
-        sky_cubemap=torch.zeros(6, 2, 2, 3),
-        affine_matrix=torch.eye(3, 4).repeat(2, 1, 1),
-    )
-    primitive.affine_matrix[1] = torch.tensor(
-        [
-            [1.0, 0.0, 0.0, 0.1],
-            [0.0, 1.0, 0.0, 0.2],
-            [0.0, 0.0, 1.0, 0.3],
-        ]
-    )
-
+    primitive, context, rays, poses = _render_inputs(_ftheta_parameters())
     seen: dict[str, object] = {}
-    camera_to_world = torch.eye(4)
-    camera_to_world[:3, 3] = torch.tensor([2.0, 3.0, 4.0])
+    camera_to_world_start = torch.eye(4)
+    camera_to_world_start[:3, 3] = torch.tensor([2.0, 3.0, 4.0])
+    camera_to_world_end = torch.eye(4)
+    camera_to_world_end[:3, 3] = torch.tensor([5.0, 6.0, 7.0])
 
     def fake_tquat_to_se3_matrix(value: torch.Tensor, *, unbatch: bool) -> torch.Tensor:
-        seen["pose"] = value.clone()
-        seen["unbatch"] = unbatch
-        return camera_to_world.clone()
+        seen.setdefault("poses", []).append(value.clone())
+        assert unbatch is True
+        if torch.equal(value, poses[0, 0]):
+            return camera_to_world_start.clone()
+        if torch.equal(value, poses[0, 1]):
+            return camera_to_world_end.clone()
+        raise AssertionError(f"Unexpected pose: {value}")
 
     def fake_rasterization(**kwargs):
-        seen["viewmats"] = kwargs["viewmats"].clone()
-        seen["colors"] = kwargs["colors"].clone()
+        seen["rasterization"] = kwargs
         height, width = kwargs["height"], kwargs["width"]
-        return torch.zeros(1, height, width, 3), torch.zeros(1, height, width, 1), {}
+        foreground = torch.full((1, height, width, 3), 0.2)
+        opacity = torch.full((1, height, width, 1), 0.5)
+        return foreground, opacity, {}
 
     def fake_sample_sky_cubemap(cubemap: torch.Tensor, directions: torch.Tensor) -> torch.Tensor:
         del cubemap
         seen["directions"] = directions.clone()
-        return torch.full((*directions.shape[:-1], 3), 0.25)
-
-    def fake_composite(
-        foreground: torch.Tensor,
-        opacity: torch.Tensor,
-        sky_rgb: torch.Tensor,
-        affine: torch.Tensor,
-    ) -> torch.Tensor:
-        del opacity, sky_rgb
-        seen["affine"] = affine.clone()
-        return foreground
+        return torch.full((*directions.shape[:-1], 3), 0.4)
 
     fake_gsplat = ModuleType("gsplat")
     setattr(fake_gsplat, "rasterization", fake_rasterization)
-    pinhole = SimpleNamespace(focal_length=(100.0, 101.0), principal_point=(1.0, 0.5))
+    fake_gsplat_rendering = ModuleType("gsplat.rendering")
+    setattr(
+        fake_gsplat_rendering,
+        "FThetaCameraDistortionParameters",
+        _FakeFThetaCameraDistortionParameters,
+    )
+    setattr(fake_gsplat_rendering, "FThetaPolynomialType", _FakeFThetaPolynomialType)
+    setattr(fake_gsplat_rendering, "RollingShutterType", _FakeRollingShutterType)
     monkeypatch.setitem(sys.modules, "gsplat", fake_gsplat)
+    monkeypatch.setitem(sys.modules, "gsplat.rendering", fake_gsplat_rendering)
     monkeypatch.setattr(render_preview_module, "tquat_to_se3_matrix", fake_tquat_to_se3_matrix)
-    monkeypatch.setattr(render_preview_module, "to_simple_pinhole_model_parameters", lambda _: pinhole)
     monkeypatch.setattr(render_preview_module, "sample_sky_cubemap", fake_sample_sky_cubemap)
-    monkeypatch.setattr(render_preview_module, "composite_sky_and_affine", fake_composite)
 
-    output_path = tmp_path / "preview.png"
-    stats = render_preview_module.render_reference_preview(primitive, context, output_path, frame_index=1)
+    composed, opacity, sky = render_preview_module.render_composited_frame(primitive, context)
 
-    torch.testing.assert_close(seen["pose"], poses[1, 1])
-    assert seen["unbatch"] is True
-    torch.testing.assert_close(seen["viewmats"], torch.linalg.inv(camera_to_world).unsqueeze(0))
-    torch.testing.assert_close(seen["colors"], primitive.static_layer.rgb)
-    torch.testing.assert_close(seen["directions"], rays[1, ..., 3:])
-    torch.testing.assert_close(seen["affine"], primitive.affine_matrix[1])
-    assert stats.path == output_path
-    assert stats.width == 3
-    assert stats.height == 2
-    assert output_path.is_file()
+    kwargs = seen["rasterization"]
+    assert isinstance(kwargs, dict)
+    assert kwargs["camera_model"] == "ftheta"
+    assert kwargs["packed"] is False
+    assert kwargs["with_ut"] is True
+    assert kwargs["with_eval3d"] is True
+    assert kwargs["global_z_order"] is False
+    assert kwargs["rolling_shutter"] is _FakeRollingShutterType.ROLLING_TOP_TO_BOTTOM
+    torch.testing.assert_close(kwargs["rays"], rays)
+    torch.testing.assert_close(
+        kwargs["viewmats"],
+        torch.linalg.inv(camera_to_world_start).unsqueeze(0),
+    )
+    torch.testing.assert_close(
+        kwargs["viewmats_rs"],
+        torch.linalg.inv(camera_to_world_end).unsqueeze(0),
+    )
+    torch.testing.assert_close(
+        kwargs["Ks"],
+        torch.tensor([[[100.0, 0.0, 1.25], [0.0, 100.0, 0.75], [0.0, 0.0, 1.0]]]),
+    )
+    ftheta_coeffs = kwargs["ftheta_coeffs"]
+    assert isinstance(ftheta_coeffs, _FakeFThetaCameraDistortionParameters)
+    assert ftheta_coeffs.reference_poly is _FakeFThetaPolynomialType.PIXELDIST_TO_ANGLE
+    assert ftheta_coeffs.pixeldist_to_angle_poly == (0.0, 0.01, 0.0, 0.0, 0.0, 0.0)
+    assert ftheta_coeffs.angle_to_pixeldist_poly == (0.0, 100.0, 0.0, 0.0, 0.0, 0.0)
+    assert ftheta_coeffs.max_angle == 1.25
+    assert ftheta_coeffs.linear_cde == (1.0, 0.01, -0.02)
+    torch.testing.assert_close(seen["directions"], rays[0, ..., 3:])
+    torch.testing.assert_close(opacity, torch.full((2, 3), 0.5))
+    torch.testing.assert_close(sky, torch.full((2, 3, 3), 0.4))
+    torch.testing.assert_close(composed, torch.full((2, 3, 3), 0.4))
+
+
+def test_composited_frame_rejects_ftheta_external_windshield_distortion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    primitive, context, _, _ = _render_inputs(_ftheta_parameters(external_distortion=SimpleNamespace()))
+    fake_gsplat = ModuleType("gsplat")
+    setattr(fake_gsplat, "rasterization", lambda **_: None)
+    monkeypatch.setitem(sys.modules, "gsplat", fake_gsplat)
+
+    with pytest.raises(NotImplementedError, match="external windshield distortion"):
+        render_preview_module.render_composited_frame(primitive, context)
+
+
+def test_composited_frame_rejects_non_ftheta_before_loading_gsplat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    primitive, context, _, _ = _render_inputs(object())
+
+    def unexpected_gsplat_import():
+        raise AssertionError("unsupported cameras must fail before loading gsplat")
+
+    monkeypatch.setattr(render_preview_module, "require_gsplat", unexpected_gsplat_import)
+
+    with pytest.raises(NotImplementedError, match="supports NCore F-theta cameras only"):
+        render_preview_module.render_composited_frame(primitive, context)

--- a/tests/test_render_preview.py
+++ b/tests/test_render_preview.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+
+import instant_nurec.predict.render_preview as render_preview_module
+
+from instant_nurec.predict.render_preview import composite_sky_and_affine
+from instant_nurec.primitives.kelvin_primitive import KelvinInstantNuRecPrimitive, KelvinStaticLayer
+
+
+def _identity_affine() -> torch.Tensor:
+    return torch.eye(3, 4)
+
+
+def test_transparent_foreground_reveals_sky() -> None:
+    foreground = torch.zeros(2, 3, 3)
+    opacity = torch.zeros(2, 3)
+    sky = torch.full_like(foreground, 0.6)
+
+    output = composite_sky_and_affine(foreground, opacity, sky, _identity_affine())
+
+    torch.testing.assert_close(output, sky)
+
+
+def test_opaque_foreground_hides_sky() -> None:
+    foreground = torch.full((2, 3, 3), 0.2)
+    opacity = torch.ones(2, 3, 1)
+    sky = torch.full_like(foreground, 0.8)
+
+    output = composite_sky_and_affine(foreground, opacity, sky, _identity_affine())
+
+    torch.testing.assert_close(output, foreground)
+
+
+def test_affine_is_applied_after_sky_compositing() -> None:
+    foreground = torch.zeros(1, 1, 3)
+    opacity = torch.zeros(1, 1)
+    sky = torch.tensor([[[0.1, 0.2, 0.3]]])
+    affine = torch.tensor(
+        [
+            [2.0, 0.0, 0.0, 0.1],
+            [0.0, 1.0, 0.0, 0.2],
+            [0.0, 0.0, 0.5, 0.3],
+        ]
+    )
+
+    output = composite_sky_and_affine(foreground, opacity, sky, affine)
+
+    torch.testing.assert_close(output, torch.tensor([[[0.3, 0.4, 0.45]]]))
+
+
+def test_reference_preview_uses_end_pose_frame_rays_and_sensor_affine(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    rays = torch.arange(2 * 2 * 3 * 6, dtype=torch.float32).reshape(2, 2, 3, 6)
+    poses = torch.zeros(2, 2, 7)
+    poses[..., 6] = 1.0
+    poses[0, 0, :3] = torch.tensor([1.0, 2.0, 3.0])
+    poses[0, 1, :3] = torch.tensor([4.0, 5.0, 6.0])
+    poses[1, 0, :3] = torch.tensor([10.0, 11.0, 12.0])
+    poses[1, 1, :3] = torch.tensor([20.0, 21.0, 22.0])
+    rendering = SimpleNamespace(
+        rays=rays,
+        poses_tquat_startend=poses,
+        sensor_model_parameters=[object(), object()],
+    )
+    camera_data = SimpleNamespace(
+        b=2,
+        meta=[SimpleNamespace(unique_sensor_idx=9), SimpleNamespace(unique_sensor_idx=3)],
+    )
+    context = SimpleNamespace(
+        data=SimpleNamespace(camera=camera_data),
+        rendering=SimpleNamespace(camera=rendering),
+    )
+
+    static = KelvinStaticLayer(
+        positions=torch.zeros(1, 3),
+        densities=torch.full((1, 1), 0.5),
+        rotations=torch.tensor([[1.0, 0.0, 0.0, 0.0]]),
+        scales=torch.ones(1, 3),
+        rgb=torch.tensor([[1.5, -0.5, 0.25]]),
+    )
+    primitive = KelvinInstantNuRecPrimitive(
+        static_layer=static,
+        dynamic_layers=[],
+        sky_cubemap=torch.zeros(6, 2, 2, 3),
+        affine_matrix=torch.eye(3, 4).repeat(2, 1, 1),
+    )
+    primitive.affine_matrix[1] = torch.tensor(
+        [
+            [1.0, 0.0, 0.0, 0.1],
+            [0.0, 1.0, 0.0, 0.2],
+            [0.0, 0.0, 1.0, 0.3],
+        ]
+    )
+
+    seen: dict[str, object] = {}
+    camera_to_world = torch.eye(4)
+    camera_to_world[:3, 3] = torch.tensor([2.0, 3.0, 4.0])
+
+    def fake_tquat_to_se3_matrix(value: torch.Tensor, *, unbatch: bool) -> torch.Tensor:
+        seen["pose"] = value.clone()
+        seen["unbatch"] = unbatch
+        return camera_to_world.clone()
+
+    def fake_rasterization(**kwargs):
+        seen["viewmats"] = kwargs["viewmats"].clone()
+        seen["colors"] = kwargs["colors"].clone()
+        height, width = kwargs["height"], kwargs["width"]
+        return torch.zeros(1, height, width, 3), torch.zeros(1, height, width, 1), {}
+
+    def fake_sample_sky_cubemap(cubemap: torch.Tensor, directions: torch.Tensor) -> torch.Tensor:
+        del cubemap
+        seen["directions"] = directions.clone()
+        return torch.full((*directions.shape[:-1], 3), 0.25)
+
+    def fake_composite(
+        foreground: torch.Tensor,
+        opacity: torch.Tensor,
+        sky_rgb: torch.Tensor,
+        affine: torch.Tensor,
+    ) -> torch.Tensor:
+        del opacity, sky_rgb
+        seen["affine"] = affine.clone()
+        return foreground
+
+    fake_gsplat = ModuleType("gsplat")
+    setattr(fake_gsplat, "rasterization", fake_rasterization)
+    pinhole = SimpleNamespace(focal_length=(100.0, 101.0), principal_point=(1.0, 0.5))
+    monkeypatch.setitem(sys.modules, "gsplat", fake_gsplat)
+    monkeypatch.setattr(render_preview_module, "tquat_to_se3_matrix", fake_tquat_to_se3_matrix)
+    monkeypatch.setattr(render_preview_module, "to_simple_pinhole_model_parameters", lambda _: pinhole)
+    monkeypatch.setattr(render_preview_module, "sample_sky_cubemap", fake_sample_sky_cubemap)
+    monkeypatch.setattr(render_preview_module, "composite_sky_and_affine", fake_composite)
+
+    output_path = tmp_path / "preview.png"
+    stats = render_preview_module.render_reference_preview(primitive, context, output_path, frame_index=1)
+
+    torch.testing.assert_close(seen["pose"], poses[1, 1])
+    assert seen["unbatch"] is True
+    torch.testing.assert_close(seen["viewmats"], torch.linalg.inv(camera_to_world).unsqueeze(0))
+    torch.testing.assert_close(seen["colors"], primitive.static_layer.rgb)
+    torch.testing.assert_close(seen["directions"], rays[1, ..., 3:])
+    torch.testing.assert_close(seen["affine"], primitive.affine_matrix[1])
+    assert stats.path == output_path
+    assert stats.width == 3
+    assert stats.height == 2
+    assert output_path.is_file()

--- a/tests/test_render_video.py
+++ b/tests/test_render_video.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import instant_nurec.predict.render_video as render_video
+
+
+def test_infer_source_fps_uses_median_start_cadence() -> None:
+    timestamps = torch.tensor(
+        [[10, 20], [33_343, 33_353], [66_677, 66_687], [100_010, 100_020]],
+        dtype=torch.int64,
+    )
+
+    assert render_video.infer_source_fps(timestamps) == pytest.approx(1_000_000 / 33_333)
+
+
+@pytest.mark.parametrize(
+    "timestamps, message",
+    [
+        (torch.zeros(1, 2, dtype=torch.int64), "At least two"),
+        (torch.tensor([[2, 3], [2, 4]]), "strictly increasing"),
+        (torch.zeros(2, 3, dtype=torch.int64), "shape"),
+    ],
+)
+def test_infer_source_fps_rejects_invalid_timeline(
+    timestamps: torch.Tensor,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        render_video.infer_source_fps(timestamps)
+
+
+def test_require_ffmpeg_reports_missing_executable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(render_video.shutil, "which", lambda _: None)
+
+    with pytest.raises(RuntimeError, match="ffmpeg on PATH"):
+        render_video.require_ffmpeg()
+
+
+def test_require_ffmpeg_reports_missing_libx264(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(render_video.shutil, "which", lambda _: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(
+        render_video.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="h264_nvenc\n", stderr=""),
+    )
+
+    with pytest.raises(RuntimeError, match="libx264 encoder"):
+        render_video.require_ffmpeg()
+
+
+def test_partial_video_paths_are_unique_and_share_output_directory(tmp_path: Path) -> None:
+    output = tmp_path / "scene.render.mp4"
+    first = render_video._reserve_partial_path(output)
+    second = render_video._reserve_partial_path(output)
+    try:
+        assert first.parent == output.parent
+        assert second.parent == output.parent
+        assert first != second
+        assert first.name.endswith(".partial.mp4")
+        assert second.name.endswith(".partial.mp4")
+    finally:
+        first.unlink(missing_ok=True)
+        second.unlink(missing_ok=True)
+
+
+def test_render_reference_video_streams_every_frame_and_atomically_finishes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    timestamps = torch.tensor(
+        [[0, 100], [33_333, 33_433], [133_333, 133_433]],
+        dtype=torch.int64,
+    )
+    calibration = SimpleNamespace(
+        sequence_id="context-main",
+        unique_sensor_idx=7,
+        camera_model_parameters=SimpleNamespace(resolution=(4, 2)),
+    )
+    trajectory = SimpleNamespace(
+        sequence_id="context-main",
+        cameras_frame_timestamps_us={"front": timestamps},
+    )
+    rig = SimpleNamespace(
+        camera_calibrations=OrderedDict([("front", calibration)]),
+        rig_trajectories=[trajectory],
+    )
+    geometry = SimpleNamespace(sensor_ids_to_frame_range={"front": range(3)})
+    geometry.to = lambda *, device: geometry
+    geometry_type = SimpleNamespace(from_rig_trajectories=lambda _: geometry)
+    monkeypatch.setattr(render_video, "CameraFreePoseViewGeometry", geometry_type)
+    monkeypatch.setattr(render_video, "require_ffmpeg", lambda: "/usr/bin/ffmpeg")
+
+    frame_context_calls: list[int] = []
+
+    def fake_frame_context(_geometry, *, unique_sensor_idx, unique_frame_idx, device):
+        assert _geometry is geometry
+        assert unique_sensor_idx == 7
+        assert device == torch.device("cpu")
+        frame_context_calls.append(unique_frame_idx)
+        return SimpleNamespace(frame=unique_frame_idx)
+
+    monkeypatch.setattr(render_video, "_frame_context", fake_frame_context)
+
+    def fake_render(_primitive, context):
+        value = 0.25 + context.frame * 0.1
+        return (
+            torch.full((2, 4, 3), value),
+            torch.full((2, 4), 0.25),
+            torch.full((2, 4, 3), 0.2),
+        )
+
+    monkeypatch.setattr(render_video, "render_composited_frame", fake_render)
+
+    popen_calls: list[list[str]] = []
+    popen_kwargs: list[dict[str, object]] = []
+    processes: list[_FakeProcess] = []
+
+    class _CapturePipe:
+        def __init__(self) -> None:
+            self.data = bytearray()
+            self.closed = False
+
+        def write(self, value: bytes) -> int:
+            self.data.extend(value)
+            return len(value)
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _FakeProcess:
+        def __init__(self, command: list[str], **kwargs: object) -> None:
+            popen_calls.append(command)
+            popen_kwargs.append(kwargs)
+            self.stdin = _CapturePipe()
+            self.returncode: int | None = None
+            processes.append(self)
+
+        def poll(self) -> int | None:
+            return self.returncode
+
+        def wait(self) -> int:
+            self.returncode = 0
+            Path(popen_calls[-1][-1]).write_bytes(b"encoded-mp4")
+            return 0
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+    monkeypatch.setattr(render_video.subprocess, "Popen", _FakeProcess)
+
+    primitive = SimpleNamespace(device=lambda: torch.device("cpu"))
+    output = tmp_path / "scene.render.mp4"
+    stats = render_video.render_reference_video(primitive, rig, output)
+
+    assert frame_context_calls == [0, 1, 2]
+    assert len(popen_calls) == 1
+    assert "4x2" in popen_calls[0]
+    partial_path = Path(popen_calls[0][-1])
+    assert partial_path.parent == output.parent
+    assert partial_path.name.endswith(".partial.mp4")
+    assert partial_path != output.with_suffix(".partial.mp4")
+    assert popen_kwargs[0]["stderr"] is not render_video.subprocess.PIPE
+    assert len(processes[0].stdin.data) == 3 * 4 * 2 * 3
+    assert output.read_bytes() == b"encoded-mp4"
+    assert not partial_path.exists()
+    assert stats.path == output
+    assert stats.frame_count == 3
+    assert stats.fps == pytest.approx(1_000_000 / 33_333)
+    assert stats.duration_seconds == pytest.approx(3 / stats.fps)
+    assert stats.width == 4
+    assert stats.height == 2
+    assert stats.background_fraction == pytest.approx(0.75)
+    assert stats.sky_contribution_mean == pytest.approx(0.15)
+
+
+def test_render_reference_video_reports_ffmpeg_stderr_on_broken_pipe(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    timestamps = torch.tensor([[0, 100], [33_333, 33_433]], dtype=torch.int64)
+    calibration = SimpleNamespace(
+        sequence_id="context-main",
+        unique_sensor_idx=7,
+        camera_model_parameters=SimpleNamespace(resolution=(4, 2)),
+    )
+    trajectory = SimpleNamespace(
+        sequence_id="context-main",
+        cameras_frame_timestamps_us={"front": timestamps},
+    )
+    rig = SimpleNamespace(
+        camera_calibrations=OrderedDict([("front", calibration)]),
+        rig_trajectories=[trajectory],
+    )
+    geometry = SimpleNamespace(sensor_ids_to_frame_range={"front": range(2)})
+    geometry.to = lambda *, device: geometry
+    geometry_type = SimpleNamespace(from_rig_trajectories=lambda _: geometry)
+    monkeypatch.setattr(render_video, "CameraFreePoseViewGeometry", geometry_type)
+    monkeypatch.setattr(render_video, "require_ffmpeg", lambda: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(render_video, "_frame_context", lambda *args, **kwargs: SimpleNamespace())
+    monkeypatch.setattr(
+        render_video,
+        "render_composited_frame",
+        lambda *args: (
+            torch.zeros(2, 4, 3),
+            torch.zeros(2, 4),
+            torch.zeros(2, 4, 3),
+        ),
+    )
+
+    class _BrokenPipe:
+        closed = False
+
+        def write(self, value: bytes) -> int:
+            del value
+            raise BrokenPipeError("ffmpeg closed stdin")
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _FailedProcess:
+        def __init__(self, command: list[str], **kwargs: object) -> None:
+            del command
+            self.stdin = _BrokenPipe()
+            self.returncode = 1
+            stderr_log = kwargs["stderr"]
+            stderr_log.write(b"Unknown encoder 'libx264'\n")
+            stderr_log.flush()
+
+        def poll(self) -> int:
+            return self.returncode
+
+        def wait(self) -> int:
+            return self.returncode
+
+        def kill(self) -> None:
+            raise AssertionError("Exited ffmpeg process must not be killed")
+
+    monkeypatch.setattr(render_video.subprocess, "Popen", _FailedProcess)
+
+    output = tmp_path / "scene.render.mp4"
+    with pytest.raises(RuntimeError, match="status 1: Unknown encoder 'libx264'") as exc_info:
+        render_video.render_reference_video(SimpleNamespace(device=lambda: torch.device("cpu")), rig, output)
+
+    assert isinstance(exc_info.value.__cause__, BrokenPipeError)
+    assert not output.exists()
+    assert list(tmp_path.iterdir()) == []

--- a/tests/test_system_export_banner.py
+++ b/tests/test_system_export_banner.py
@@ -43,12 +43,20 @@ def _make_primitive(n_gaussians: int) -> MagicMock:
     return primitive
 
 
-def _make_system(out_dir: Path, run_id: str, merge_enabled: bool) -> system_mod.GaussiansInstantNuRecSystem:
+def _make_system(
+    out_dir: Path,
+    run_id: str,
+    merge_enabled: bool,
+    *,
+    render_video: bool = False,
+) -> system_mod.GaussiansInstantNuRecSystem:
     inst = system_mod.GaussiansInstantNuRecSystem.__new__(system_mod.GaussiansInstantNuRecSystem)
     inst.out_dir = str(out_dir)
     inst.run_id = run_id
     inst.predict_config = types.SimpleNamespace(
         primitive_merge=types.SimpleNamespace(enabled=merge_enabled),
+        render_preview=False,
+        render_video=render_video,
     )
     return inst
 
@@ -107,3 +115,84 @@ def test_banner_count_uses_thousands_separator(
     inst.on_predict_batch_end(outputs, batch)
 
     assert "(1,000,000 gaussians)" in capsys.readouterr().out
+
+
+def test_full_video_uses_source_rig_and_prints_verified_timeline(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(system_mod, "export_ply", lambda **kwargs: None)
+    video_stats = types.SimpleNamespace(
+        path=tmp_path / "run3" / "ply" / "seq_video" / "seq_video.render.mp4",
+        frame_count=599,
+        fps=29.9994,
+        duration_seconds=19.9667,
+        background_fraction=0.42,
+        sky_contribution_mean=0.1234,
+    )
+    render_video = MagicMock(return_value=video_stats)
+    monkeypatch.setattr(system_mod, "render_reference_video", render_video)
+
+    primitive = _make_primitive(1_918_461)
+    outputs, batch = _make_outputs([primitive], sequence_id="seq_video")
+    ncore_path = tmp_path / "sequence.json"
+    batch.meta[0]["ncore_json_path"] = ncore_path
+    inst = _make_system(tmp_path, run_id="run3", merge_enabled=True, render_video=True)
+    full_rig = MagicMock(name="full_rig")
+    dataset = MagicMock()
+    dataset.config.context_camera_ids = ["front"]
+    dataset.load_full_camera_rig.return_value = full_rig
+    inst.datamodule = types.SimpleNamespace(predict_dataset=dataset)
+
+    inst.on_predict_batch_end(outputs, batch)
+
+    dataset.load_full_camera_rig.assert_called_once_with(
+        ncore_path,
+        batch.context_rig[0],
+        camera_id="front",
+    )
+    expected_path = tmp_path / "run3" / "ply" / "seq_video" / "seq_video.render.mp4"
+    render_video.assert_called_once_with(primitive, full_rig, expected_path)
+    out = capsys.readouterr().out
+    assert "599 frames, 29.999 fps, 19.97s" in out
+    assert f"{expected_path.resolve()}" in out
+
+
+def test_video_failure_happens_after_primary_exports(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[str] = []
+
+    def fake_export_ply(**kwargs) -> None:
+        del kwargs
+        calls.append("ply")
+
+    def fake_export_sky(primitive, rig, path):
+        del primitive, rig
+        calls.append("sky")
+        return path.with_suffix(".sky.npz"), path.with_suffix(".sky.png")
+
+    def fail_video(*args, **kwargs):
+        del args, kwargs
+        calls.append("video")
+        raise RuntimeError("encoder failed")
+
+    monkeypatch.setattr(system_mod, "export_ply", fake_export_ply)
+    monkeypatch.setattr(system_mod, "export_sky", fake_export_sky)
+    monkeypatch.setattr(system_mod, "render_reference_video", fail_video)
+
+    primitive = _make_primitive(3)
+    outputs, batch = _make_outputs([primitive], sequence_id="seq_failure")
+    batch.meta[0]["ncore_json_path"] = tmp_path / "sequence.json"
+    inst = _make_system(tmp_path, run_id="run4", merge_enabled=True, render_video=True)
+    dataset = MagicMock()
+    dataset.config.context_camera_ids = ["front"]
+    dataset.load_full_camera_rig.return_value = MagicMock(name="full_rig")
+    inst.datamodule = types.SimpleNamespace(predict_dataset=dataset)
+
+    with pytest.raises(RuntimeError, match="encoder failed"):
+        inst.on_predict_batch_end(outputs, batch)
+
+    assert calls == ["ply", "sky", "video"]

--- a/tests/test_system_export_banner.py
+++ b/tests/test_system_export_banner.py
@@ -25,6 +25,18 @@ sys.path.insert(0, str(REPO_ROOT))
 from instant_nurec.model import system as system_mod  # noqa: E402
 
 
+@pytest.fixture(autouse=True)
+def _stub_sky_export(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        system_mod,
+        "export_sky",
+        lambda primitive, rig, path: (
+            path.with_suffix(".sky.npz"),
+            path.with_suffix(".sky.png"),
+        ),
+    )
+
+
 def _make_primitive(n_gaussians: int) -> MagicMock:
     primitive = MagicMock()
     primitive.static_layer.densities = torch.zeros(n_gaussians)
@@ -80,6 +92,8 @@ def test_banner_uses_no_chunk_suffix_when_merge_enabled(
     out = capsys.readouterr().out
     expected = (tmp_path / "run1" / "ply" / "seq_y" / "seq_y.ply").resolve()
     assert f"Wrote 3DGS PLY (1,883,483 gaussians): {expected}" in out
+    assert f"Wrote sky sidecar: {expected.with_suffix('.sky.npz')}" in out
+    assert f"Wrote sky preview: {expected.with_suffix('.sky.png')}" in out
 
 
 def test_banner_count_uses_thousands_separator(

--- a/uv.lock
+++ b/uv.lock
@@ -163,6 +163,22 @@ wheels = [
 ]
 
 [[package]]
+name = "gsplat"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaxtyping" },
+    { name = "ninja" },
+    { name = "numpy" },
+    { name = "rich" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/94/a0963873708223385ac926112dc3e40ab08297784ac53d95309b4cb5a801/gsplat-1.5.3.tar.gz", hash = "sha256:343f080c470e891ba3c697c03bdf0952cb982d1d535fdc24adb23c2cb4fba906", size = 4743603, upload-time = "2025-07-04T16:50:42.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/68/c5cbbdb86421a3f45ac0b52cf9860b1048d089335151d3f37c23aabcbef1/gsplat-1.5.3-py3-none-any.whl", hash = "sha256:515a3773641f5e7f7717acab6276c0b1d6dbcad087b7968ca653337c3189a982", size = 6519041, upload-time = "2025-07-04T16:50:40.559Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -241,6 +257,11 @@ dependencies = [
     { name = "zarr" },
 ]
 
+[package.optional-dependencies]
+render = [
+    { name = "gsplat" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
@@ -251,6 +272,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "einops", specifier = "==0.8.1" },
+    { name = "gsplat", marker = "extra == 'render'", specifier = "==1.5.3" },
     { name = "huggingface-hub", specifier = "==0.36.2" },
     { name = "numcodecs", specifier = "==0.11.0" },
     { name = "numpy", specifier = "==1.26.4" },
@@ -270,12 +292,25 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "zarr", specifier = "==2.18.2" },
 ]
+provides-extras = ["render"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-cov", specifier = ">=5" },
     { name = "ruff", specifier = ">=0.4" },
+]
+
+[[package]]
+name = "jaxtyping"
+version = "0.3.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wadler-lindig" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/c1/091b8852bd7cbf50bd655543c8506033cf4029300c67f8c176c1286879a9/jaxtyping-0.3.11.tar.gz", hash = "sha256:b09c14acf6686feb9e0df5b0d8c6e7c5b6f8d36bf059ee54cd522a186c2ef050", size = 46489, upload-time = "2026-06-13T18:35:23.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/38/c66bbdc5047f4776c2bd3e47e5295a350e3fa44d5b8942105e71c2a876a0/jaxtyping-0.3.11-py3-none-any.whl", hash = "sha256:8a4bedc4e3f963fa82df41bd13c7ebc2bad925601eb48614c65798f21329d4e3", size = 56593, upload-time = "2026-06-13T18:35:22.01Z" },
 ]
 
 [[package]]
@@ -288,6 +323,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]
@@ -322,6 +369,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -346,6 +402,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
+name = "ninja"
+version = "1.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/73/79a0b22fc731989c708068427579e840a6cf4e937fe7ae5c5d0b7356ac22/ninja-1.13.0.tar.gz", hash = "sha256:4a40ce995ded54d9dc24f8ea37ff3bf62ad192b547f6c7126e7e25045e76f978", size = 242558, upload-time = "2025-08-11T15:10:19.421Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/74/d02409ed2aa865e051b7edda22ad416a39d81a84980f544f8de717cab133/ninja-1.13.0-py3-none-macosx_10_9_universal2.whl", hash = "sha256:fa2a8bfc62e31b08f83127d1613d10821775a0eb334197154c4d6067b7068ff1", size = 310125, upload-time = "2025-08-11T15:09:50.971Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/de/6e1cd6b84b412ac1ef327b76f0641aeb5dcc01e9d3f9eee0286d0c34fd93/ninja-1.13.0-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3d00c692fb717fd511abeb44b8c5d00340c36938c12d6538ba989fe764e79630", size = 177467, upload-time = "2025-08-11T15:09:52.767Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/83/49320fb6e58ae3c079381e333575fdbcf1cca3506ee160a2dcce775046fa/ninja-1.13.0-py3-none-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:be7f478ff9f96a128b599a964fc60a6a87b9fa332ee1bd44fa243ac88d50291c", size = 187834, upload-time = "2025-08-11T15:09:54.115Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c7/ba22748fb59f7f896b609cd3e568d28a0a367a6d953c24c461fe04fc4433/ninja-1.13.0-py3-none-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:60056592cf495e9a6a4bea3cd178903056ecb0943e4de45a2ea825edb6dc8d3e", size = 202736, upload-time = "2025-08-11T15:09:55.745Z" },
+    { url = "https://files.pythonhosted.org/packages/79/22/d1de07632b78ac8e6b785f41fa9aad7a978ec8c0a1bf15772def36d77aac/ninja-1.13.0-py3-none-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:1c97223cdda0417f414bf864cfb73b72d8777e57ebb279c5f6de368de0062988", size = 179034, upload-time = "2025-08-11T15:09:57.394Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/de/0e6edf44d6a04dabd0318a519125ed0415ce437ad5a1ec9b9be03d9048cf/ninja-1.13.0-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fb46acf6b93b8dd0322adc3a4945452a4e774b75b91293bafcc7b7f8e6517dfa", size = 180716, upload-time = "2025-08-11T15:09:58.696Z" },
+    { url = "https://files.pythonhosted.org/packages/54/28/938b562f9057aaa4d6bfbeaa05e81899a47aebb3ba6751e36c027a7f5ff7/ninja-1.13.0-py3-none-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4be9c1b082d244b1ad7ef41eb8ab088aae8c109a9f3f0b3e56a252d3e00f42c1", size = 146843, upload-time = "2025-08-11T15:10:00.046Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fb/d06a3838de4f8ab866e44ee52a797b5491df823901c54943b2adb0389fbb/ninja-1.13.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:6739d3352073341ad284246f81339a384eec091d9851a886dfa5b00a6d48b3e2", size = 154402, upload-time = "2025-08-11T15:10:01.657Z" },
+    { url = "https://files.pythonhosted.org/packages/31/bf/0d7808af695ceddc763cf251b84a9892cd7f51622dc8b4c89d5012779f06/ninja-1.13.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:11be2d22027bde06f14c343f01d31446747dbb51e72d00decca2eb99be911e2f", size = 552388, upload-time = "2025-08-11T15:10:03.349Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/70/c99d0c2c809f992752453cce312848abb3b1607e56d4cd1b6cded317351a/ninja-1.13.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:aa45b4037b313c2f698bc13306239b8b93b4680eb47e287773156ac9e9304714", size = 472501, upload-time = "2025-08-11T15:10:04.735Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/43/c217b1153f0e499652f5e0766da8523ce3480f0a951039c7af115e224d55/ninja-1.13.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5f8e1e8a1a30835eeb51db05cf5a67151ad37542f5a4af2a438e9490915e5b72", size = 638280, upload-time = "2025-08-11T15:10:06.512Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/45/9151bba2c8d0ae2b6260f71696330590de5850e5574b7b5694dce6023e20/ninja-1.13.0-py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:3d7d7779d12cb20c6d054c61b702139fd23a7a964ec8f2c823f1ab1b084150db", size = 642420, upload-time = "2025-08-11T15:10:08.35Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/95752eb635bb8ad27d101d71bef15bc63049de23f299e312878fc21cb2da/ninja-1.13.0-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:d741a5e6754e0bda767e3274a0f0deeef4807f1fec6c0d7921a0244018926ae5", size = 585106, upload-time = "2025-08-11T15:10:09.818Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/31/aa56a1a286703800c0cbe39fb4e82811c277772dc8cd084f442dd8e2938a/ninja-1.13.0-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:e8bad11f8a00b64137e9b315b137d8bb6cbf3086fbdc43bf1f90fd33324d2e96", size = 707138, upload-time = "2025-08-11T15:10:11.366Z" },
+    { url = "https://files.pythonhosted.org/packages/34/6f/5f5a54a1041af945130abdb2b8529cbef0cdcbbf9bcf3f4195378319d29a/ninja-1.13.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b4f2a072db3c0f944c32793e91532d8948d20d9ab83da9c0c7c15b5768072200", size = 581758, upload-time = "2025-08-11T15:10:13.295Z" },
+    { url = "https://files.pythonhosted.org/packages/95/97/51359c77527d45943fe7a94d00a3843b81162e6c4244b3579fe8fc54cb9c/ninja-1.13.0-py3-none-win32.whl", hash = "sha256:8cfbb80b4a53456ae8a39f90ae3d7a2129f45ea164f43fadfa15dc38c4aef1c9", size = 267201, upload-time = "2025-08-11T15:10:15.158Z" },
+    { url = "https://files.pythonhosted.org/packages/29/45/c0adfbfb0b5895aa18cec400c535b4f7ff3e52536e0403602fc1a23f7de9/ninja-1.13.0-py3-none-win_amd64.whl", hash = "sha256:fb8ee8719f8af47fed145cced4a85f0755dd55d45b2bddaf7431fa89803c5f3e", size = 309975, upload-time = "2025-08-11T15:10:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/df/93/a7b983643d1253bb223234b5b226e69de6cda02b76cdca7770f684b795f5/ninja-1.13.0-py3-none-win_arm64.whl", hash = "sha256:3c0b40b1f0bba764644385319028650087b4c1b18cdfa6f45cb39a3669b81aa9", size = 290806, upload-time = "2025-08-11T15:10:18.018Z" },
 ]
 
 [[package]]
@@ -742,6 +824,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
@@ -970,6 +1065,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "wadler-lindig"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/67/cbae4bf7683a64755c2c1778c418fea96d00e34395bb91743f08bd951571/wadler_lindig-0.1.7.tar.gz", hash = "sha256:81d14d3fe77d441acf3ebd7f4aefac20c74128bf460e84b512806dccf7b2cd55", size = 15842, upload-time = "2025-06-18T07:00:42.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl", hash = "sha256:e3ec83835570fd0a9509f969162aeb9c65618f998b1f42918cfc8d45122fe953", size = 20516, upload-time = "2025-06-18T07:00:41.684Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -165,17 +165,14 @@ wheels = [
 [[package]]
 name = "gsplat"
 version = "1.5.3"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/nerfstudio-project/gsplat.git?rev=a337c3dcaca733ddc3e16bdc156c536aaf5e19ba#a337c3dcaca733ddc3e16bdc156c536aaf5e19ba" }
 dependencies = [
     { name = "jaxtyping" },
     { name = "ninja" },
     { name = "numpy" },
+    { name = "nvtx" },
     { name = "rich" },
     { name = "torch" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/94/a0963873708223385ac926112dc3e40ab08297784ac53d95309b4cb5a801/gsplat-1.5.3.tar.gz", hash = "sha256:343f080c470e891ba3c697c03bdf0952cb982d1d535fdc24adb23c2cb4fba906", size = 4743603, upload-time = "2025-07-04T16:50:42.899Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/68/c5cbbdb86421a3f45ac0b52cf9860b1048d089335151d3f37c23aabcbef1/gsplat-1.5.3-py3-none-any.whl", hash = "sha256:515a3773641f5e7f7717acab6276c0b1d6dbcad087b7968ca653337c3189a982", size = 6519041, upload-time = "2025-07-04T16:50:40.559Z" },
 ]
 
 [[package]]
@@ -272,7 +269,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "einops", specifier = "==0.8.1" },
-    { name = "gsplat", marker = "extra == 'render'", specifier = "==1.5.3" },
+    { name = "gsplat", marker = "extra == 'render'", git = "https://github.com/nerfstudio-project/gsplat.git?rev=a337c3dcaca733ddc3e16bdc156c536aaf5e19ba" },
     { name = "huggingface-hub", specifier = "==0.36.2" },
     { name = "numcodecs", specifier = "==0.11.0" },
     { name = "numpy", specifier = "==1.26.4" },
@@ -604,6 +601,17 @@ version = "12.8.55"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/cd/0e8c51b2ae3a58f054f2e7fe91b82d201abfb30167f2431e9bd92d532f42/nvidia_nvtx_cu12-12.8.55-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dd0780f1a55c21d8e06a743de5bd95653de630decfff40621dbde78cc307102", size = 89896, upload-time = "2025-01-23T17:50:44.487Z" },
+]
+
+[[package]]
+name = "nvtx"
+version = "0.2.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/dd/692765e87de30bae1522cdffaa0f2b52949658a92a0fa6d96b1a01eae9d2/nvtx-0.2.15.tar.gz", hash = "sha256:2287d3be05b85661deb386f878d1f536c2e532774aa9ec7a50c434942ed81ae5", size = 121230, upload-time = "2026-03-18T10:01:25.547Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/65/435d10b2041ee082c07d5aed129afd504012c8908796d695f10e66bcc716/nvtx-0.2.15-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:157b80ea9b4db6c8f47f8dbe2fa2e81e7a7f1445bb87f8268f43dec9210b78a1", size = 806443, upload-time = "2026-03-18T10:05:49.308Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bc/be94576ba33af75bcc68a857daade64cb86481764d4fb0f36308b1f6fc85/nvtx-0.2.15-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02bca69ee55e0be41eabf908de9dbcdd18e702c7f49f9aa63fd396ce684ff5d5", size = 808183, upload-time = "2026-03-18T10:11:16.262Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/7a/42109f1cfb1ff9913201cb2b804956a4f003db4c018c2522a3c8066b3a1c/nvtx-0.2.15-cp311-cp311-win_amd64.whl", hash = "sha256:dbe41f78f5a811bd4cdad0a237e5b41a4937d8c2c6c9abdd161091671a598bc0", size = 134631, upload-time = "2026-03-18T10:02:11.247Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This addresses the sky-rendering request in [issue #5's follow-up comment](https://github.com/NVIDIA/instant-nurec/issues/5#issuecomment-5067081408) and makes the reference renderer honor the source camera calibration and trajectory.

- derive a renderable cubemap from the released decoder's canonical RGB and SKY semantics (the public checkpoints omit the learned `sky.*` head)
- retain the observation mask, infill unseen directions from pruned ROAD Gaussians, and merge chunk cubemaps with mask-aware weights
- export a versioned `<stem>.sky.npz` sidecar plus `<stem>.sky.png` atlas next to every PLY, including affine-to-sensor metadata
- render `<stem>.render.png` with the original NCore F-theta calibration, exact per-pixel world rays, exposure START/END poses, and rolling shutter
- add `--merge --render-video` to stream every original source exposure to an H.264 `<stem>.render.mp4` at the source cadence without materializing the full ray sequence
- pin the public gsplat F-theta convergence fix and explicit 3DGUT world-ray path at [`a337c3dc`](https://github.com/nerfstudio-project/gsplat/commit/a337c3dcaca733ddc3e16bdc156c536aaf5e19ba)
- fail explicitly for unsupported camera/distortion models, truncated `--max-chunks`, multi-sequence video input, missing `libx264`, or encoder failures

Standard 3DGS PLY has no environment-map or per-camera ISP fields, so existing PLY viewers continue to show the Gaussian foreground only. The sidecar preserves that non-PLY state for a sidecar-aware renderer, while the PNG/MP4 outputs provide immediately testable source-view renders.

## Validation

- `uv sync --frozen --extra render`
- `.venv/bin/pytest -q` — **542 passed**
- `.venv/bin/ruff check --no-cache .`
- `uv lock --check`
- `git diff --check`
- live CUDA exact-ray F-theta/3DGUT smoke with the pinned gsplat commit
- full public example clip, two chunks plus merge and all 599 source frames:

```bash
INSTANT_NUREC_RUN_ID=calibrated-sky-final .venv/bin/python run_inference.py \
  --model pa-front \
  --ncore-path demo_clip/clips/000da9de-0ee5-465a-9a2d-e7e91d3016bb/pai_000da9de-0ee5-465a-9a2d-e7e91d3016bb.json \
  --output-dir /tmp/instant-nurec-calibrated-final \
  --max-chunks 2 --merge --render-preview --render-video
```

The example completed successfully with **1,918,461** merged Gaussians. The MP4 is H.264 High/yuv420p, **784x448**, exactly **599 frames**, **29.9994 fps**, and **19.967 s**; a full decode found no corrupt, blank, or duplicate frames. Exact source/render comparisons at frames 0/299/598 measured static-feature displacement medians of **0.782 / 0.943 / 0.995 px** (p90 **1.630 / 2.043 / 2.487 px**), with stable horizon and edge-to-edge geometry.

## Renderer scope

The optional outputs are calibrated source-trajectory checks, not arbitrary novel-view renders. This public path currently supports NCore F-theta cameras without external windshield distortion and rejects other models rather than silently approximating them. Dynamic people/vehicles in the released public inference path remain subject to the model's current empty dynamic-layer output; that affects scene content, not camera calibration.
