### PR TITLE
fix(motion): honor sparse camera indices in frame-gap computation

### DIFF
--- a/instant_nurec/utils/motion.py
+++ b/instant_nurec/utils/motion.py
@@ -66,9 +66,13 @@ class TimeRemapping:
         prev_gap_timestamps_us = torch.zeros_like(frames_timestamps_us)
         next_gap_timestamps_us = torch.zeros_like(frames_timestamps_us)
 
-        # Process for each camera
-        num_cameras: int = frames_camera_idxs.unique().shape[0]
-        for camera_idx in range(num_cameras):
+        # Process for each camera. unique_sensor_idx values are indices into
+        # supervision_camera_ids, so they can be sparse (e.g. {0, 2}) when the
+        # context cameras are a strict subset; iterate the distinct values that
+        # are actually present instead of range(num_cameras), otherwise any
+        # camera whose index >= num_cameras never gets its gaps filled and all
+        # of its frames fall back to the 500000 us default below.
+        for camera_idx in frames_camera_idxs.unique().tolist():
             camera_mask = torch.where(frames_camera_idxs == camera_idx)[0]
             sorted_time, sorted_idx = torch.sort(frames_timestamps_us[camera_mask])
             sorted_time_gap = sorted_time[1:] - sorted_time[:-1]

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -93,6 +93,42 @@ def test_compute_frame_gap_two_cameras_independent():
     assert gap[3, 0].item() == 9949 and gap[3, 1].item() == 9949
 
 
+def test_compute_frame_gap_sparse_camera_idxs():
+    """unique_sensor_idx values are indices into supervision_camera_ids and
+    can be sparse when the context cameras are a strict subset (e.g.
+    supervision = [front(0), left(1), right(2)], context = [front, right]).
+
+    Regression test for the former ``range(num_cameras)`` loop, which only
+    visited camera indices ``{0, ..., num_cameras - 1}`` and silently left any
+    camera with ``index >= num_cameras`` (here: right == 2) at the 500000us
+    fallback instead of its true frame gap.
+    """
+    ts = torch.tensor(
+        [
+            [0, 10000],       # front
+            [10000, 20000],   # front
+            [20000, 30000],   # front
+            [50000, 60000],   # right
+            [60000, 70000],   # right
+            [70000, 80000],   # right
+        ]
+    )
+    cam = torch.tensor([0, 0, 0, 2, 2, 2])
+    gap = TimeRemapping._compute_frame_gap(ts, cam)
+    # Every frame of both cameras gets the true 10000us gap — no fallback.
+    assert torch.equal(gap, torch.full_like(gap, 10000))
+
+
+def test_compute_frame_gap_single_sparse_camera():
+    """A single context camera whose supervision index is nonzero (e.g. only
+    ``right`` == 2 in a larger supervision rig) must still get real gaps; the
+    dense loop bug left such a rig entirely at the 500000us fallback."""
+    ts = torch.tensor([[0, 10000], [10000, 20000], [20000, 30000]])
+    cam = torch.tensor([2, 2, 2])
+    gap = TimeRemapping._compute_frame_gap(ts, cam)
+    assert torch.equal(gap, torch.full_like(gap, 10000))
+
+
 def test_compute_frame_gap_single_frame_per_camera_falls_back_to_500000():
     """When a camera has only one frame, both prev and next are missing,
     triggering the 500000us fallback (0.5s default per the docstring)."""


### PR DESCRIPTION
## Problem

`TimeRemapping._compute_frame_gap` (used by the Kelvin motion head to build `prev`/`next` warp-target timestamps) computed the frame gap per camera with:

```python
num_cameras = frames_camera_idxs.unique().shape[0]
for camera_idx in range(num_cameras):
    camera_mask = torch.where(frames_camera_idxs == camera_idx)[0]
```

`frames_camera_idxs` holds `meta.unique_sensor_idx`, which is an index into `supervision_camera_ids` (assigned by `enumerate` in `instantnurec_ncore.py`). The dataset already asserts `context_camera_ids <= supervision_camera_ids`, so when the context rig is a strict subset the indices are sparse. For supervision `[front(0), left(1), right(2), back(3)]` with context `[front, right]`, the loop only visits indices `{0, 1}` and camera `right` (idx 2) is never processed — every one of its frames falls back to the 500000 us default gap.

Reproduction (`_compute_frame_gap`, 10 ms frame spacing):

```
front (camera 0): 10000us  (correct)
right (camera 2): 500000us (wrong -> 0.5s warp target)
```

## Fix

Iterate the distinct camera indices actually present:

```python
for camera_idx in frames_camera_idxs.unique().tolist():
```

This visits exactly the cameras that have frames, independent of their `supervision_camera_ids` slot. For the dense `{0..k-1}` layout the iteration set is identical, so existing behavior is unchanged.

## Verification

- New regression tests in `tests/test_motion.py` cover the sparse subset (`{0, 2}`) and a single sparse camera (`{2}`); both fail against the pre-fix code (`500000` fallback) and pass with the fix.
- Full `tests/test_motion.py` passes (15 tests), `ruff check` clean on both files.