### PR TITLE
feat(training): add standalone two-phase training

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,17 +83,25 @@ source .venv/bin/activate
 
 `setup.sh` calls `uv sync --frozen`, which installs the locked
 dependency tree from `uv.lock`. The build backend is plain `setuptools`
-and every kernel is pure torch, so there are no compiled extensions to
-build.
+and the default inference environment has no additional compiled extensions.
+The optional render and training environments JIT-compile their pinned CUDA
+dependencies on first use.
 
 To bump a dependency, edit `pyproject.toml` and run `uv lock` to
 regenerate the lockfile, then commit both files together.
 
 ## Running tests
 
+The complete test environment includes nvdiffrast under NVIDIA's Source Code
+License (1-Way Commercial). Review `THIRD_PARTY_LICENSE.txt` before installation
+or redistribution.
+
 ```bash
+uv sync --frozen --extra training
 .venv/bin/python -m pytest tests/ -q
 ```
+
+The training extra is required to collect the complete test suite.
 
 Branch coverage is the bar for new functions. Please add a test (or set
 of tests) covering each branch of any new code.

--- a/README.md
+++ b/README.md
@@ -15,19 +15,21 @@ NVIDIA InstantNuRec is a feed-forward neural reconstruction model for autonomous
 
 3D simulation platforms are critical for autonomous driving because they enable end-to-end policy evaluation, thereby reducing development costs and improving safety. In recent years, neural simulation has become predominant, with methods such as NuRec playing a central role; however, these methods remain relatively slow and typically require per-scene tuning. In this work, we present Instant NuRec, a feed-forward neural reconstruction model that turns a multi-view driving log into a fully simulatable 3D Gaussian Splatting (3DGS) world in a single forward pass. The model accepts multi-view input from a calibrated camera rig and emits a layered output consisting of static and dynamic 3DGS layers, a sky cubemap, and per-camera ISP corrections, while providing native support for non-pinhole camera models via 3DGUT. It reconstructs a 10–20-second multi-camera scene in roughly 1.5 seconds and achieves a PSNR on the Waymo Open Dataset that is 2.01 dB above the strongest evaluated baseline. Instant NuRec is deeply integrated into NuRec and is compatible with AlpaSim for closed-loop simulation.
 
-> **Repository scope:** This standalone CLI exports the static scene Gaussians
-> to PLY together with an observation-derived sky cubemap sidecar and optional
-> reference render. The abstract above describes the complete research model,
-> including layers that are not part of this static export path.
+> **Repository scope:** The default inference CLI exports static scene
+> Gaussians, an observation-derived sky cubemap, and optional calibrated
+> renders. The repository also includes two-phase dense front-camera training; see
+> [docs/TRAINING.md](docs/TRAINING.md). Varying-camera, point-query, and TokenGS
+> training are not included in this release.
 
 ![InstantNuRec demo](docs/demo.gif)
 
 ## Pipeline Overview
 
-This repo goes from ncorev4 ingest → frame batch prep → forward pass
-→ 3D-Gaussian PLY and sky-cubemap export. The PLY output is usable
-directly as a static reconstruction, and can also serve as initialization
-for downstream NuRec training to reach higher fidelity.
+The inference path goes from NCore V4 ingest → frame batch prep → forward
+pass → 3D-Gaussian PLY and sky-cubemap export. The training path uses the
+same calibrated data contract for context supervision followed by
+differentiable novel-view rendering. Exported PLYs remain usable directly as
+static reconstructions or as initialization for downstream NuRec refinement.
 
 Instant-NuRec and
 [NuRec](https://docs.nvidia.com/nurec/nurec/reconstruct-av-scene.html)
@@ -43,6 +45,9 @@ per-scene refinement pipeline that produces a high-fidelity USDZ.
 For common errors and fixes (HF auth, driver / CUDA mismatch, OOM at
 chunk-prep, `--max-chunks` truncation), see
 [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
+
+For two-phase full-model training and Waymo Open
+Dataset download/conversion, see [docs/TRAINING.md](docs/TRAINING.md).
 
 - **Usage questions and discussion:** post on the
   [NVIDIA Developer Forum (Omniverse / NuRec)](https://forums.developer.nvidia.com/c/omniverse/platform/nurec/752).
@@ -98,6 +103,12 @@ CUDA dependency is whatever the pinned `torch` wheel ships with.
 The optional calibrated sky-composited renders use `gsplat`, which is not
 installed by `setup.sh`. Install the render extra before using
 `--render-preview` or `--render-video`:
+
+The render and training extras install nvdiffrast under NVIDIA's Source Code
+License (1-Way Commercial). Non-NVIDIA use is limited to non-commercial
+research or evaluation; read the complete terms in
+[THIRD_PARTY_LICENSE.txt](THIRD_PARTY_LICENSE.txt) before installing or
+redistributing these extras.
 
 ```bash
 uv sync --extra render
@@ -260,6 +271,9 @@ For a composited RGB color `c`, apply row `[A | b]` as
 
 To also produce a calibrated still preview and full source-trajectory video:
 
+This command installs the render extra governed by the nvdiffrast terms linked
+in the setup section above.
+
 ```bash
 uv sync --extra render
 python run_inference.py \
@@ -406,10 +420,17 @@ instant-nurec/
 <details>
 <summary><b>Development</b></summary>
 
+The full test environment installs the training extra governed by the
+nvdiffrast terms linked in the setup section above.
+
 ```bash
+uv sync --frozen --extra training
 .venv/bin/python -m pytest tests/ -q
 .venv/bin/ruff check .
 ```
+
+The training extra is required to collect the full test suite. Base-only
+inference installations can run the inference-specific tests directly.
 
 </details>
 

--- a/THIRD_PARTY_LICENSE.txt
+++ b/THIRD_PARTY_LICENSE.txt
@@ -801,3 +801,189 @@ This component is licensed under the Apache License, Version 2.0. The complete
 Apache License 2.0 terms are reproduced in section 2 of this file.
 
 ================================================================================
+
+20. nvdiffrast 0.4.0 (https://github.com/NVlabs/nvdiffrast)
+
+Copyright (c) 2020, NVIDIA Corporation. All rights reserved.
+
+Nvidia Source Code License (1-Way Commercial)
+
+=======================================================================
+
+1. Definitions
+
+"Licensor" means any person or entity that distributes its Work.
+
+"Software" means the original work of authorship made available under
+this License.
+
+"Work" means the Software and any additions to or derivative works of
+the Software that are made available under this License.
+
+The terms "reproduce," "reproduction," "derivative works," and
+"distribution" have the meaning as provided under U.S. copyright law;
+provided, however, that for the purposes of this License, derivative
+works shall not include works that remain separable from, or merely
+link (or bind by name) to the interfaces of, the Work.
+
+Works, including the Software, are "made available" under this License
+by including in or with the Work either (a) a copyright notice
+referencing the applicability of this License to the Work, or (b) a
+copy of this License.
+
+2. License Grants
+
+    2.1 Copyright Grant. Subject to the terms and conditions of this
+    License, each Licensor grants to you a perpetual, worldwide,
+    non-exclusive, royalty-free, copyright license to reproduce,
+    prepare derivative works of, publicly display, publicly perform,
+    sublicense and distribute its Work and any resulting derivative
+    works in any form.
+
+3. Limitations
+
+    3.1 Redistribution. You may reproduce or distribute the Work only
+    if (a) you do so under this License, (b) you include a complete
+    copy of this License with your distribution, and (c) you retain
+    without modification any copyright, patent, trademark, or
+    attribution notices that are present in the Work.
+
+    3.2 Derivative Works. You may specify that additional or different
+    terms apply to the use, reproduction, and distribution of your
+    derivative works of the Work ("Your Terms") only if (a) Your Terms
+    provide that the use limitation in Section 3.3 applies to your
+    derivative works, and (b) you identify the specific derivative
+    works that are subject to Your Terms. Notwithstanding Your Terms,
+    this License (including the redistribution requirements in Section
+    3.1) will continue to apply to the Work itself.
+
+    3.3 Use Limitation. The Work and any derivative works thereof only
+    may be used or intended for use non-commercially. The Work or
+    derivative works thereof may be used or intended for use by Nvidia
+    or its affiliates commercially or non-commercially. As used herein,
+    "non-commercially" means for research or evaluation purposes only
+    and not for any direct or indirect monetary gain.
+
+    3.4 Patent Claims. If you bring or threaten to bring a patent claim
+    against any Licensor (including any claim, cross-claim or
+    counterclaim in a lawsuit) to enforce any patents that you allege
+    are infringed by any Work, then your rights under this License from
+    such Licensor (including the grant in Section 2.1) will terminate
+    immediately.
+
+    3.5 Trademarks. This License does not grant any rights to use any
+    Licensor's or its affiliates' names, logos, or trademarks, except
+    as necessary to reproduce the notices described in this License.
+
+    3.6 Termination. If you violate any term of this License, then your
+    rights under this License (including the grant in Section 2.1) will
+    terminate immediately.
+
+4. Disclaimer of Warranty.
+
+THE WORK IS PROVIDED "AS IS" WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WARRANTIES OR CONDITIONS OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE OR
+NON-INFRINGEMENT. YOU BEAR THE RISK OF UNDERTAKING ANY ACTIVITIES UNDER
+THIS LICENSE.
+
+5. Limitation of Liability.
+
+EXCEPT AS PROHIBITED BY APPLICABLE LAW, IN NO EVENT AND UNDER NO LEGAL
+THEORY, WHETHER IN TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE
+SHALL ANY LICENSOR BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY DIRECT,
+INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING OUT OF
+OR RELATED TO THIS LICENSE, THE USE OR INABILITY TO USE THE WORK
+(INCLUDING BUT NOT LIMITED TO LOSS OF GOODWILL, BUSINESS INTERRUPTION,
+LOST PROFITS OR DATA, COMPUTER FAILURE OR MALFUNCTION, OR ANY OTHER
+COMMERCIAL DAMAGES OR LOSSES), EVEN IF THE LICENSOR HAS BEEN ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGES.
+
+=======================================================================
+
+================================================================================
+
+21. LPIPS 0.1.4 (https://github.com/richzhang/PerceptualSimilarity)
+
+Copyright (c) 2018, Richard Zhang, Phillip Isola, Alexei A. Efros, Eli
+Shechtman, Oliver Wang. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+================================================================================
+
+22. PyTorch Lightning 2.6.5 (https://github.com/Lightning-AI/pytorch-lightning)
+
+Apache License 2.0
+
+Copyright 2018-2021 William Falcon
+
+This component is licensed under the Apache License, Version 2.0. The complete
+Apache License 2.0 terms are reproduced in section 2 of this file.
+
+================================================================================
+
+23. safetensors 0.6.2 (https://github.com/huggingface/safetensors)
+
+Apache License 2.0
+
+This component is licensed under the Apache License, Version 2.0. The complete
+Apache License 2.0 terms are reproduced in section 2 of this file.
+
+================================================================================
+
+24. TorchMetrics 1.7.0 (https://github.com/Lightning-AI/torchmetrics)
+
+Apache License 2.0
+
+Copyright 2020-2022 Lightning-AI team
+
+This component is licensed under the Apache License, Version 2.0. The complete
+Apache License 2.0 terms are reproduced in section 2 of this file.
+
+================================================================================
+
+25. Weights & Biases 0.28.2 (https://github.com/wandb/wandb)
+
+MIT License
+
+Copyright (c) 2021 Weights and Biases, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+================================================================================

--- a/configs/training/full_model_front_context.yaml
+++ b/configs/training/full_model_front_context.yaml
@@ -1,0 +1,100 @@
+# Full-model front-camera phase 1, aligned to the reference training contract.
+# Replace every /absolute/path placeholder before launch.
+seed: 38
+out_dir: /absolute/path/to/training-runs
+phase: context
+reference_profile: full-model-front-v1
+
+logger:
+  name: wandb
+  project: instant-nurec
+  entity: ""
+  run_name: full-model-front-context
+  group: full-model-front
+  tags: [instant-nurec, training, context]
+  job_type: context
+  offline: false
+  log_model: false
+
+dataset:
+  train: &train_ncore
+    ncore_json_list_path: /absolute/path/to/manifests/train.lst
+    open_consolidated: true
+    camera_max_fov_deg: 190.0
+    n_camera_mask_dilation_iterations: 10
+    camera_subsampler: {frame_width: 784, frame_height: 448}
+    context_camera_ids: [camera_front_wide_120fov]
+    supervision_camera_ids: [camera_front_wide_120fov]
+    frame_batch_sampler:
+      name: uniform
+      n_frames_per_sample: 18
+      n_samples_per_sequence: 10
+      frame_gap_timestamp_us: 500000
+    supervision_frame_batch:
+      n_frames_per_camera: 6
+      prepend_timestamps_us: 100000
+      append_timestamps_us: 100000
+      sample_strategy: random
+      camera_subsampler: {frame_width: 1296, frame_height: 720}
+      include_context_frames: false
+    aux_data: {enabled: true, enabled_context: true, semantic_segmentation: true, depth: true, egomask: true}
+  val:
+    <<: *train_ncore
+    ncore_json_list_path: /absolute/path/to/manifests/val.lst
+
+model:
+  freeze_encoder: false
+  # Production phase 1 must initialize from the official DAv3 base weights.
+  # Leave empty only for a mechanics smoke test from random initialization.
+  init_weights_paths:
+    dav3: /absolute/path/to/dav3/base.safetensors
+  post_processing:
+    enabled: true
+    optimization_start_global_step: 1000
+  decoder:
+    name: dpt-decoder
+
+system:
+  max_epochs: 40
+  train_batch_size: 2
+  val_batch_size: 2
+  train_num_workers: 6
+  val_num_workers: 4
+  precision: bf16-mixed
+  accelerator: gpu
+  devices: auto
+  num_nodes: 1
+  strategy: ddp_find_unused_parameters_true
+  enable_render_global_step: 1000000
+  log_every_n_steps: 10
+  checkpoint_monitor: val/psnr
+  checkpoint_mode: max
+  save_top_k: 2
+  optimizer:
+    lr: 0.0001
+    eps: 1.0e-15
+    betas: [0.9, 0.99]
+    weight_decay: 0.0
+    implementation: auto
+  scheduler:
+    warmup_factor: 0.01
+    warmup_steps: 100
+    cosine_factor: 0.0333
+    cosine_factor_progress: 1.0
+
+loss:
+  primitive_sky_cubemap: 1.0
+  primitive_rgb: 0.1
+  primitive_distance: 1.0
+  primitive_distance_gradient: 1.0
+  primitive_semantics: 0.01
+  primitive_normal: 0.2
+  primitive_velocity: 1.0
+  rgb: 0.0
+  lpips: 0.0
+  distance: 0.0
+  background: 0.0
+  distance_min_m: 0.1
+  primitive_distance_max_m: 300.0
+  primitive_distance_gradient_max_m: 50.0
+  render_distance_max_m: 50.0

--- a/configs/training/full_model_front_render.yaml
+++ b/configs/training/full_model_front_render.yaml
@@ -1,0 +1,98 @@
+# Full-model front-camera phase 2, aligned to the reference training contract.
+# Replace every /absolute/path placeholder before launch.
+seed: 38
+out_dir: /absolute/path/to/training-runs
+phase: render
+reference_profile: full-model-front-v1
+
+logger:
+  name: wandb
+  project: instant-nurec
+  entity: ""
+  run_name: full-model-front-render
+  group: full-model-front
+  tags: [instant-nurec, training, render]
+  job_type: render
+  offline: false
+  log_model: false
+
+dataset:
+  train: &train_ncore
+    ncore_json_list_path: /absolute/path/to/manifests/train.lst
+    open_consolidated: true
+    camera_max_fov_deg: 190.0
+    n_camera_mask_dilation_iterations: 10
+    camera_subsampler: {frame_width: 784, frame_height: 448}
+    context_camera_ids: [camera_front_wide_120fov]
+    supervision_camera_ids: [camera_front_wide_120fov]
+    frame_batch_sampler:
+      name: uniform
+      n_frames_per_sample: 18
+      n_samples_per_sequence: 10
+      frame_gap_timestamp_us: 500000
+    supervision_frame_batch:
+      n_frames_per_camera: 6
+      prepend_timestamps_us: 100000
+      append_timestamps_us: 100000
+      sample_strategy: random
+      camera_subsampler: {frame_width: 1296, frame_height: 720}
+      include_context_frames: false
+    aux_data: {enabled: true, enabled_context: true, semantic_segmentation: true, depth: true, egomask: true}
+  val:
+    <<: *train_ncore
+    ncore_json_list_path: /absolute/path/to/manifests/val.lst
+
+model:
+  freeze_encoder: true
+  init_weights_paths:
+    full: /absolute/path/to/context-run/checkpoints/last.ckpt
+  post_processing:
+    enabled: true
+    optimization_start_global_step: 1000
+  decoder:
+    name: dpt-decoder
+
+system:
+  max_epochs: 40
+  train_batch_size: 2
+  val_batch_size: 2
+  train_num_workers: 6
+  val_num_workers: 4
+  precision: bf16-mixed
+  accelerator: gpu
+  devices: auto
+  num_nodes: 1
+  strategy: ddp_find_unused_parameters_true
+  enable_render_global_step: 0
+  log_every_n_steps: 10
+  checkpoint_monitor: val/psnr
+  checkpoint_mode: max
+  save_top_k: 2
+  optimizer:
+    lr: 0.0001
+    eps: 1.0e-15
+    betas: [0.9, 0.99]
+    weight_decay: 0.0
+    implementation: auto
+  scheduler:
+    warmup_factor: 0.01
+    warmup_steps: 100
+    cosine_factor: 0.0333
+    cosine_factor_progress: 1.0
+
+loss:
+  primitive_sky_cubemap: 0.01
+  primitive_rgb: 0.01
+  primitive_distance: 1.0
+  primitive_distance_gradient: 0.01
+  primitive_semantics: 0.01
+  primitive_normal: 0.2
+  primitive_velocity: 1.0
+  rgb: 1.0
+  lpips: 0.2
+  distance: 0.1
+  background: 2.0
+  distance_min_m: 0.1
+  primitive_distance_max_m: 300.0
+  primitive_distance_gradient_max_m: 50.0
+  render_distance_max_m: 50.0

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -1,0 +1,709 @@
+# Training Instant NuRec
+
+This guide covers reproducible full-model training in this standalone
+repository, including the Waymo Open Dataset. The checked-in
+profile `full-model-front-v1` identifies the behavior snapshot implemented by
+the public trainer; it is not a claim that distributed runs will be bitwise
+identical.
+
+## What can be trained here
+
+| Model variant | Decoder | Standalone inference | Standalone training | Notes |
+| --- | --- | --- | --- | --- |
+| Front-camera dense model | dense DPT, one Gaussian per context pixel | yes | yes, two phases | Primary supported training path. |
+| Multiview dense model | dense DPT | yes | fixed camera/frame sets | The random 1/3/5-camera and 12/16/18-frame curriculum is not included. |
+| Point-query `noroad` / `road` | sparse cross-attention | yes | no | The full-model composition deliberately rejects the point-query decoder. |
+| TokenGS | token decoder | no | no | Not included in the public training path. |
+
+The runnable examples therefore cover the dense front-camera model. They
+retain the same model, losses, optimizer, scheduler, camera calibration, and
+two-phase structure as the front-camera reference recipe. The final section
+lists the remaining standalone data/orchestration differences explicitly.
+
+## Reference training contract
+
+The reference is the two-phase dense DAv3 front-camera recipe: context
+supervision first, then differentiable novel-view rendering from the phase-one
+checkpoint.
+
+The standalone trainer preserves these training-step rules:
+
+1. Run model/loss batch-start hooks, including the affine-gradient gate.
+2. Zero all optimizer gradients.
+3. Reconstruct context primitives and differentiable supervision tensors.
+4. Add novel-view rendering only after `enable_render_global_step`.
+5. Mean-reduce the per-item total across the batch and call manual backward.
+6. Skip the optimizer only when every parameter gradient is `None`.
+7. Set epoch/local-step progress and step the progress-based scheduler once.
+
+Forward and backward/step are each wrapped in a distributed exception
+broadcast. If one DDP rank fails, every rank exits instead of leaving peers
+blocked at the backward synchronization point.
+
+The shared numerical contract is:
+
+| Setting | Value |
+| --- | --- |
+| epochs per phase | 40 |
+| precision | BF16 mixed precision |
+| optimizer | fused Adam when NVIDIA Apex is installed |
+| learning rate / epsilon / betas | `1e-4` / `1e-15` / `(0.9, 0.99)` |
+| warmup | 100 steps, starting at factor `0.01` |
+| cosine floor | factor `0.0333` at progress `1.0` |
+| front context | 18 frames at a fixed 0.5 s gap, one `camera_front_wide_120fov`, 784x448, batch 2/GPU |
+| front supervision | 6 frames/camera, 1296x720 |
+| context render gate | `1_000_000` (rendering stays disabled) |
+| render gate | `0` |
+| render initialization | phase-one checkpoint; encoder frozen; GS head reinitialized |
+| render DDP | find-unused-parameters enabled |
+
+The context loss weights are sky cubemap L1 `1.0`, context RGB L1 `0.1`,
+distance L1 `1.0` over 0.1-300 m with a 0.98 quantile reduction, multiscale
+distance-gradient L1 `1.0` over 0.1-50 m at strides 1/2/4/8, semantics CE `0.01`,
+normal cosine `0.2`, and velocity L1 `1.0`. The render phase changes sky,
+context RGB, and distance-gradient regularization to `0.01`, and adds rendered
+RGB MSE `1.0`, LPIPS `0.2`, inverse-depth MSE `0.1`, and background MSE `2.0`.
+Synthetic rendered RGB has weight `0.25`. Only missing normal,
+rendered-distance, and velocity supervision is allowed; all other configured
+labels are required.
+
+### Model-family scope
+
+The front-camera path is the complete two-phase reference implemented here.
+The variable-camera path uses a random camera/frame curriculum that is not yet
+exposed by the standalone data schema. Point-query is a one-stage frozen-encoder path with sparse
+cross-attention; TokenGS remains a model-development path without a public
+production data/schedule contract. Use the support table above when reporting
+which variants were actually trained in this repository.
+
+### Camera calibration and affine color transform
+
+There are two separate transformations and both are used during training:
+
+- Geometry uses the original NCore intrinsics, distortion coefficients,
+  `T_sensor_rig`, rig trajectory, exposure start/end poses, and shutter model.
+  OpenCV pinhole, OpenCV fisheye, and F-theta cameras are supported directly;
+  the F-theta path also preserves the optional bivariate windshield model.
+  Rendering uses calibrated world rays and the original rolling/global shutter
+  trajectory rather than substituting a pinhole approximation.
+- Appearance uses a learned per-camera 3x4 RGB affine matrix `[A | b]`.
+  It is applied after foreground/sky alpha composition as
+  `clamp(A @ rgb + b, 0, 1)`. The affine head is zero-initialized, so the
+  initial transform is identity. Its decoded output is detached until global
+  step 1000 when `model.post_processing.optimization_start_global_step: 1000`.
+
+The affine is an ISP/color correction. It does not replace or modify geometric
+camera intrinsics or trajectories.
+
+The differentiable renderer follows the reference 3DGUT contract: `RGB-d` output,
+`RendererConfig_ParallelBatch`, eval3d enabled, and the unscented transform
+`alpha=1`, `beta=2`, `kappa=0`, image-margin factor `0.1`, with every sigma
+point required to be valid. The returned distance is opacity-weighted and is
+normalized exactly once in the inverse-distance loss. CUDA sky composition
+uses nvdiffrast cube-boundary filtering so gradients remain continuous across
+cube-face seams. Each complete rendered frame is checkpointed with PyTorch's
+non-reentrant checkpoint implementation. Gaussian foreground is saturated
+before sky composition and the learned affine transform, and RGB MSE compacts
+valid pixels before applying the synthetic-pixel weight.
+
+## Environment
+
+Use Python 3.11 and an NVIDIA GPU for real training. From the repository root:
+
+The training extra includes nvdiffrast under NVIDIA's Source Code License
+(1-Way Commercial), whose non-NVIDIA use is limited to non-commercial research
+or evaluation. Read the complete terms in `THIRD_PARTY_LICENSE.txt` before
+installing, and obtain the required release/legal approval for redistribution
+or commercial use.
+
+```bash
+uv sync --frozen --extra training
+source .venv/bin/activate
+python -c 'import torch; print(torch.__version__, torch.cuda.get_device_name())'
+instant-nurec-train --help
+```
+
+The base environment pins `nvidia-ncore==18.7.0`; the training extra pins
+PyTorch Lightning 2.6.5, TorchMetrics 1.7.0, LPIPS 0.1.4, Weights & Biases
+0.28.2, and the calibrated `gsplat` renderer. `optimizer.implementation: auto`
+uses `apex.optimizers.FusedAdam` when available and otherwise logs a warning and
+uses `torch.optim.Adam`. Set `apex-fused-adam` to fail rather than fall back when
+exact optimizer-kernel matching matters.
+
+The first phase-two render JIT-compiles the pinned CUDA kernels for the active
+PyTorch/CUDA/GPU target. Instant NuRec limits the fallback build to calibrated
+3DGUT and its RGB/RGB-d channel counts; explicit `BUILD_3DGUT` and
+`NUM_CHANNELS` environment values still take precedence. Ensure a compatible
+CUDA toolkit/compiler is visible, allow several minutes for the first step,
+and keep the extension cache between workers on the same software image.
+
+Download the exact public DAv3 Base initialization used by the pinned recipe.
+The revision and SHA256 below make the input reproducible:
+
+```bash
+mkdir -p checkpoints/dav3
+hf download depth-anything/DA3-BASE model.safetensors \
+  --revision f4a6c9b3c95e41c82048423d3493a81ec3fa810e \
+  --local-dir checkpoints/dav3
+echo 'e01067dc1659613083d9145a9a2547ccdbe6ccbbf83c4fe7b3e8a4e2bdae78b5  checkpoints/dav3/model.safetensors' \
+  | sha256sum --check
+```
+
+Set `model.init_weights_paths.dav3` to that file in the context-phase
+configuration. The standalone converter was validated against this exact
+541,518,028-byte checkpoint.
+
+## NCore V4 input contract
+
+Each dataset split is a list of absolute NCore V4 sequence-metadata `.json`
+files. Every JSON must resolve all of its component-store paths. A training
+sample requires:
+
+- dynamic `rig -> world` poses;
+- the configured camera and its frames, calibration, and `T_sensor_rig`;
+- intrinsics and masks component groups named `default`;
+- a cuboids group named `default` (it may be empty, but the current loader
+  expects the component to exist).
+
+RGB and any named `ego` mask are always consumed. The configured production
+profile strictly requires RGB, metric distance, semantic flags, and sky
+supervision; a missing required signal raises an error. Only normal,
+render-distance, and velocity supervision are allowed to be unavailable, and
+each omitted loss is reported. A plain Waymo conversion has RGB, poses,
+calibration, lidar, and cuboids (the v18.7 converter writes an empty
+camera-mask group), but not the derived dense depth/semantic/normal auxiliary
+labels. It therefore needs the explicit RGB-only profile below.
+
+The loader discovers optional stores adjacent to each NCore data shard using
+`<data-shard>.aux.<signal>.zarr[.itar]` (legacy `-annotations` archives are also
+accepted). It recognizes the `semantic_segmentation`, `depth`, and `egomask`
+groups. Keep these sidecars beside the base stores and enable them explicitly:
+
+```yaml
+aux_data:
+  enabled: true
+  enabled_context: true
+  semantic_segmentation: true
+  depth: true
+  egomask: true
+```
+
+Depth is loaded as metric distance; context normals are derived from that
+distance and calibrated rays. Semantic class names are mapped to the model's sky,
+road, vehicle, ego, and validity flags. Cuboids supply motion supervision.
+
+### Deterministic train/validation manifests
+
+Generate manifests only after conversion has completed. When the source does
+not provide an official split, make a deterministic whole-sequence split.
+NCore 18.7.0's Waymo converter does not emit manifests:
+
+```bash
+mkdir -p "$NCORE_ROOT/manifests"
+find "$NCORE_ROOT/all" -type f -name '*.json' -print | sort \
+  > "$NCORE_ROOT/manifests/all.lst"
+awk 'NR % 10 == 0' "$NCORE_ROOT/manifests/all.lst" \
+  > "$NCORE_ROOT/manifests/val.lst"
+awk 'NR % 10 != 0' "$NCORE_ROOT/manifests/all.lst" \
+  > "$NCORE_ROOT/manifests/train.lst"
+```
+
+For a small dataset, split by whole sequence, never by frame, to prevent
+trajectory leakage. Inspect the result before launching:
+
+```bash
+wc -l "$NCORE_ROOT/manifests/"{all,train,val}.lst
+comm -12 \
+  <(sort "$NCORE_ROOT/manifests/train.lst") \
+  <(sort "$NCORE_ROOT/manifests/val.lst")
+```
+
+`comm` must print nothing. Point each split at its manifest with
+`dataset.{train,val}.ncore_json_list_path`. Entries may be absolute, or relative
+to `ncore_json_base_path` when that optional base is set. Explicit
+`ncore_json_paths` arrays remain available for short, programmatically generated
+runs and take precedence when both forms are present. All paths in the
+committed examples are placeholders and must be replaced with local absolute
+paths.
+
+### Sampling and retry behavior
+
+The checked-in configs use one train manifest and one validation manifest.
+Every sequence yields ten indexed samples. Each item uses 18 uniformly spaced
+context frames at a 500,000 us gap and six random supervision frames. Dataset
+and optional mixture resampling use a NumPy generator seeded from the first
+eight bytes of `SHA256("{rng_epoch}_{item_index}_{global_seed}")`, interpreted
+as one big-endian integer. `global_seed` is the top-level `seed` in the resolved
+training config; validation keeps `rng_epoch=-1`. Dataloaders are recreated
+each epoch so worker processes see the new training epoch.
+
+Training and validation retry a failed indexed sample with a deterministic
+replacement, without revisiting an already failed index, for at most ten
+attempts. This keeps intentionally short or corrupt outliers from aborting
+distributed training without changing manifest length or epoch permutations.
+Prediction remains one-shot and fails loudly so an inference input is never
+silently replaced.
+
+Always verify that train and validation manifests are disjoint before a quality
+run. A single clip may be reused only for an optimizer smoke test, never for
+quality evaluation.
+
+## Waymo Open Dataset v1.4.3 to NCore V4
+
+Waymo data remains subject to the [Waymo Open Dataset Terms](https://waymo.com/open/terms/).
+Accept them and choose the Perception v1.4.3 release on the official
+[download page](https://waymo.com/open/download/). The files are hosted in the
+[v1.4.3 Cloud Storage bucket](https://console.cloud.google.com/storage/browser/waymo_open_dataset_v_1_4_3).
+
+### 1. Download TFRecords
+
+Install and authenticate the Google Cloud CLI, then list the training objects.
+Download one or a few segments first; the full release is large:
+
+```bash
+export RAW_ROOT=/absolute/path/to/waymo-v1.4.3
+mkdir -p "$RAW_ROOT/train-one"
+
+gcloud storage ls \
+  'gs://waymo_open_dataset_v_1_4_3/individual_files/training/*.tfrecord' \
+  > "$RAW_ROOT/training-objects.txt"
+
+# Pick a specific object from the list so the trial is reproducible.
+WAYMO_OBJECT="$(sed -n '1p' "$RAW_ROOT/training-objects.txt")"
+gcloud storage cp "$WAYMO_OBJECT" "$RAW_ROOT/train-one/"
+```
+
+Keep the original TFRecords immutable and record the object names used for each
+split. Do not put segments from the same source sequence in both train and val.
+After validating the one-segment path, the corresponding full downloads are:
+
+```bash
+mkdir -p "$RAW_ROOT/training" "$RAW_ROOT/validation"
+gcloud storage cp \
+  'gs://waymo_open_dataset_v_1_4_3/individual_files/training/*.tfrecord' \
+  "$RAW_ROOT/training/"
+gcloud storage cp \
+  'gs://waymo_open_dataset_v_1_4_3/individual_files/validation/*.tfrecord' \
+  "$RAW_ROOT/validation/"
+```
+
+These transfers are large. Preserve Waymo's official training/validation split
+rather than repartitioning the combined objects.
+
+### 2. Install the official NVIDIA converter
+
+The supported conversion path is the
+[NCore Waymo converter](https://nvidia.github.io/ncore/conversions/waymo/waymo.html),
+not a hand-written TensorFlow parser. Follow the installation and invocation
+instructions for the pinned NCore v18.7.0 release so its schema and command-line
+contract cannot drift.
+
+The converter implementation and flags are documented in the official pinned
+[converter source](https://github.com/NVIDIA/ncore/blob/v18.7.0/tools/data_converter/waymo/converter.py)
+and [README](https://github.com/NVIDIA/ncore/blob/v18.7.0/tools/data_converter/waymo/README.md).
+
+### 3. Convert to split NCore V4 stores
+
+Use the pinned converter's documented Waymo V4 command with a source root,
+an output directory, camera `camera_front_50fov`, lidar `lidar_top`, and the
+`separate-sensors` profile. If GPU conversion is unavailable, follow the
+converter's documented CPU mode; it is slower but produces the same NCore
+layout. The conversion
+smoke test for this guide used an already available Waymo v1.4.2 TFRecord; the
+download instructions target v1.4.3, but that v1.4.3 download was not exercised
+here.
+
+NCore 18.7.0 has no `--duration-sec` option. To make a bounded conversion,
+place only the selected TFRecords directly under `RAW_TRAIN_ONE`; its TFRecord
+glob is non-recursive. The output uses the
+OpenCV pinhole camera model `camera_front_50fov` and lidar `lidar_top`; the
+standalone trainer supports that pinhole calibration directly.
+
+Once the bounded conversion passes, repeat it for `$RAW_ROOT/training` into
+`$NCORE_ROOT/train`, and for `$RAW_ROOT/validation` into `$NCORE_ROOT/val`.
+Generate manifests without mixing the official splits:
+
+```bash
+mkdir -p "$NCORE_ROOT/manifests"
+find "$NCORE_ROOT/train" -type f -name '*.json' -print | sort \
+  > "$NCORE_ROOT/manifests/train.lst"
+find "$NCORE_ROOT/val" -type f -name '*.json' -print | sort \
+  > "$NCORE_ROOT/manifests/val.lst"
+```
+
+For Waymo, use a direct train/val dataset. In both
+splits, select `EXTERNAL` cuboids because the v18.7.0 converter writes every
+Waymo box with that source. `AUTOLABEL` and `GT_ANNOTATION` select no tracks.
+The converter emits no dense auxiliary sidecars, so disable them explicitly:
+
+```yaml
+dataset:
+  train: &waymo
+    ncore_json_list_path: /absolute/path/to/manifests/train.lst
+    camera_subsampler: {frame_width: 784, frame_height: 448}
+    context_camera_ids: [camera_front_50fov]
+    supervision_camera_ids: [camera_front_50fov]
+    frame_batch_sampler:
+      name: uniform
+      n_frames_per_sample: 18
+      n_samples_per_sequence: 10
+      frame_gap_timestamp_us: 500000
+    supervision_frame_batch:
+      n_frames_per_camera: 6
+      prepend_timestamps_us: 100000
+      append_timestamps_us: 100000
+      sample_strategy: random
+      camera_subsampler: {frame_width: 1296, frame_height: 720}
+      include_context_frames: false
+    cuboid_tracks_params:
+      track_label_source: EXTERNAL
+    aux_data:
+      enabled: false
+      enabled_context: false
+      semantic_segmentation: false
+      depth: false
+      egomask: false
+  val:
+    <<: *waymo
+    ncore_json_list_path: /absolute/path/to/manifests/val.lst
+```
+
+The converter stores the original pinhole intrinsics, rational radial,
+tangential and thin-prism distortion, camera extrinsics, and poses. Do not
+rewrite these values to imitate another camera model. This repository accepts
+lowercase `cyclist` as dynamic because the official Waymo converter emits that
+spelling.
+
+An exercised converted sequence completed a reduced two-frame CUDA smoke run:
+one context optimization step, resume to the next global step, and one render
+optimization step with the RGB-only profile. It retained the full
+OpenCV pinhole distortion and rolling-shutter calibration; render training also
+created nonzero optimizer state for the affine camera transform. Apex was not
+installed, so this smoke used the documented PyTorch Adam fallback. It verifies
+the conversion/loader/optimizer/checkpoint/render path, not production quality
+or the unexercised v1.4.3 download.
+
+## Configure a run
+
+Start from:
+
+- `configs/training/full_model_front_context.yaml`
+- `configs/training/full_model_front_render.yaml`
+
+Replace the manifest, output, and initialization path placeholders in both
+files. For Waymo, use the direct dataset block above and the RGB-only losses
+below.
+
+The checked-in configs log to W&B project `instant-nurec`. Leave
+`logger.entity` empty to use the account's default entity, or set it explicitly. Authenticate once with
+`wandb login`, and change `logger.run_name`, `group`, and `tags` to identify the
+experiment. `run_id` is also the stable W&B run ID; resume from a copy of the
+run's `resolved.yaml` so checkpoint and W&B histories continue together.
+Validate the resolved config without allocating a GPU:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+from instant_nurec.training.run import load_training_config
+
+for name in (
+    "configs/training/full_model_front_context.yaml",
+    "configs/training/full_model_front_render.yaml",
+):
+    cfg = load_training_config(Path(name))
+    print(name, cfg.phase, cfg.system.max_epochs, cfg.reference_profile)
+PY
+```
+
+### Phase 1: context supervision
+
+Phase 1 trains the encoder, DPT context geometry/RGB/semantic/motion heads, and
+sky decoder. Rendering is disabled by the one-million-step gate, so neither the
+Gaussian head nor affine output is consumed; both are intentionally unused in
+this phase, and phase 2 reinitializes the Gaussian head. Independently sampled
+supervision frames are still used to build the observed sky-cubemap target.
+
+```bash
+instant-nurec-train \
+  --config configs/training/full_model_front_context.yaml
+```
+
+For reproducible training, initialize the DAv3 encoder from the intended base
+safetensors through `model.init_weights_paths.dav3`.
+The loader converts the official DAv3 keys into the encoder, DPT
+reassembly, and depth head; it zero-initializes the context and Gaussian output
+heads. Sky starts from its model initialization and the affine linear layer
+starts at identity. Do not silently train a production run from random weights.
+A random initialization is useful only for testing forward, backward,
+optimizer, checkpoint, and resume mechanics.
+
+### Phase 2: differentiable render supervision
+
+Set `model.init_weights_paths.full` to phase 1's `last.ckpt`. Phase 2 resets the
+Gaussian head, resets the affine linear layer to identity, freezes the encoder,
+renders every supervision camera with its original calibration, and enables
+the render losses from step zero.
+
+```bash
+instant-nurec-train \
+  --config configs/training/full_model_front_render.yaml
+```
+
+Outputs are written under `<out_dir>/<run_id>/`:
+
+```text
+<run>/
+├── resolved.yaml
+├── checkpoints/
+│   ├── last.ckpt
+│   └── epoch=...-psnr=....ckpt
+└── wandb/...
+```
+
+Every checkpoint stores `training_contract` with the reference profile,
+phase, selected optimizer implementation, and world size.
+
+The render phase reports `train/psnr` and `val/psnr` using the official metric:
+after calibrated Gaussian/sky composition and affine ISP correction, it keeps
+pixels with `RGB_LABEL` and without `INVALID`, then computes one global
+`10 * log10(1 / MSE)` value with data range 1. Synthetic and harmonized RGB
+pixels remain included. Phase 1 does not render; its increasing `val/psnr =
+0.1 * epoch` is checkpoint plumbing only and must never be read as image
+quality. Use a quality gate only when the train/validation split, resolution,
+masks, initialization, and evaluation protocol are all documented; do not
+reuse thresholds across datasets or protocols.
+
+### A bounded end-to-end smoke test
+
+Before a long run, copy each production config and change only:
+
+```yaml
+system:
+  max_epochs: 1
+  train_batch_size: 1
+  val_batch_size: 1
+  train_num_workers: 0
+  val_num_workers: 0
+  devices: 1
+  num_nodes: 1
+  limit_train_batches: 1
+  limit_val_batches: 1
+  save_every_n_train_steps: 1
+```
+
+For a lower-memory plumbing test, also use four context frames and a 196x112
+context crop plus one 196x112 supervision frame. That deliberately changes the
+model/data contract and is not a quality-equivalence run. A successful
+smoke test must complete backward and optimizer step, write `last.ckpt`, then
+resume that checkpoint for at least one more step.
+
+## Distributed training
+
+The batch sizes in the configs are per process/GPU. On one machine, set
+`devices` to the GPU count and use `strategy:
+ddp_find_unused_parameters_true` for both phases. Context leaves the Gaussian
+head and affine output unused while rendering is gated off; render can also
+have conditional branches. The launcher automatically upgrades `auto`, `ddp`,
+or explicit find-unused-false to this safe strategy whenever the requested
+world size is distributed. Lightning starts the local workers:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1,2,3 \
+  instant-nurec-train --config /path/to/four-gpu-config.yaml
+```
+
+For multi-node work, set the same `num_nodes`, `devices`, config, code commit,
+and visible dataset paths on every node, then launch through the site's Slurm
+or torchrun integration. Do not wrap a Lightning self-spawning `devices: 8`
+run in a second eight-process launcher. Confirm from startup logs that world
+size equals `num_nodes * devices`. Generate one run ID before launch and export
+it to every rank as `INSTANT_NUREC_RUN_ID`; otherwise independently parsed
+YAMLs would generate different output directories and W&B IDs:
+
+```bash
+export INSTANT_NUREC_RUN_ID="context-$(date -u +%Y%m%d-%H%M%S)"
+```
+
+## Checkpoint initialization and resume
+
+These are different operations:
+
+- `model.init_weights_paths.dav3` initializes phase 1 from the official DAv3
+  safetensors; `model.init_weights_paths.full` initializes a new run from a
+  complete model/Lightning state dict. Use `full` for phase 2. Optimizer,
+  scheduler, epoch, and global step start fresh.
+- `resume_from_checkpoint` restores a Lightning training checkpoint, including
+  optimizer, scheduler, epoch, and global step. Use it only to continue the
+  same phase/config.
+
+Training checkpoints are mid-epoch resumable. The checkpoint stores the next
+unprocessed training batch, and the reconstructed sampler skips exactly the
+completed prefix of the same seed/epoch permutation. Its reported length stays
+equal to the full epoch length; this is intentional so Lightning continues
+with the original epoch-global `batch_idx`; the progress-based scheduler then
+follows the same learning-rate sequence. In DDP, Lightning replaces
+the random sampler inside the skip batch sampler with its distributed sampler,
+while retaining the restored batch cursor. Keep the seed, dataset/manifests,
+batch size, world size, and sampler inputs unchanged when resuming.
+
+To resume, copy the original resolved YAML, add:
+
+```yaml
+resume_from_checkpoint: /absolute/path/to/run/checkpoints/last.ckpt
+```
+
+Keep `phase`, model topology, data ordering, world size, optimizer, and schedule
+unchanged. Inspect the stored contract before resuming:
+
+```bash
+python - /path/to/last.ckpt <<'PY'
+import sys
+import torch
+
+checkpoint = torch.load(sys.argv[1], map_location="cpu", weights_only=False)
+print(checkpoint["training_contract"])
+print("epoch", checkpoint["epoch"], "global_step", checkpoint["global_step"])
+PY
+```
+
+### Slurm preemption
+
+`system.save_on_preemption` defaults to `true`. On POSIX systems the trainer
+handles `SIGUSR1` by finishing the current batch, atomically publishing
+`checkpoints/last.ckpt`, marking W&B as preempting when supported, and exiting
+with status 1. Checkpointing is collective in DDP, but the host launcher only
+needs to forward the signal to rank zero; the callback synchronizes the
+decision across ranks. An outer Slurm script can then call `scontrol requeue`
+from the host. No Slurm executable or cluster-specific requeue logic is needed
+inside the training container.
+
+The data-cursor callback is registered before both periodic checkpoints and
+the signal checkpoint, so the just-completed batch is not replayed. A signal
+during validation restarts the validation loop from its beginning after
+resume; this is required because epoch-level metric accumulators cannot be
+recovered exactly in the middle of validation. Disable the handler only when
+another launcher owns `SIGUSR1`:
+
+```yaml
+system:
+  save_on_preemption: false
+```
+
+## No-auxiliary versus production-auxiliary training
+
+The production loss profile is strict: RGB, context distance, semantics, sky,
+render RGB/LPIPS, and render-background inputs must be present when their
+weights are nonzero. Only normal, render-distance, and velocity may be reported
+as unavailable and omitted. This prevents an apparently successful RGB-only
+run from silently claiming full-supervision equivalence.
+
+| Data | Active supervision | Intended use |
+| --- | --- | --- |
+| official Waymo-to-NCore conversion | RGB; calibration/trajectory; lidar/EXTERNAL cuboids | ingestion, camera-model, render, optimizer, checkpoint and resume validation with the explicit profile below |
+| RGB-only NCore fixture | RGB; masks/cuboids present in the base stores | loader and data-integrity smoke tests only |
+| production NCore plus adjacent derived aux | RGB, metric distance, semantic flags, derived normals, motion/cuboids | full reference loss profile and model-quality training |
+
+For a Waymo plumbing run, use this context-phase loss block:
+
+```yaml
+loss:
+  primitive_sky_cubemap: 0.0
+  primitive_rgb: 0.1
+  primitive_distance: 0.0
+  primitive_distance_gradient: 0.0
+  primitive_semantics: 0.0
+  primitive_normal: 0.0
+  primitive_velocity: 0.0
+  rgb: 0.0
+  lpips: 0.0
+  distance: 0.0
+  background: 0.0
+```
+
+In render phase keep context RGB plus image reconstruction, but leave all
+derived-label losses disabled:
+
+```yaml
+loss:
+  primitive_sky_cubemap: 0.0
+  primitive_rgb: 0.01
+  primitive_distance: 0.0
+  primitive_distance_gradient: 0.0
+  primitive_semantics: 0.0
+  primitive_normal: 0.0
+  primitive_velocity: 0.0
+  rgb: 1.0
+  lpips: 0.2
+  distance: 0.0
+  background: 0.0
+```
+
+Do not interpret an RGB-only run as a reproduction of the released model's
+quality. In particular, lidar points alone are not automatically rasterized to
+`CameraFrameLabels.metric_distance`, and Waymo's class labels are not
+automatically converted into per-pixel semantic flags. Those dense aux
+labels must be generated and attached in the same coordinate frame and mask
+conventions as the cameras.
+
+## Validation checklist
+
+Use this order; stop at the first failure:
+
+1. Parse both YAML files and confirm the reference profile.
+2. Open every NCore JSON and all referenced stores.
+3. Decode the configured camera, validate monotonic timestamps, finite
+   intrinsics/extrinsics, and overlapping rig-pose coverage.
+4. Materialize one batch and confirm context/supervision image counts and
+   resolutions.
+5. Run a CPU loss/optimizer unit test.
+6. Run one true CUDA context optimization step and save a checkpoint.
+7. Resume it and confirm the global step advances.
+8. Initialize render phase from that checkpoint and run one calibrated CUDA
+   render/backward step.
+9. Run one short validation epoch and inspect W&B for finite loss and, in
+   phase 2, the masked `val/psnr` metric.
+10. Only then remove batch limits and launch the 40-epoch phases.
+
+Useful gates from the repository root are:
+
+```bash
+pytest -q
+ruff check instant_nurec tests
+```
+
+The standalone loop now reproduces the official masked RGB PSNR. Compare model
+quality only when checkpoint, cameras, frames, masks, resolution, and metric
+protocol are the same; the paper's Waymo PSNR is a separate evaluation.
+
+## Supported scope and limitations
+
+No known unimplemented training-step, configured-loss, calibrated-renderer, or
+mixture-sampling blocker remains for the dense DAv3 front-camera two-phase
+recipe. Keep these bounded differences visible in experiment reports:
+
+- Random varying-camera/frame curricula, point-query training, and TokenGS
+  training are not exposed. Legacy TokenGS checkpoint-key conversion is also
+  absent; it is not used by the DAv3 context-to-render path.
+- Cuboid loading ranges tracks from context frames only and does not implement
+  the negative full-clip sentinel. With the stock 1 s extrapolation and
+  supervision window of +/-0.1 s, this does not truncate the front-camera recipe.
+- Apex FusedAdam is optional. The PyTorch Adam fallback and public CUDA kernels
+  are not bitwise substitutes for the reference optimizer and renderer stack.
+- CUDA sky filtering follows the nvdiffrast cube contract; the CPU-only utility
+  fallback samples faces independently and is not seam-equivalent. An
+  all-invalid rendered RGB mask preserves the reference NaN result, while an
+  all-invalid background mask is reported as skipped.
+- Lowercase Waymo `cyclist` is deliberately treated as dynamic, correcting the
+  converter/class-list mismatch present across the pinned repositories.
+- W&B logs losses, learning rate, and RGB PSNR, but not depth/media dashboards.
+
+The real-data verification completed bounded context, resume, and render
+optimization steps; it did not run both 40-epoch phases to convergence, did not
+download Waymo v1.4.3, and did not establish model-quality equivalence. Full
+production claims require disjoint manifests, complete auxiliary labels, the
+same initialization weights/hardware/optimizer, and end-to-end validation of
+the resulting checkpoints.
+
+Record the standalone Git commit, `resolved.yaml`, NCore converter version,
+Waymo object list or dataset revision, GPU count/type, optimizer implementation,
+and emitted checkpoint contract with every result.

--- a/instant_nurec/config_schema/dataset.py
+++ b/instant_nurec/config_schema/dataset.py
@@ -47,6 +47,7 @@ class AdaptiveSequentialFrameBatchSamplerConfig(BaseConfigSchema):
     context-camera count.
     """
 
+    name: Literal["adaptive_sequential", "uniform"] = "adaptive_sequential"
     n_frames_per_sample: int = Field(
         default=18,
         gt=0,
@@ -71,6 +72,11 @@ class AdaptiveSequentialFrameBatchSamplerConfig(BaseConfigSchema):
             "mean more chunks needed to cover a clip."
         ),
     )
+    frame_gap_timestamp_us: int = Field(
+        default=500_000,
+        gt=0,
+        description="Fixed timestamp gap used when name=uniform (the reference training sampler).",
+    )
 
 
 class CameraSubsamplerConfig(BaseConfigSchema):
@@ -88,18 +94,78 @@ class CameraSubsamplerConfig(BaseConfigSchema):
     )
 
 
-class NCoreInstantNuRecDatasetConfig(BaseConfigSchema):
-    """Predict-side config for the NCorev4 dataset loader.
+class SupervisionFrameBatchConfig(BaseConfigSchema):
+    """Training-only novel-view sampling relative to each context chunk."""
 
-    Required field: ``ncore_json_paths`` — an explicit list of absolute
-    sequence-metadata JSON paths. The CLI's ``resolve_ncore_paths``
-    helper resolves a ``--ncore-path`` (single ``.json`` or ``.lst``)
-    into this list before constructing the config.
+    n_frames_per_camera: int = Field(
+        default=0,
+        ge=0,
+        description="Supervision frames per camera. Zero keeps predict-mode behavior.",
+    )
+    camera_subsampler: CameraSubsamplerConfig = Field(default_factory=CameraSubsamplerConfig)
+    prepend_timestamps_us: int = Field(default=0, ge=0)
+    append_timestamps_us: int = Field(default=0, ge=0)
+    sample_strategy: Literal["random", "stratified"] = "random"
+    include_context_frames: bool = Field(
+        default=False,
+        description="Union context frame indices into the sampled supervision batch.",
+    )
+
+
+class NCoreAuxDataConfig(BaseConfigSchema):
+    """Optional adjacent NCore auxiliary labels used by training losses."""
+
+    enabled: bool = False
+    enabled_context: bool = False
+    semantic_segmentation: bool = True
+    depth: bool | str = Field(
+        default=True,
+        description=(
+            "True to load adjacent NCore depth, False to disable depth, or a path "
+            "to override the adjacent depth store. Supported template variable: {{clip_id}}."
+        ),
+    )
+    egomask: bool = True
+
+
+class ExternalSupervisionCameraIdConfig(BaseConfigSchema):
+    """Camera stored in a sequence-relative external NCore V4 archive."""
+
+    ncore_path: str = Field(
+        description="Path to the external NCore archive, relative to the sequence JSON directory."
+    )
+    camera_id: str
+    unique_sensor_idx: int = Field(
+        ge=0,
+        description="Context-camera affine index intentionally shared by this supervision camera.",
+    )
+    sample_ratio: float = Field(
+        default=1.0,
+        ge=0.0,
+        le=1.0,
+        description="Additional frame downsampling ratio after supervision sampling.",
+    )
+
+
+class NCoreInstantNuRecDatasetConfig(BaseConfigSchema):
+    """NCore V4 sequence configuration for prediction and training.
+
+    Supply either ``ncore_json_paths`` directly or an official-style
+    ``ncore_json_list_path`` manifest. Relative manifest entries can be
+    anchored with ``ncore_json_base_path``.
     """
 
     ncore_json_paths: list[str] = Field(
+        default_factory=list,
         description="Absolute paths to ncorev4 sequence metadata JSON files.",
-        min_length=1,
+    )
+    ncore_json_list_path: str | None = Field(
+        default=None,
+        description="Path to a newline-delimited manifest of NCore V4 sequence JSON files.",
+    )
+    ncore_json_base_path: str | None = Field(
+        default=None,
+        description="Optional base used to resolve relative entries in ncore_json_list_path.",
     )
     open_consolidated: bool = Field(default=True)
     camera_max_fov_deg: float = Field(
@@ -114,7 +180,7 @@ class NCoreInstantNuRecDatasetConfig(BaseConfigSchema):
         description="Image resize and crop applied before model inference.",
     )
 
-    context_camera_ids: list[str] = Field(
+    context_camera_ids: list[str | ExternalSupervisionCameraIdConfig] = Field(
         default_factory=lambda: ["camera_front_wide_120fov"],
         description="A list of camera ids, such as `camera_front_wide_120fov`",
     )
@@ -122,14 +188,37 @@ class NCoreInstantNuRecDatasetConfig(BaseConfigSchema):
     frame_batch_sampler: AdaptiveSequentialFrameBatchSamplerConfig = Field(
         default_factory=AdaptiveSequentialFrameBatchSamplerConfig,
     )
-    supervision_camera_ids: list[str] = Field(
+    supervision_camera_ids: list[str | ExternalSupervisionCameraIdConfig] = Field(
         default_factory=lambda: ["camera_front_wide_120fov"],
         description="A list of camera ids, such as `camera_front_wide_120fov`. This is also used to determine the canonical order of cameras in unique sensor idx",
+    )
+    supervision_frame_batch: SupervisionFrameBatchConfig = Field(
+        default_factory=SupervisionFrameBatchConfig,
+        description="Independent supervision sampling used by full-model training.",
     )
 
     cuboid_tracks_params: NCoreInstantNuRecCuboidTracksParamsConfig = Field(
         default_factory=NCoreInstantNuRecCuboidTracksParamsConfig,
     )
+    aux_data: NCoreAuxDataConfig = Field(default_factory=NCoreAuxDataConfig)
+
+    def model_post_init(self, __context) -> None:
+        if not self.ncore_json_paths and self.ncore_json_list_path is None:
+            raise ValueError("Either ncore_json_paths or ncore_json_list_path must be provided")
+
+
+class NCoreMixtureComponentConfig(BaseConfigSchema):
+    sample_ratio: float = Field(default=1.0, ge=0.0)
+    config: NCoreInstantNuRecDatasetConfig
+
+
+class NCoreMixtureDatasetConfig(BaseConfigSchema):
+    """Official-style named mixture of independently configured NCore datasets."""
+
+    mixture: dict[str, NCoreMixtureComponentConfig] = Field(min_length=1)
+
+
+NCoreTrainDatasetConfig = NCoreInstantNuRecDatasetConfig | NCoreMixtureDatasetConfig
 
 
 
@@ -139,4 +228,6 @@ class InstantNuRecSplitsConfig(BaseConfigSchema):
     split; pydantic ``extras="ignore"`` drops the train/val/test entries
     that the pretrained ``parsed.yaml`` still carries."""
 
+    train: NCoreTrainDatasetConfig | None = Field(default=None, description="Dataset used for training")
+    val: NCoreTrainDatasetConfig | None = Field(default=None, description="Dataset used for validation")
     predict: NCoreInstantNuRecDatasetConfig | None = Field(default=None, description="Dataset to use in prediction mode")

--- a/instant_nurec/config_schema/models.py
+++ b/instant_nurec/config_schema/models.py
@@ -142,6 +142,11 @@ class KelvinSkyCubemapDecoderConfig(BaseConfigSchema):
     checkpointing: bool = Field(default=True, description="Whether to use checkpointing for the cubemap decoder")
 
 
+class PostProcessingConfig(BaseConfigSchema):
+    enabled: bool = Field(default=True)
+    optimization_start_global_step: int = Field(default=0, ge=0)
+
+
 class KelvinModelConfig(BaseConfigSchema):
     """
     Configuration for the Kelvin model.
@@ -159,6 +164,12 @@ class KelvinModelConfig(BaseConfigSchema):
 
     scene_rescale: float = Field(default=0.15, description="Rescale scenes for model input and output")
     sky: KelvinSkyCubemapDecoderConfig = Field(default_factory=KelvinSkyCubemapDecoderConfig)
+    post_processing: PostProcessingConfig = Field(default_factory=PostProcessingConfig)
+    freeze_encoder: bool = Field(default=False)
+    init_weights_paths: dict[str, str] = Field(
+        default_factory=dict,
+        description="Component paths or a full phase-one checkpoint used to initialize training.",
+    )
 
     patch_shape: Tuple[int, int] = Field(default=(14, 14))
 

--- a/instant_nurec/config_schema/train.py
+++ b/instant_nurec/config_schema/train.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+
+from pathlib import Path
+from typing import Literal
+
+import shortuuid
+
+from instant_nurec.config_schema.base_schema import BaseConfigSchema, Field
+from instant_nurec.config_schema.dataset import InstantNuRecSplitsConfig
+from instant_nurec.config_schema.models import KelvinModelConfig
+
+
+class TrainingOptimizerConfig(BaseConfigSchema):
+    lr: float = Field(default=1.0e-4, gt=0)
+    eps: float = Field(default=1.0e-15, gt=0)
+    betas: tuple[float, float] = Field(default=(0.9, 0.99))
+    weight_decay: float = Field(default=0.0, ge=0)
+    implementation: Literal["auto", "apex-fused-adam", "torch-adam"] = "auto"
+
+
+class TrainingSchedulerConfig(BaseConfigSchema):
+    warmup_factor: float = Field(default=0.01, gt=0, le=1)
+    warmup_steps: int = Field(default=100, ge=1)
+    cosine_factor: float = Field(default=0.0333, gt=0, le=1)
+    cosine_factor_progress: float = Field(default=1.0, gt=0, le=1)
+
+
+class TrainingLoggerConfig(BaseConfigSchema):
+    """Experiment logger settings for standalone training."""
+
+    name: Literal["csv", "wandb"] = "csv"
+    project: str = "instant-nurec"
+    entity: str = ""
+    run_name: str | None = None
+    group: str = ""
+    tags: list[str] = Field(default_factory=list)
+    job_type: str = ""
+    offline: bool = False
+    log_model: bool = False
+
+
+class TrainingSystemConfig(BaseConfigSchema):
+    max_epochs: int = Field(default=40, ge=1)
+    train_batch_size: int = Field(default=2, ge=1)
+    val_batch_size: int = Field(default=2, ge=1)
+    train_num_workers: int = Field(default=6, ge=0)
+    val_num_workers: int = Field(default=4, ge=0)
+    precision: Literal["bf16-mixed", "32-true"] = "bf16-mixed"
+    accelerator: Literal["auto", "cpu", "gpu"] = "auto"
+    devices: int | str = "auto"
+    num_nodes: int = Field(default=1, ge=1)
+    strategy: str = "auto"
+    deterministic: bool | Literal["warn"] = Field(
+        default="warn",
+        description=(
+            "Lightning deterministic policy. 'warn' preserves deterministic dataset sampling "
+            "while permitting CUDA bicubic backward, which has no deterministic implementation."
+        ),
+    )
+    enable_render_global_step: int = Field(default=1_000_000, ge=0)
+    limit_train_batches: int | float | None = None
+    limit_val_batches: int | float | None = None
+    log_every_n_steps: int = Field(default=10, ge=1)
+    save_every_n_train_steps: int | None = Field(default=None, ge=1)
+    save_on_preemption: bool = Field(
+        default=True,
+        description="Atomically save checkpoints/last.ckpt and exit when SIGUSR1 is received.",
+    )
+    checkpoint_monitor: str = "val/psnr"
+    checkpoint_mode: Literal["min", "max"] = "max"
+    save_top_k: int = Field(default=2, ge=0)
+    optimizer: TrainingOptimizerConfig = Field(default_factory=TrainingOptimizerConfig)
+    scheduler: TrainingSchedulerConfig = Field(default_factory=TrainingSchedulerConfig)
+
+
+class TrainingLossConfig(BaseConfigSchema):
+    primitive_sky_cubemap: float = Field(default=1.0, ge=0)
+    primitive_rgb: float = Field(default=0.1, ge=0)
+    primitive_distance: float = Field(default=1.0, ge=0)
+    primitive_distance_gradient: float = Field(default=1.0, ge=0)
+    primitive_semantics: float = Field(default=0.01, ge=0)
+    primitive_normal: float = Field(default=0.2, ge=0)
+    primitive_velocity: float = Field(default=1.0, ge=0)
+    rgb: float = Field(default=0.0, ge=0)
+    lpips: float = Field(default=0.0, ge=0)
+    distance: float = Field(default=0.0, ge=0)
+    background: float = Field(default=0.0, ge=0)
+    distance_min_m: float = Field(default=0.1, gt=0)
+    primitive_distance_max_m: float = Field(default=300.0, gt=0)
+    primitive_distance_gradient_max_m: float = Field(default=50.0, gt=0)
+    render_distance_max_m: float = Field(default=50.0, gt=0)
+
+    @classmethod
+    def context_phase(cls) -> "TrainingLossConfig":
+        return cls()
+
+    @classmethod
+    def render_phase(cls) -> "TrainingLossConfig":
+        return cls(
+            primitive_sky_cubemap=0.01,
+            primitive_rgb=0.01,
+            primitive_distance=1.0,
+            primitive_distance_gradient=0.01,
+            primitive_semantics=0.01,
+            primitive_normal=0.2,
+            primitive_velocity=1.0,
+            rgb=1.0,
+            lpips=0.2,
+            distance=0.1,
+            background=2.0,
+        )
+
+
+class TrainingConfig(BaseConfigSchema):
+    """Standalone full-model training configuration."""
+
+    seed: int = 38
+    out_dir: Path
+    run_id: str = Field(default_factory=shortuuid.uuid)
+    phase: Literal["context", "render"] = "context"
+    reference_profile: str = "full-model-front-v1"
+    dataset: InstantNuRecSplitsConfig
+    model: KelvinModelConfig = Field(default_factory=KelvinModelConfig)
+    system: TrainingSystemConfig = Field(default_factory=TrainingSystemConfig)
+    logger: TrainingLoggerConfig = Field(default_factory=TrainingLoggerConfig)
+    loss: TrainingLossConfig | None = None
+    resume_from_checkpoint: Path | None = None
+
+    def model_post_init(self, __context) -> None:
+        if (environment_run_id := os.environ.get("INSTANT_NUREC_RUN_ID")) is not None:
+            self.run_id = environment_run_id
+        if self.dataset.train is None:
+            raise ValueError("dataset.train is required")
+        if self.phase == "render":
+            self.system.enable_render_global_step = 0
+            if self.loss is None:
+                self.loss = TrainingLossConfig.render_phase()
+            if self.system.strategy == "auto":
+                self.system.strategy = "ddp_find_unused_parameters_true"
+        elif self.loss is None:
+            self.loss = TrainingLossConfig.context_phase()

--- a/instant_nurec/datasets/datamodule.py
+++ b/instant_nurec/datasets/datamodule.py
@@ -36,6 +36,7 @@ class InstantNuRecDataModule:
             frame_width=dataset_config.camera_subsampler.frame_width,
             frame_height=dataset_config.camera_subsampler.frame_height,
             n_frames_per_sample=dataset_config.frame_batch_sampler.n_frames_per_sample,
+            global_seed=self.instantnurec_config.seed,
         )
         return DataLoader(
             self.predict_dataset,

--- a/instant_nurec/datasets/instantnurec_base.py
+++ b/instant_nurec/datasets/instantnurec_base.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 
 import logging
 
-from typing import Tuple
+from abc import abstractmethod
+from typing import Tuple, TypeVar
 
 import numpy as np
 import torch
@@ -136,9 +137,75 @@ class CameraSubsampler:
 class InstantNuRecDataError(Exception):
     """Raised when an error occurs while loading InstantNuRec data.
 
-    Propagated directly to the caller — predict fails loud on a bad sample.
+    Prediction propagates this directly to the caller. Training opts into the
+    official bounded replacement-sampling recovery in the indexable wrapper.
     """
 
     def __init__(self, message: str = "An error occurred while loading InstantNuRec data"):
         super().__init__(message)
         self.message = message
+
+
+_DataBatchT = TypeVar("_DataBatchT")
+
+
+class BaseInstantNuRecIndexableDataset(torch.utils.data.Dataset[_DataBatchT]):
+    """Indexable dataset with the official opt-in training recovery contract."""
+
+    MAX_GETITEM_ATTEMPTS = 10
+
+    # Prediction deliberately keeps the one-shot, fail-loud behavior. Training
+    # constructors opt in to retries explicitly.
+    _retry_on_error = False
+
+    def __getitem__(self, batch_idx: int) -> _DataBatchT:
+        if not self._retry_on_error:
+            return self.getitem_allow_exceptions(batch_idx, self._get_rng(batch_idx))
+
+        current_batch_idx = batch_idx
+        failed_batch_indices: list[int] = []
+
+        while len(failed_batch_indices) < self.MAX_GETITEM_ATTEMPTS:
+            rng = self._get_rng(current_batch_idx)
+            try:
+                return self.getitem_allow_exceptions(current_batch_idx, rng)
+            except Exception as error:
+                failed_batch_indices.append(current_batch_idx)
+
+                # Match the reference implementation: replacement sampling uses
+                # the failed item's RNG and never revisits a failed index.
+                while (new_batch_idx := int(rng.integers(0, len(self)))) in failed_batch_indices:
+                    pass
+
+                if isinstance(error, InstantNuRecDataError):
+                    logger.warning(
+                        "Known InstantNuRecDataError occurred while getting item %d in %s. "
+                        "Reason: %s. Switching to a random index %d.",
+                        current_batch_idx,
+                        self.__class__.__name__,
+                        error.message,
+                        new_batch_idx,
+                    )
+                else:
+                    logger.error(
+                        "Unexpected error occurred while getting item %d in %s. "
+                        "Switching to a random index %d.",
+                        current_batch_idx,
+                        self.__class__.__name__,
+                        new_batch_idx,
+                    )
+                    logger.exception(error)
+
+                current_batch_idx = new_batch_idx
+
+        raise InstantNuRecDataError(
+            f"{self.__class__.__name__} tried out {len(failed_batch_indices)} attempts = "
+            f"{failed_batch_indices} and none of them worked. Please check the dataset integrity "
+            "and ensure that the data is not corrupted."
+        )
+
+    @abstractmethod
+    def _get_rng(self, batch_idx: int) -> np.random.Generator: ...
+
+    @abstractmethod
+    def getitem_allow_exceptions(self, batch_idx: int, rng: np.random.Generator) -> _DataBatchT: ...

--- a/instant_nurec/datasets/instantnurec_ncore.py
+++ b/instant_nurec/datasets/instantnurec_ncore.py
@@ -14,15 +14,19 @@
 # limitations under the License.
 
 import dataclasses
+import hashlib
 import logging
 import math
+import os
 
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
+from typing import cast
 
 import numpy as np
 import torch
 
+from scipy import ndimage
 from upath import UPath
 
 import ncore.data
@@ -31,11 +35,17 @@ import instant_nurec.utils.ncore_utils as ncore_utils
 
 from instant_nurec.datasets.tracks import CuboidTracks, CuboidTracksDataPack, TrackFlags
 from instant_nurec.datasets.utils import compute_cuboid_df, consolidate_cuboid_tracks
-from instant_nurec.config_schema.dataset import NCoreInstantNuRecDatasetConfig
-from instant_nurec.datasets.instantnurec_base import CameraSubsampler, InstantNuRecDataError
+from instant_nurec.config_schema.dataset import ExternalSupervisionCameraIdConfig, NCoreInstantNuRecDatasetConfig
+from instant_nurec.datasets.instantnurec_base import (
+    BaseInstantNuRecIndexableDataset,
+    CameraSubsampler,
+    InstantNuRecDataError,
+)
 from instant_nurec.datasets.samplers import (
     AdaptiveSequentialFrameBatchSampler,
     SampledSensorFrameIdxs,
+    UniformFrameBatchSampler,
+    get_closest_frame_index,
 )
 from instant_nurec.utils.batch import (
     CameraFrameLabels,
@@ -47,7 +57,7 @@ from instant_nurec.utils.batch import (
 from instant_nurec.utils.files import parse_universal_path
 from instant_nurec.utils.geometry import se3_matrix_inverse
 from instant_nurec.utils.misc import to_torch, unpack_optional
-from instant_nurec.utils.types import FrameConversion, HalfClosedInterval, RigTrajectories
+from instant_nurec.utils.types import FrameConversion, HalfClosedInterval, RayFlags, RigTrajectories
 
 
 logger = logging.getLogger(__name__)
@@ -67,7 +77,7 @@ def interval_list_intersect(
     return intersected_intervals
 
 
-class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
+class NCoreInstantNuRecDataset(BaseInstantNuRecIndexableDataset[InstantNuRecDataBatch]):
     """
     The native ncore dataset loader
     """
@@ -85,6 +95,10 @@ class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
             "motorcycle",
             "motorcycle_with_rider",
             "cycle",
+            # Waymo v18.7 emits lowercase `cyclist`. The reference set has
+            # only uppercase `CYCLIST`; accepting both fixes that upstream
+            # integration bug while preserving existing labels.
+            "cyclist",
         ]
     )
 
@@ -95,31 +109,58 @@ class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
 
     @dataclass(frozen=True)
     class ExtendedCameraId:
-        """Camera id with a unique sensor index."""
+        """Camera id with optional sequence-relative external NCore source."""
 
         camera_id: str
         unique_sensor_idx: int
+        external_ncore_path: str | None = None
+        sample_ratio: float = 1.0
 
         @staticmethod
-        def from_config(camera_id: str, unique_sensor_idx: int = -1) -> "NCoreInstantNuRecDataset.ExtendedCameraId":
+        def from_config(
+            camera_id: str | ExternalSupervisionCameraIdConfig,
+            unique_sensor_idx: int = -1,
+        ) -> "NCoreInstantNuRecDataset.ExtendedCameraId":
+            if isinstance(camera_id, str):
+                return NCoreInstantNuRecDataset.ExtendedCameraId(
+                    camera_id=camera_id,
+                    unique_sensor_idx=unique_sensor_idx,
+                )
             return NCoreInstantNuRecDataset.ExtendedCameraId(
-                camera_id=camera_id, unique_sensor_idx=unique_sensor_idx
+                camera_id=camera_id.camera_id,
+                unique_sensor_idx=camera_id.unique_sensor_idx,
+                external_ncore_path=camera_id.ncore_path,
+                sample_ratio=camera_id.sample_ratio,
             )
 
         def __str__(self) -> str:
-            return self.camera_id
+            if self.external_ncore_path is None:
+                return self.camera_id
+            return f"{self.camera_id}-({self.external_ncore_path.replace('/', '_')})"
+
+        @property
+        def loader_key(self) -> str:
+            return self.main_loader_key() if self.external_ncore_path is None else self.external_ncore_path
+
+        @staticmethod
+        def main_loader_key() -> str:
+            return "main"
 
         @property
         def canonical_order(self) -> str:
             """Canonical order to be in rig trajectory and the data batch."""
-            return f"{self.unique_sensor_idx:03d}"
+            order = f"{self.unique_sensor_idx:03d}"
+            if self.external_ncore_path is not None:
+                order += f"-{self.external_ncore_path}"
+            return order
 
     @dataclass
     class LoadersAndSensorsResult:
-        """Result of loading sequence loader and camera sensors for an ncore sequence."""
+        """Result of loading sequence, optional labels, and camera sensors."""
 
-        T_rig_worlds_with_timestamps_us: tuple[np.ndarray, np.ndarray]
-        sequence_loader: ncore.data.SequenceLoaderProtocol
+        T_rig_worlds_with_timestamps_us: dict[str, tuple[np.ndarray, np.ndarray]]
+        sequence_loaders: dict[str, ncore.data.SequenceLoaderProtocol]
+        aux_loaders: dict[str, ncore_utils.AuxShardDataLoader]
         camera_sensors: dict["NCoreInstantNuRecDataset.ExtendedCameraId", ncore.data.CameraSensorProtocol]
 
     def __init__(
@@ -128,6 +169,8 @@ class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
         frame_width: int,
         frame_height: int,
         n_frames_per_sample: int,
+        global_seed: int | None = None,
+        retry_on_error: bool = False,
     ):
         # ``frame_width`` / ``frame_height`` / ``n_frames_per_sample`` are
         # passed in by the caller (typically ``instant_nurec.model.make``),
@@ -135,6 +178,8 @@ class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
         self._frame_width = frame_width
         self._frame_height = frame_height
         self._n_frames_per_sample = n_frames_per_sample
+        self._global_seed = global_seed
+        self._retry_on_error = retry_on_error
 
         self.open_consolidated = config.open_consolidated
         self.camera_max_fov_deg = config.camera_max_fov_deg
@@ -159,17 +204,79 @@ class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
 
         self.cuboid_tracks_params = config.cuboid_tracks_params
 
-        self.ncore_json_paths: list[UPath] = [parse_universal_path(p) for p in config.ncore_json_paths]
-        logger.info(f"Loaded {len(self.ncore_json_paths)} sequence(s).")
+        self.ncore_json_paths = self._resolve_ncore_json_paths(config)
+        logger.info("Loaded %d sequence(s).", len(self.ncore_json_paths))
 
         self.num_samples_per_sequence: int = config.frame_batch_sampler.n_samples_per_sequence
         self.config = config
+        # Match the reference dataset contract: train sampling is deterministic for
+        # (epoch, item index, global seed), while validation keeps rng_epoch=-1
+        # so its samples do not drift from epoch to epoch.
+        self._rng_epoch = -1
+        self._epoch = -1
 
-    def _build_frame_batch_sampler(self) -> AdaptiveSequentialFrameBatchSampler:
+    @staticmethod
+    def _resolve_ncore_json_paths(config: NCoreInstantNuRecDatasetConfig) -> list[UPath]:
+        """Resolve explicit paths or an official-style newline manifest."""
+
+        if config.ncore_json_paths:
+            if config.ncore_json_list_path is not None:
+                logger.warning(
+                    "Both ncore_json_paths and ncore_json_list_path are set; "
+                    "using the explicit ncore_json_paths override."
+                )
+            return [parse_universal_path(path) for path in config.ncore_json_paths]
+
+        manifest = parse_universal_path(unpack_optional(config.ncore_json_list_path))
+        base = parse_universal_path(config.ncore_json_base_path) if config.ncore_json_base_path else None
+        paths: list[UPath] = []
+        with manifest.open("r") as stream:
+            for raw_line in stream:
+                entry = raw_line.strip()
+                if not entry or entry.startswith("#"):
+                    continue
+                if base is not None and "://" not in entry and not entry.startswith("/"):
+                    paths.append(base / entry)
+                else:
+                    paths.append(parse_universal_path(entry))
+        if not paths:
+            raise ValueError(f"NCore manifest contains no sequence paths: {manifest}")
+        return paths
+
+    def _build_frame_batch_sampler(self) -> AdaptiveSequentialFrameBatchSampler | UniformFrameBatchSampler:
+        if self.config.frame_batch_sampler.name == "uniform":
+            return UniformFrameBatchSampler(
+                self.config.frame_batch_sampler,
+                n_frames_per_sample=self._n_frames_per_sample,
+            )
         return AdaptiveSequentialFrameBatchSampler(
             self.config.frame_batch_sampler,
             n_frames_per_sample=self._n_frames_per_sample,
         )
+
+    def set_rng_epoch(self, rng_epoch: int) -> None:
+        self._rng_epoch = rng_epoch
+
+    def set_epoch(self, epoch: int) -> None:
+        self._epoch = epoch
+
+    @property
+    def epoch(self) -> int:
+        return self._epoch
+
+    def _get_rng(self, batch_idx: int) -> np.random.Generator:
+        """Return the official per-item SHA256-derived NumPy generator."""
+
+        global_seed = getattr(self, "_global_seed", None)
+        if global_seed is None:
+            if "PL_GLOBAL_SEED" not in os.environ:
+                raise RuntimeError(
+                    "No dataset global seed was supplied and PL_GLOBAL_SEED is unset; "
+                    "pass global_seed or call pytorch_lightning.seed_everything() first"
+                )
+            global_seed = int(os.environ["PL_GLOBAL_SEED"])
+        digest = hashlib.sha256(f"{self._rng_epoch}_{batch_idx}_{global_seed}".encode()).digest()
+        return np.random.default_rng(seed=int.from_bytes(digest[:8], "big"))
 
     def _build_camera_subsampler(self):
         from instant_nurec.datasets.instantnurec_base import CameraSubsampler
@@ -312,6 +419,7 @@ class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
         camera_idx_mapping: dict[UniqueFrameId, int],
         camera_sensors: dict[ExtendedCameraId, ncore.data.CameraSensorProtocol],
         camera_subsampler: CameraSubsampler,
+        aux_loaders: dict[str, ncore_utils.AuxShardDataLoader],
     ) -> DataBatch:
         """
         Load actual data batch given the sampled frame batch. idx_mapping is used to determine the unique frame index for the frame meta.
@@ -334,15 +442,86 @@ class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
             if camera_id not in camera_sensors:
                 continue
             camera_sensor = camera_sensors[camera_id]
+            aux_loader = aux_loaders.get(camera_id.loader_key)
+            frame_height = camera_subsampler.frame_height
+            frame_width = camera_subsampler.frame_width
+
+            static_mask = ncore_utils.get_camera_sensor_mask(camera_sensor)
+            if static_mask is None:
+                static_invalid_mask = np.zeros((frame_height, frame_width), dtype=bool)
+            else:
+                static_mask = camera_subsampler.apply_frame_data(static_mask)
+                static_invalid_mask = cast(
+                    np.ndarray,
+                    ndimage.binary_dilation(
+                        static_mask,
+                        iterations=self.n_camera_mask_dilation_iterations,
+                    ),
+                )
 
             # Determine unique sensor index mapping
             unique_sensor_idx = camera_id.unique_sensor_idx
             for frame_idx in frame_idxs:
+                frame_end_timestamp_us = int(
+                    camera_sensor.get_frame_timestamp_us(frame_idx, ncore.data.FrameTimepoint.END)
+                )
                 # Collect labels data
                 labels = CameraFrameLabels()
                 frame_image_array = camera_sensor.get_frame_image_array(frame_idx).astype(np.float32) / 255.0
                 frame_image_array = camera_subsampler.apply_frame_data(frame_image_array)
                 labels.rgb = to_torch(frame_image_array, device="cpu").unsqueeze(0)
+                flags = torch.full(
+                    (frame_height, frame_width),
+                    int(RayFlags.RGB_LABEL),
+                    dtype=torch.int32,
+                )
+                if camera_id.external_ncore_path is not None:
+                    flags |= int(RayFlags.SYNTHETIC)
+                invalid_ego_mask = static_invalid_mask.copy()
+
+                if aux_loader is not None:
+                    data_camera_id = camera_id.camera_id
+                    sky_mask: np.ndarray | bool = False
+                    if self.config.aux_data.semantic_segmentation and aux_loader.has_semantic_segmentation(
+                        data_camera_id
+                    ):
+                        semantics = np.asarray(
+                            aux_loader.get_semantic_segmentation(data_camera_id, frame_end_timestamp_us)
+                        )
+                        classes = aux_loader.get_semantic_segmentation_meta(data_camera_id)["stuff_classes"]
+                        sky_mask = semantics == classes.index("sky") if "sky" in classes else False
+                        semantics = camera_subsampler.apply_frame_data(semantics)
+                        flags |= int(RayFlags.VALID_SEMANTIC)
+                        if "sky" in classes:
+                            flags[semantics == classes.index("sky")] |= int(RayFlags.SKY_SEMANTIC)
+                        if "road" in classes:
+                            flags[semantics == classes.index("road")] |= int(RayFlags.ROAD_SEMANTIC)
+                        for vehicle_class in ("car", "truck", "bus", "train", "motorcycle", "bicycle"):
+                            if vehicle_class in classes:
+                                flags[semantics == classes.index(vehicle_class)] |= int(RayFlags.VEHICLE_SEMANTIC)
+                        if "egocar" in classes:
+                            invalid_ego_mask |= semantics == classes.index("egocar")
+
+                    if self.config.aux_data.depth and aux_loader.has_depth(data_camera_id):
+                        metric_distance = aux_loader.get_depth(data_camera_id, frame_end_timestamp_us)
+                        metric_distance[~np.isfinite(metric_distance) | sky_mask] = 0.0
+                        metric_distance = camera_subsampler.apply_depth_data(metric_distance)
+                        labels.metric_distance = to_torch(metric_distance, device="cpu")[None, ..., None]
+
+                    if self.config.aux_data.egomask and aux_loader.has_egomask(data_camera_id):
+                        ego_mask = aux_loader.get_egomask(data_camera_id)
+                        ego_mask = camera_subsampler.apply_frame_data(ego_mask)
+                        invalid_ego_mask |= cast(
+                            np.ndarray,
+                            ndimage.binary_dilation(
+                                ego_mask,
+                                iterations=self.n_camera_mask_dilation_iterations,
+                            ),
+                        )
+
+                invalid_ego_mask_t = torch.from_numpy(invalid_ego_mask)
+                flags[invalid_ego_mask_t] |= int(RayFlags.INVALID | RayFlags.EGO_SEMANTIC)
+                labels.flags = flags[None, ..., None]
 
                 camera_batch_list.append(
                     DataBatch.Camera(
@@ -366,7 +545,7 @@ class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
         frame_batch: SampledSensorFrameIdxs,
         camera_sensors: dict[ExtendedCameraId, ncore.data.CameraSensorProtocol],
         T_world_ref: np.ndarray,
-        T_rig_worlds_with_timestamps_us: tuple[np.ndarray, np.ndarray],
+        T_rig_worlds_with_timestamps_us: dict[str, tuple[np.ndarray, np.ndarray]],
         camera_subsampler: CameraSubsampler,
     ) -> tuple[RigTrajectories, dict[UniqueFrameId, int]]:
         """
@@ -378,9 +557,9 @@ class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
         """
         ## Load cameras
 
-        # camera_id_name -> timestamps_us
+        # loader_key -> camera_id_name -> timestamps_us
         frame_timestamps_us_list: list[tuple[int, int]] = []
-        camera_frame_timestamps_us: dict[str, torch.Tensor] = {}
+        camera_frame_timestamps_us: dict[str, dict[str, torch.Tensor]] = defaultdict(dict)
         all_camera_model_parameters: dict[
             NCoreInstantNuRecDataset.ExtendedCameraId, ncore.data.ConcreteCameraModelParametersUnion
         ] = {}
@@ -416,45 +595,50 @@ class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
                 )
                 current_unique_frame_idx += 1
 
-            camera_frame_timestamps_us[str(camera_id)] = torch.tensor(
+            camera_frame_timestamps_us[camera_id.loader_key][str(camera_id)] = torch.tensor(
                 frame_timestamps_us_list, dtype=torch.int64, device="cpu"
             )
 
-        # Standalone predict has a single loader keyed `"main"` (no external archives).
-        T_rig_worlds, T_rig_world_timestamps_us = T_rig_worlds_with_timestamps_us
+        rig_trajectores: list[RigTrajectories.RigTrajectory] = []
+        for loader_key, (T_rig_worlds, T_rig_world_timestamps_us) in T_rig_worlds_with_timestamps_us.items():
+            loader_camera_timestamps = camera_frame_timestamps_us.get(loader_key)
+            if not loader_camera_timestamps:
+                continue
 
-        # In the new batch design the sensor poses can only obtained by interpolating rig poses.
-        # In cases where rig timestamps do not fully cover the sensor timestamps, we extend the rig using constant padding.
-        # This can happen, e.g., in Gen3C setting where rig timestamps are end-of-frame ones, so start-of-frame of the 1st frame
-        # is not covered.
-        sensor_min_timestamp_us = int(min((v.min().item() for v in camera_frame_timestamps_us.values()))) - 1
-        sensor_max_timestamp_us = int(max((v.max().item() for v in camera_frame_timestamps_us.values()))) + 1
-        if sensor_min_timestamp_us < int(T_rig_world_timestamps_us[0].item()):
-            T_rig_worlds = np.concatenate([T_rig_worlds[:1], T_rig_worlds], axis=0)
-            T_rig_world_timestamps_us = np.concatenate(
-                [[sensor_min_timestamp_us], T_rig_world_timestamps_us], axis=0
-            )
-        if sensor_max_timestamp_us > int(T_rig_world_timestamps_us[-1].item()):
-            T_rig_worlds = np.concatenate([T_rig_worlds, T_rig_worlds[-1:]], axis=0)
-            T_rig_world_timestamps_us = np.concatenate(
-                [T_rig_world_timestamps_us, [sensor_max_timestamp_us]], axis=0
-            )
+            # Interpolation must cover each exposure boundary. Constant endpoint
+            # padding is the official behavior for both main and external rigs.
+            sensor_min_timestamp_us = int(min(v.min().item() for v in loader_camera_timestamps.values())) - 1
+            sensor_max_timestamp_us = int(max(v.max().item() for v in loader_camera_timestamps.values())) + 1
+            if sensor_min_timestamp_us < int(T_rig_world_timestamps_us[0]):
+                T_rig_worlds = np.concatenate([T_rig_worlds[:1], T_rig_worlds], axis=0)
+                T_rig_world_timestamps_us = np.concatenate(
+                    [[sensor_min_timestamp_us], T_rig_world_timestamps_us], axis=0
+                )
+            if sensor_max_timestamp_us > int(T_rig_world_timestamps_us[-1]):
+                T_rig_worlds = np.concatenate([T_rig_worlds, T_rig_worlds[-1:]], axis=0)
+                T_rig_world_timestamps_us = np.concatenate(
+                    [T_rig_world_timestamps_us, [sensor_max_timestamp_us]], axis=0
+                )
 
-        rig_trajectores: list[RigTrajectories.RigTrajectory] = [
-            RigTrajectories.RigTrajectory(
-                sequence_id=sequence_id_prefix + "main",
-                cameras_frame_timestamps_us=camera_frame_timestamps_us,
-                T_rig_worlds=to_torch(T_world_ref @ T_rig_worlds, device="cpu", dtype=torch.float64),
-                T_rig_world_timestamps_us=to_torch(T_rig_world_timestamps_us, device="cpu", dtype=torch.int64),
+            rig_trajectores.append(
+                RigTrajectories.RigTrajectory(
+                    sequence_id=sequence_id_prefix + loader_key,
+                    cameras_frame_timestamps_us=loader_camera_timestamps,
+                    T_rig_worlds=to_torch(T_world_ref @ T_rig_worlds, device="cpu", dtype=torch.float64),
+                    T_rig_world_timestamps_us=to_torch(
+                        T_rig_world_timestamps_us,
+                        device="cpu",
+                        dtype=torch.int64,
+                    ),
+                )
             )
-        ]
 
         camera_calibrations = OrderedDict(
             [
                 (
                     str(camera_id),
                     RigTrajectories.CameraCalibration(
-                        sequence_id=sequence_id_prefix + "main",
+                        sequence_id=sequence_id_prefix + camera_id.loader_key,
                         unique_sensor_idx=camera_id.unique_sensor_idx,
                         T_sensor_rig=to_torch(unpack_optional(camera_sensors[camera_id].T_sensor_rig), device="cpu"),
                         camera_model_parameters=all_camera_model_parameters[camera_id],
@@ -493,40 +677,80 @@ class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
             dataset_paths,
         ) = ncore_utils.parse_sequence_meta_file(ncore_json_path)
 
-        # ShardDataLoader is logging using root. Let's suppress this information.
-        (root_logger := logging.getLogger()).setLevel(logging.WARNING)
+        # Load each source archive once. External supervision archives carry
+        # their own calibrated cameras and rig trajectories but share the main
+        # clip's world coordinate frame.
+        root_logger = logging.getLogger()
+        previous_level = root_logger.level
+        root_logger.setLevel(logging.WARNING)
+        T_rig_worlds_with_timestamps_us: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+        sequence_loaders: dict[str, ncore.data.SequenceLoaderProtocol] = {}
+        aux_loaders: dict[str, ncore_utils.AuxShardDataLoader] = {}
+        camera_sensors: dict[NCoreInstantNuRecDataset.ExtendedCameraId, ncore.data.CameraSensorProtocol] = {}
         try:
-            sequence_loader = ncore_utils.create_sequence_loader(
-                dataset_paths=dataset_paths,
-                open_consolidated=self.open_consolidated,
-                v4_poses_component_group="default",
-                v4_intrinsics_component_group="default",
-                v4_masks_component_group="default",
-                v4_cuboids_component_group="default",
-            )
-        except FileNotFoundError as e:
-            raise InstantNuRecDataError(f"Ncore files not found for dataset_paths {dataset_paths}.") from e
+            for camera_id in all_camera_ids:
+                current_dataset_paths = (
+                    dataset_paths
+                    if camera_id.external_ncore_path is None
+                    else [ncore_json_path.parent / camera_id.external_ncore_path]
+                )
+                loader_key = camera_id.loader_key
+                sequence_loader = sequence_loaders.get(loader_key)
+                if sequence_loader is None:
+                    try:
+                        sequence_loader = ncore_utils.create_sequence_loader(
+                            dataset_paths=current_dataset_paths,
+                            open_consolidated=self.open_consolidated,
+                            v4_poses_component_group="default",
+                            v4_intrinsics_component_group="default",
+                            v4_masks_component_group="default",
+                            v4_cuboids_component_group="default",
+                        )
+                    except FileNotFoundError as exc:
+                        raise InstantNuRecDataError(
+                            f"Ncore files not found for dataset_paths {current_dataset_paths}."
+                        ) from exc
+                    sequence_loaders[loader_key] = sequence_loader
+                    rig_world_edge: ncore_transformations.PoseGraphInterpolator.Edge = unpack_optional(
+                        sequence_loader.pose_graph.get_edge("rig", "world"),
+                        msg="Rig-to-world poses required for rig-trajectories",
+                    )
+                    T_rig_worlds_with_timestamps_us[loader_key] = (
+                        rig_world_edge.T_source_target,
+                        unpack_optional(
+                            rig_world_edge.timestamps_us,
+                            msg="Rig-to-world pose requires to be dynamic",
+                        ),
+                    )
+                    if self.config.aux_data.enabled:
+                        try:
+                            signal_override_paths: dict[str, UPath] = {}
+                            if isinstance(self.config.aux_data.depth, str):
+                                depth_override_path = parse_universal_path(
+                                    self.config.aux_data.depth.replace(
+                                        "{{clip_id}}", sequence_loader.sequence_id
+                                    )
+                                )
+                                if depth_override_path.exists():
+                                    signal_override_paths["depth"] = depth_override_path
+                            aux_loaders[loader_key] = ncore_utils.AuxShardDataLoader(
+                                sequence_id=sequence_loader.sequence_id,
+                                dataset_paths=current_dataset_paths,
+                                open_consolidated=self.open_consolidated,
+                                signal_override_paths=signal_override_paths,
+                            )
+                        except ValueError as exc:
+                            raise InstantNuRecDataError(
+                                f"Failed to load auxiliary labels for sequence {ncore_json_path.stem}."
+                            ) from exc
+                camera_sensors[camera_id] = sequence_loader.get_camera_sensor(camera_id.camera_id)
+        finally:
+            root_logger.setLevel(previous_level)
 
-        # NB [JH]: We should be very careful about the poses' timestamps_us -- it can be a large
-        # superset of sensor timestamps (e.g. 36s vs 10s).
-        # TODO: frame-pose-only data might fail here as there are no rig poses and might require refined logic.
-        rig_world_edge: ncore_transformations.PoseGraphInterpolator.Edge = unpack_optional(
-            sequence_loader.pose_graph.get_edge("rig", "world"),
-            msg="Rig-to-world poses required for rig-trajectories",
-        )
-        T_rig_worlds_with_timestamps_us = (
-            rig_world_edge.T_source_target,
-            unpack_optional(rig_world_edge.timestamps_us, msg="Rig-to-world pose requires to be dynamic"),
-        )
-
-        camera_sensors = {
-            camera_id: sequence_loader.get_camera_sensor(camera_id.camera_id) for camera_id in all_camera_ids
-        }
-
-        root_logger.setLevel(logging.INFO)
         return NCoreInstantNuRecDataset.LoadersAndSensorsResult(
             T_rig_worlds_with_timestamps_us=T_rig_worlds_with_timestamps_us,
-            sequence_loader=sequence_loader,
+            sequence_loaders=sequence_loaders,
+            aux_loaders=aux_loaders,
             camera_sensors=camera_sensors,
         )
 
@@ -608,7 +832,11 @@ class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
         # Full-video output must not outrun the scene reconstruction. Mirror the
         # sampler's interval/chunk calculation across every configured context
         # camera and fail explicitly when --max-chunks would truncate the clip.
-        rig_timestamps_us = np.asarray(loaders_sensors.T_rig_worlds_with_timestamps_us[1])
+        rig_timestamps_us = np.asarray(
+            loaders_sensors.T_rig_worlds_with_timestamps_us[
+                NCoreInstantNuRecDataset.ExtendedCameraId.main_loader_key()
+            ][1]
+        )
         sequence_start_timestamp_us = int(rig_timestamps_us.min())
         sequence_end_timestamp_us = int(rig_timestamps_us.max())
         for context_camera in self.all_context_camera_ids:
@@ -633,9 +861,12 @@ class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
             )
         if sequence_end_timestamp_us < sequence_start_timestamp_us:
             raise ValueError("Context-camera and rig-pose timestamp ranges do not overlap")
-        max_chunk_timespan_us = (
-            self.config.frame_batch_sampler.max_frame_gap_timestamp_us * self._n_frames_per_sample
+        gap_us = (
+            self.config.frame_batch_sampler.frame_gap_timestamp_us
+            if self.config.frame_batch_sampler.name == "uniform"
+            else self.config.frame_batch_sampler.max_frame_gap_timestamp_us
         )
+        max_chunk_timespan_us = gap_us * self._n_frames_per_sample
         required_chunks = max(
             1,
             math.ceil(
@@ -710,7 +941,11 @@ class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
             camera_calibrations=OrderedDict([(selected_camera_id, camera_calibration)]),
         )
 
-    def __getitem__(self, batch_idx: int) -> InstantNuRecDataBatch:
+    def getitem_allow_exceptions(
+        self,
+        batch_idx: int,
+        rng: np.random.Generator,
+    ) -> InstantNuRecDataBatch:
         # Disable fsspect INFO logs to not spam the logs.
         logging.getLogger("fsspec").setLevel(logging.WARNING)
 
@@ -743,16 +978,25 @@ class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
 
         loaders_sensors = self._get_loaders_and_sensors(ncore_json_path, supervision_camera_ids)
         T_rig_worlds_with_timestamps_us = loaders_sensors.T_rig_worlds_with_timestamps_us
-        sequence_loader = loaders_sensors.sequence_loader
+        sequence_loaders = loaders_sensors.sequence_loaders
+        aux_loaders = loaders_sensors.aux_loaders
         camera_sensors = loaders_sensors.camera_sensors
+        main_loader_key = NCoreInstantNuRecDataset.ExtendedCameraId.main_loader_key()
+        sequence_loader = sequence_loaders[main_loader_key]
 
         # Determine the timestamps interval to select frames from.
         context_camera_frame_timestamps_us: dict[str, np.ndarray] = {}
 
         # Standalone predict always selects the full sequence range; subranges
         # were a training-time control that the predict YAML never carried.
-        main_timestamps = T_rig_worlds_with_timestamps_us[1]
+        main_timestamps = T_rig_worlds_with_timestamps_us[main_loader_key][1]
         select_intervals = [HalfClosedInterval(int(main_timestamps.min()), int(main_timestamps.max()))]
+        for loader_key, (_, pose_timestamps_us) in T_rig_worlds_with_timestamps_us.items():
+            if loader_key != main_loader_key:
+                select_intervals = interval_list_intersect(
+                    select_intervals,
+                    HalfClosedInterval(int(pose_timestamps_us.min()), int(pose_timestamps_us.max())),
+                )
         # Intersect also with sensor timestamps (with +/- 0.1s tolerance)
         for camera_id in context_camera_ids:
             timestamps_us = camera_sensors[camera_id].get_frames_timestamps_us(ncore.data.FrameTimepoint.END)
@@ -766,6 +1010,7 @@ class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
             sample_idx,
             context_camera_frame_timestamps_us,
             select_intervals,
+            rng=rng,
         )
         if len(context_frame_batch) == 0:
             # If nothing is sampled (e.g. out of bounds), return 0-sized batch to be concatenated with other batches.
@@ -795,8 +1040,83 @@ class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
                 context_camera_mapping,
                 camera_sensors,
                 context_camera_subsampler,
+                aux_loaders if self.config.aux_data.enabled_context else {},
             )
         )
+
+        # Training samples novel supervision independently inside the temporal
+        # extent selected for this context chunk.  Predict profiles leave
+        # n_frames_per_camera at zero and retain the original behavior.
+        supervision = None
+        supervision_rig_trajectory = None
+        n_supervision_frames = self.config.supervision_frame_batch.n_frames_per_camera
+        if n_supervision_frames > 0:
+            context_times: list[int] = []
+            for camera_id in context_camera_ids:
+                frame_indices = context_frame_batch[str(camera_id)]
+                camera_times = camera_sensors[camera_id].get_frames_timestamps_us(ncore.data.FrameTimepoint.END)
+                context_times.extend(int(camera_times[index]) for index in frame_indices)
+            start_us, end_us = min(context_times), max(context_times)
+            supervision_frame_batch: SampledSensorFrameIdxs = {}
+            for camera_id in supervision_camera_ids:
+                camera_times = camera_sensors[camera_id].get_frames_timestamps_us(ncore.data.FrameTimepoint.END)
+                min_index = max(
+                    get_closest_frame_index(
+                        camera_times,
+                        start_us - self.config.supervision_frame_batch.prepend_timestamps_us,
+                    ),
+                    0,
+                )
+                max_index = min(
+                    get_closest_frame_index(
+                        camera_times,
+                        end_us + self.config.supervision_frame_batch.append_timestamps_us,
+                    ),
+                    len(camera_times) - 1,
+                )
+                candidates = np.arange(min_index, max_index + 1)
+                if self.config.supervision_frame_batch.sample_strategy == "random":
+                    indices = np.sort(
+                        rng.choice(candidates, size=n_supervision_frames, replace=True)
+                    ).tolist()
+                else:
+                    indices = []
+                    bins = np.linspace(0, len(candidates), n_supervision_frames + 1, dtype=int)
+                    for bin_start, bin_end in zip(bins[:-1], bins[1:]):
+                        if bin_start == bin_end:
+                            indices.append(int(candidates[bin_start]))
+                        else:
+                            indices.append(int(rng.choice(candidates[bin_start:bin_end])))
+                if camera_id.sample_ratio != 1.0:
+                    sampled_size = round(len(indices) * camera_id.sample_ratio)
+                    indices = np.sort(rng.choice(indices, size=sampled_size, replace=False)).tolist()
+                if self.config.supervision_frame_batch.include_context_frames and str(camera_id) in context_frame_batch:
+                    indices = sorted(set(indices) | set(context_frame_batch[str(camera_id)]))
+                if indices:
+                    supervision_frame_batch[str(camera_id)] = indices
+
+            supervision_subsampler_cfg = self.config.supervision_frame_batch.camera_subsampler
+            supervision_camera_subsampler = CameraSubsampler(
+                frame_width=supervision_subsampler_cfg.frame_width,
+                frame_height=supervision_subsampler_cfg.frame_height,
+            )
+            supervision_rig_trajectory, supervision_camera_mapping = self._get_rig_trajectory(
+                "supervision-",
+                supervision_frame_batch,
+                camera_sensors,
+                T_world_ref,
+                T_rig_worlds_with_timestamps_us,
+                supervision_camera_subsampler,
+            )
+            supervision = DataAndRenderingBatch(
+                data=self._load_data_batch(
+                    supervision_frame_batch,
+                    supervision_camera_mapping,
+                    camera_sensors,
+                    supervision_camera_subsampler,
+                    aux_loaders,
+                )
+            )
 
         cuboid_tracks = self._compute_cuboid_tracks(
             context_frame_batch,
@@ -812,7 +1132,9 @@ class NCoreInstantNuRecDataset(torch.utils.data.Dataset[InstantNuRecDataBatch]):
 
         instantnurec_data_batch = InstantNuRecDataBatch(
             context=[context],
+            supervision=[supervision] if supervision is not None else None,
             context_rig=[context_rig_trajectory],
+            supervision_rig=[supervision_rig_trajectory] if supervision_rig_trajectory is not None else None,
             cuboid_tracks=[cuboid_tracks],
             meta=[meta],
         )

--- a/instant_nurec/datasets/mixture.py
+++ b/instant_nurec/datasets/mixture.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from instant_nurec.config_schema.dataset import NCoreMixtureDatasetConfig
+from instant_nurec.datasets.instantnurec_base import BaseInstantNuRecIndexableDataset
+from instant_nurec.datasets.instantnurec_ncore import NCoreInstantNuRecDataset
+from instant_nurec.utils.batch import InstantNuRecDataBatch
+
+
+logger = logging.getLogger(__name__)
+
+
+class NCoreMixtureDataset(BaseInstantNuRecIndexableDataset[InstantNuRecDataBatch]):
+    """Mixture sampling with the reference length and resampling contract."""
+
+    @dataclass
+    class SubDataset:
+        name: str
+        dataset: NCoreInstantNuRecDataset
+        sample_ratio: float
+        full_length: int = field(init=False)
+        sampled_length: int = field(init=False)
+
+        def __post_init__(self) -> None:
+            self.full_length = len(self.dataset)
+            if self.full_length <= 0:
+                raise ValueError(f"Dataset {self.name!r} is empty")
+            self.sampled_length = int(self.full_length * self.sample_ratio)
+            logger.info(
+                "Mixture component %s has %d samples; selecting %d (ratio %.4g).",
+                self.name,
+                self.full_length,
+                self.sampled_length,
+                self.sample_ratio,
+            )
+
+        def sample_at(self, index: int, rng: np.random.Generator) -> InstantNuRecDataBatch:
+            if not 0 <= index < self.sampled_length:
+                raise IndexError(f"Sub-index {index} is outside component {self.name!r}")
+            if self.sampled_length >= self.full_length and index < self.full_length:
+                return self.dataset[index]
+            return self.dataset[int(rng.integers(self.full_length))]
+
+    def __init__(
+        self,
+        config: NCoreMixtureDatasetConfig,
+        *,
+        global_seed: int | None = None,
+        retry_on_error: bool = False,
+    ) -> None:
+        self.datasets: list[NCoreMixtureDataset.SubDataset] = []
+        self._global_seed = global_seed
+        self._retry_on_error = retry_on_error
+        self._rng_epoch = -1
+        self._epoch = -1
+        for name, component in config.mixture.items():
+            if component.sample_ratio == 0:
+                continue
+            dataset_config = component.config
+            dataset = NCoreInstantNuRecDataset(
+                dataset_config,
+                frame_width=dataset_config.camera_subsampler.frame_width,
+                frame_height=dataset_config.camera_subsampler.frame_height,
+                n_frames_per_sample=dataset_config.frame_batch_sampler.n_frames_per_sample,
+                global_seed=global_seed,
+                retry_on_error=retry_on_error,
+            )
+            self.datasets.append(self.SubDataset(name, dataset, component.sample_ratio))
+        if not self.datasets:
+            raise ValueError("NCore mixture has no enabled components")
+
+    def __len__(self) -> int:
+        return sum(component.sampled_length for component in self.datasets)
+
+    def set_rng_epoch(self, rng_epoch: int) -> None:
+        self._rng_epoch = rng_epoch
+        for component in self.datasets:
+            component.dataset.set_rng_epoch(rng_epoch)
+
+    def set_epoch(self, epoch: int) -> None:
+        self._epoch = epoch
+        for component in self.datasets:
+            component.dataset.set_epoch(epoch)
+
+    @property
+    def epoch(self) -> int:
+        return self._epoch
+
+    def _get_rng(self, batch_idx: int) -> np.random.Generator:
+        global_seed = self._global_seed
+        if global_seed is None:
+            if "PL_GLOBAL_SEED" not in os.environ:
+                raise RuntimeError(
+                    "No mixture global seed was supplied and PL_GLOBAL_SEED is unset; "
+                    "pass global_seed or call pytorch_lightning.seed_everything() first"
+                )
+            global_seed = int(os.environ["PL_GLOBAL_SEED"])
+        digest = hashlib.sha256(f"{self._rng_epoch}_{batch_idx}_{global_seed}".encode()).digest()
+        return np.random.default_rng(seed=int.from_bytes(digest[:8], "big"))
+
+    def getitem_allow_exceptions(
+        self,
+        batch_idx: int,
+        rng: np.random.Generator,
+    ) -> InstantNuRecDataBatch:
+        if not 0 <= batch_idx < len(self):
+            raise IndexError(f"Mixture index {batch_idx} is outside [0, {len(self)})")
+        component_index = batch_idx
+        for component in self.datasets:
+            if component_index < component.sampled_length:
+                return component.sample_at(component_index, rng)
+            component_index -= component.sampled_length
+        raise RuntimeError("Mixture index routing fell through")

--- a/instant_nurec/datasets/ray_intersections.py
+++ b/instant_nurec/datasets/ray_intersections.py
@@ -58,13 +58,13 @@ def _slab_aabb_intersection(
 
 
 def ray_cuboidtracks_intersection(
-    rays_o: torch.Tensor,                # (N_rays, 3)
-    rays_d: torch.Tensor,                # (N_rays, 3)
-    rays_timestamps_us: torch.Tensor,    # (N_rays,) int64
-    tracks_packinfo: torch.Tensor,       # (N_tracks, 2) int32 [start, count]
-    tracks_poses: torch.Tensor,          # (N_total_poses, 7) [tx ty tz qx qy qz qw]
+    rays_o: torch.Tensor,  # (N_rays, 3)
+    rays_d: torch.Tensor,  # (N_rays, 3)
+    rays_timestamps_us: torch.Tensor,  # (N_rays,) int64
+    tracks_packinfo: torch.Tensor,  # (N_tracks, 2) int32 [start, count]
+    tracks_poses: torch.Tensor,  # (N_total_poses, 7) [tx ty tz qx qy qz qw]
     tracks_timestamps_us: torch.Tensor,  # (N_total_poses,) int64
-    cuboids_dims: torch.Tensor,          # (N_tracks, 3) cuboid xyz extents
+    cuboids_dims: torch.Tensor,  # (N_tracks, 3) cuboid xyz extents
     max_track_n_poses: int,
     max_intersections_per_ray: int,
     with_intersections_ts: bool,
@@ -82,13 +82,9 @@ def ray_cuboidtracks_intersection(
     dtype = rays_o.dtype
 
     intersections_cnt = torch.zeros(n_rays, dtype=torch.int32, device=device)
-    intersections_tracks_idx = torch.full(
-        (n_rays, max_intersections_per_ray), -1, dtype=torch.int32, device=device
-    )
+    intersections_tracks_idx = torch.full((n_rays, max_intersections_per_ray), -1, dtype=torch.int32, device=device)
     intersections_ts = (
-        torch.full(
-            (n_rays, max_intersections_per_ray, 2), -1.0, dtype=dtype, device=device
-        )
+        torch.full((n_rays, max_intersections_per_ray, 2), -1.0, dtype=dtype, device=device)
         if with_intersections_ts
         else None
     )
@@ -118,9 +114,7 @@ def ray_cuboidtracks_intersection(
         track_poses_slice = tracks_poses[start : start + n_poses]
 
         # Per-ray time-range gate.
-        in_range = (rays_timestamps_us >= track_ts[0]) & (
-            rays_timestamps_us <= track_ts[-1]
-        )
+        in_range = (rays_timestamps_us >= track_ts[0]) & (rays_timestamps_us <= track_ts[-1])
         ray_idxs = in_range.nonzero(as_tuple=False).squeeze(-1)
         if ray_idxs.numel() == 0:
             continue
@@ -149,12 +143,8 @@ def ray_cuboidtracks_intersection(
         # Local-frame ray.
         # The kernel does R^T (transpose) — world→local rotation.
         R_world_to_local = quat_xyzw_to_rotmat(q_interp).transpose(-1, -2)
-        rays_o_local = torch.bmm(
-            R_world_to_local, (rays_o[ray_idxs] - c_interp).unsqueeze(-1)
-        ).squeeze(-1)
-        rays_d_local = torch.bmm(R_world_to_local, rays_d[ray_idxs].unsqueeze(-1)).squeeze(
-            -1
-        )
+        rays_o_local = torch.bmm(R_world_to_local, (rays_o[ray_idxs] - c_interp).unsqueeze(-1)).squeeze(-1)
+        rays_d_local = torch.bmm(R_world_to_local, rays_d[ray_idxs].unsqueeze(-1)).squeeze(-1)
 
         half_dims = (cuboids_dims[track_id] * 0.5).expand_as(rays_o_local)
         t_pair = _slab_aabb_intersection(rays_o_local, rays_d_local, half_dims)
@@ -176,9 +166,7 @@ def ray_cuboidtracks_intersection(
             if cnt_now < max_intersections_per_ray:
                 intersections_tracks_idx[r_idx, cnt_now] = track_id
                 if with_intersections_ts:
-                    intersections_ts[r_idx, cnt_now, 0] = max(
-                        float(t_near[hit_local[i]].item()), 0.0
-                    )
+                    intersections_ts[r_idx, cnt_now, 0] = max(float(t_near[hit_local[i]].item()), 0.0)
                     intersections_ts[r_idx, cnt_now, 1] = float(t_far[hit_local[i]].item())
 
     if with_intersections_ts:
@@ -187,32 +175,45 @@ def ray_cuboidtracks_intersection(
 
 
 def point_cuboidtracks_intersection_interpolate_pose(
-    points: torch.Tensor,                # (N_points, 3)
+    points: torch.Tensor,  # (N_points, 3)
     points_timestamps_us: torch.Tensor,  # (N_points,) int64
-    tracks_packinfo: torch.Tensor,       # (N_tracks, 2) int32 [start, count]
-    tracks_poses: torch.Tensor,          # (N_total_poses, 7)
+    tracks_packinfo: torch.Tensor,  # (N_tracks, 2) int32 [start, count]
+    tracks_poses: torch.Tensor,  # (N_total_poses, 7)
     tracks_timestamps_us: torch.Tensor,  # (N_total_poses,) int64
-    cuboids_dims: torch.Tensor,          # (N_tracks, 3)
+    cuboids_dims: torch.Tensor,  # (N_tracks, 3)
     max_track_n_poses: int,
+    max_intersections_per_point: int = 1,
+    return_local_points: bool = False,
 ):
-    """Per (point, track) inside-cuboid test with interpolated pose.
+    """Per-(point, track) inside-cuboid test with interpolated poses.
 
     Returns:
-      interpolated_tracks_pose: (N_points, 7)
-      interpolated_tracks_idx: (N_points,) int32, -1 if no intersection.
+      intersections_cnt: (N_points,) int32
+      interpolated_tracks_pose: (N_points, max_intersections_per_point, 7)
+      interpolated_tracks_idx: (N_points, max_intersections_per_point) int32
+      interpolated_points_local: optional
+        (N_points, max_intersections_per_point, 3)
     """
+    if max_intersections_per_point < 1:
+        raise ValueError("max_intersections_per_point must be positive")
+
     n_points = points.shape[0]
     n_tracks = tracks_packinfo.shape[0]
     device = points.device
     dtype = points.dtype
 
-    interpolated_tracks_pose = torch.zeros((n_points, 7), dtype=dtype, device=device)
-    interpolated_tracks_idx = torch.full(
-        (n_points,), -1, dtype=torch.int32, device=device
+    intersections_cnt = torch.zeros(n_points, dtype=torch.int32, device=device)
+    interpolated_tracks_pose = torch.zeros((n_points, max_intersections_per_point, 7), dtype=dtype, device=device)
+    interpolated_tracks_idx = torch.full((n_points, max_intersections_per_point), -1, dtype=torch.int32, device=device)
+    interpolated_points_local = (
+        torch.zeros((n_points, max_intersections_per_point, 3), dtype=dtype, device=device)
+        if return_local_points
+        else None
     )
 
     if n_points == 0 or max_track_n_poses == 0 or n_tracks == 0:
-        return interpolated_tracks_pose, interpolated_tracks_idx
+        outputs = (intersections_cnt, interpolated_tracks_pose, interpolated_tracks_idx)
+        return outputs + ((interpolated_points_local,) if return_local_points else ())
 
     track_lengths = tracks_packinfo[:, 1].to(torch.int64)
 
@@ -224,9 +225,7 @@ def point_cuboidtracks_intersection_interpolate_pose(
         track_ts = tracks_timestamps_us[start : start + n_poses]
         track_poses_slice = tracks_poses[start : start + n_poses]
 
-        in_range = (points_timestamps_us >= track_ts[0]) & (
-            points_timestamps_us <= track_ts[-1]
-        )
+        in_range = (points_timestamps_us >= track_ts[0]) & (points_timestamps_us <= track_ts[-1])
         pt_idxs = in_range.nonzero(as_tuple=False).squeeze(-1)
         if pt_idxs.numel() == 0:
             continue
@@ -248,26 +247,32 @@ def point_cuboidtracks_intersection_interpolate_pose(
         q_pointtime = quat_xyzw_slerp(q_start, q_end, t_interp)
 
         R_world_to_local = quat_xyzw_to_rotmat(q_pointtime).transpose(-1, -2)
-        point_local = torch.bmm(
-            R_world_to_local, (points[pt_idxs] - c_pointtime).unsqueeze(-1)
-        ).squeeze(-1)
+        point_local = torch.bmm(R_world_to_local, (points[pt_idxs] - c_pointtime).unsqueeze(-1)).squeeze(-1)
 
         half_dim = cuboids_dims[track_id] * 0.5
         # Strict-inequality inside-cuboid check (matches the CUDA kernel:
         # ``point_bbox > -dim/2 && point_bbox < dim/2``).
-        inside = (
-            (point_local > -half_dim).all(dim=-1) & (point_local < half_dim).all(dim=-1)
-        )
+        inside = (point_local > -half_dim).all(dim=-1) & (point_local < half_dim).all(dim=-1)
         hit_local = inside.nonzero(as_tuple=False).squeeze(-1)
         if hit_local.numel() == 0:
             continue
         hit_pts = pt_idxs[hit_local]
 
-        # Last-write-wins: if multiple tracks hit the same point, the
-        # CUDA kernel races (atomicAdd-like behaviour); empirically the
-        # standalone uses a track-disjoint dataset, so we just overwrite.
-        interpolated_tracks_pose[hit_pts, :3] = c_pointtime[hit_local]
-        interpolated_tracks_pose[hit_pts, 3:] = q_pointtime[hit_local]
-        interpolated_tracks_idx[hit_pts] = track_id
+        # The CUDA implementation atomically reserves the next output slot and
+        # keeps counting even when the configured output capacity is exceeded.
+        slots = intersections_cnt[hit_pts].to(torch.long)
+        intersections_cnt[hit_pts] += 1
+        recorded = slots < max_intersections_per_point
+        if not torch.any(recorded):
+            continue
+        recorded_points = hit_pts[recorded]
+        recorded_slots = slots[recorded]
+        recorded_local = hit_local[recorded]
+        interpolated_tracks_pose[recorded_points, recorded_slots, :3] = c_pointtime[recorded_local]
+        interpolated_tracks_pose[recorded_points, recorded_slots, 3:] = q_pointtime[recorded_local]
+        interpolated_tracks_idx[recorded_points, recorded_slots] = track_id
+        if interpolated_points_local is not None:
+            interpolated_points_local[recorded_points, recorded_slots] = point_local[recorded_local]
 
-    return interpolated_tracks_pose, interpolated_tracks_idx
+    outputs = (intersections_cnt, interpolated_tracks_pose, interpolated_tracks_idx)
+    return outputs + ((interpolated_points_local,) if return_local_points else ())

--- a/instant_nurec/datasets/samplers.py
+++ b/instant_nurec/datasets/samplers.py
@@ -20,6 +20,7 @@ import logging
 import numpy as np
 
 from instant_nurec.config_schema.dataset import AdaptiveSequentialFrameBatchSamplerConfig
+from instant_nurec.datasets.instantnurec_base import InstantNuRecDataError
 from instant_nurec.utils.types import HalfClosedInterval
 
 
@@ -71,7 +72,9 @@ class AdaptiveSequentialFrameBatchSampler:
         sample_idx: int,
         camera_frame_timestamps_us: dict[str, np.ndarray],
         time_intervals: list[HalfClosedInterval],
+        rng: np.random.Generator | None = None,
     ) -> SampledSensorFrameIdxs:
+        del rng
         assert len(camera_frame_timestamps_us) > 0, "No camera timestamps is provided to the frame batch sampler"
         assert 0 <= sample_idx < self.n_samples_per_sequence, "Sample index out of bounds"
         assert len(time_intervals) > 0, "No time intervals to sample from"
@@ -122,3 +125,51 @@ class AdaptiveSequentialFrameBatchSampler:
 
         return sampled_sensor_frame_idxs
 
+
+class UniformFrameBatchSampler:
+    """Reference sampler: random start followed by a fixed time gap."""
+
+    def __init__(self, config: AdaptiveSequentialFrameBatchSamplerConfig, n_frames_per_sample: int):
+        self.n_frames_per_sample = n_frames_per_sample
+        self.n_samples_per_sequence = config.n_samples_per_sequence
+        self.frame_gap_timestamp_us = config.frame_gap_timestamp_us
+
+    def sample_frame_batch(
+        self,
+        sample_idx: int,
+        camera_frame_timestamps_us: dict[str, np.ndarray],
+        time_intervals: list[HalfClosedInterval],
+        rng: np.random.Generator | None = None,
+    ) -> SampledSensorFrameIdxs:
+        assert camera_frame_timestamps_us, "No camera timestamps provided to frame batch sampler"
+        assert 0 <= sample_idx < self.n_samples_per_sequence, "Sample index out of bounds"
+        if rng is None:
+            rng = np.random.default_rng()
+
+        total_gap = self.frame_gap_timestamp_us * (self.n_frames_per_sample - 1)
+        valid_intervals = [
+            (interval.start, interval.end - total_gap)
+            for interval in time_intervals
+            if interval.end - interval.start >= total_gap
+        ]
+        if not valid_intervals:
+            longest = max((interval.end - interval.start for interval in time_intervals), default=0)
+            raise InstantNuRecDataError(
+                f"Uniform sampling needs a contiguous span of {total_gap} us, but the longest is {longest} us"
+            )
+        counts = [end - start + 1 for start, end in valid_intervals]
+        draw = int(rng.integers(sum(counts)))
+        first_timestamp = 0
+        for (start, _), count in zip(valid_intervals, counts):
+            if draw < count:
+                first_timestamp = start + draw
+                break
+            draw -= count
+
+        reference_timestamps = [
+            first_timestamp + index * self.frame_gap_timestamp_us for index in range(self.n_frames_per_sample)
+        ]
+        return {
+            camera_id: [get_closest_frame_index(timestamps, timestamp) for timestamp in reference_timestamps]
+            for camera_id, timestamps in camera_frame_timestamps_us.items()
+        }

--- a/instant_nurec/datasets/tracks.py
+++ b/instant_nurec/datasets/tracks.py
@@ -187,6 +187,13 @@ class CuboidTracks(Tracks):
 
     cuboidtracks_data: CuboidTracksData
 
+    @dataclass(kw_only=True, slots=True)
+    class PointIntersectionResult:
+        intersections_cnt: torch.Tensor
+        interpolated_poses: lt.SE3
+        intersections_tracks_idx: torch.Tensor
+        intersections_points_local: torch.Tensor | None
+
     @property
     def cuboids_dims(self) -> torch.Tensor:
         return self.cuboidtracks_data.cuboids_dims
@@ -352,40 +359,59 @@ class CuboidTracks(Tracks):
         self,
         points: torch.Tensor,
         points_timestamps_us: torch.Tensor,
-        cuboids_dims_padding: torch.Tensor,
-    ) -> tuple[lt.SE3, torch.Tensor]:
+        cuboids_dims_padding: torch.Tensor | None = None,
+        max_intersections_per_point: int = 1,
+        with_local_points: bool = False,
+    ) -> CuboidTracks.PointIntersectionResult:
         """
-        For each point, returns the interpolated pose of the tracks that it is inside, as well as the track idx.
+        Return the cuboid-track intersections for each point.
 
         Inputs:
         - points: 3D points to check for inside check, [..., 3] [float]
         - points_timestamps_us: per point timestamp, [...] [int64]
-        - cuboids_dims_padding: 3d padding to add to cuboids, broadcastable to N_tracks x 3 [float]
+        - cuboids_dims_padding: optional 3d padding to add to cuboids,
+          broadcastable to N_tracks x 3 [float]
+        - max_intersections_per_point: maximum number of intersections stored per point
+        - with_local_points: whether to return point coordinates in each intersected cuboid frame
 
         Returns:
-        - interpolated_poses: for each point, the pose of the cuboid it is inside, [...] [SE3]
-        - interpolated_tracks_idx: for each point, the index of the intersected track (-1 if no intersection), [...] [int]
+        - PointIntersectionResult with leading dimensions matching ``points``
         """
 
         data_shape = points.shape[:-1]
         points = points.reshape(-1, 3).contiguous()
         points_timestamps_us = points_timestamps_us.reshape(-1).contiguous()
 
-        interpolated_tracks_pose_data, interpolated_tracks_idx = (
-            _point_cuboidtracks_intersection_interpolate_pose(
-                points,
-                points_timestamps_us,
-                self.tracks_packinfo,
-                self.tracks_poses.data,
-                self.tracks_timestamps_us,
-                self.cuboids_dims + cuboids_dims_padding,
-                self.max_track_n_poses,
-            )
+        cuboids_dims = self.cuboids_dims
+        if cuboids_dims_padding is not None:
+            cuboids_dims = cuboids_dims + cuboids_dims_padding
+
+        outputs = _point_cuboidtracks_intersection_interpolate_pose(
+            points=points,
+            points_timestamps_us=points_timestamps_us,
+            tracks_packinfo=self.tracks_packinfo,
+            tracks_poses=self.tracks_poses.data,
+            tracks_timestamps_us=self.tracks_timestamps_us,
+            cuboids_dims=cuboids_dims,
+            max_track_n_poses=self.max_track_n_poses,
+            max_intersections_per_point=max_intersections_per_point,
+            return_local_points=with_local_points,
         )
+        intersections_cnt = outputs[0].reshape(data_shape)
+        interpolated_tracks_pose_data = outputs[1]
+        intersections_tracks_idx = outputs[2].reshape(data_shape + (max_intersections_per_point,))
         interpolated_poses = lt.SE3(
-            interpolated_tracks_pose_data.reshape(data_shape + (interpolated_tracks_pose_data.shape[-1],))
+            interpolated_tracks_pose_data.reshape(data_shape + interpolated_tracks_pose_data.shape[-2:])
         )
-        return interpolated_poses, interpolated_tracks_idx.reshape(data_shape)
+        intersections_points_local = (
+            outputs[3].reshape(data_shape + (max_intersections_per_point, 3)) if with_local_points else None
+        )
+        return CuboidTracks.PointIntersectionResult(
+            intersections_cnt=intersections_cnt,
+            interpolated_poses=interpolated_poses,
+            intersections_tracks_idx=intersections_tracks_idx,
+            intersections_points_local=intersections_points_local,
+        )
 
     def interpolate_tracks_poses(
         self,
@@ -430,5 +456,3 @@ class CuboidTracks(Tracks):
         t_alpha = t_start + alpha[:, None] * (t_end - t_start)
 
         return lt.SE3.InitFromVec(torch.cat([t_alpha[:, :3], R_alpha.vec()], dim=1))
-
-

--- a/instant_nurec/model/backbone/decoders.py
+++ b/instant_nurec/model/backbone/decoders.py
@@ -45,12 +45,17 @@ from instant_nurec.model.backbone.grid_tokens import (
     build_grid_tokens,
     concat_grid_tokens,
 )
+from instant_nurec.model.supervision import MotionSupervision, SupervisionPack
 from instant_nurec.primitives.kelvin_primitive import (
     KelvinDynamicLayer,
     KelvinSemanticClass,
     KelvinStaticLayer,
 )
-from instant_nurec.utils.motion import TimeRemapping, warp_points_with_cuboid_tracks
+from instant_nurec.utils.motion import (
+    TimeRemapping,
+    associate_points_with_cuboid_tracks,
+    warp_points_with_cuboid_tracks,
+)
 from instant_nurec.utils.batch import DataAndRenderingBatch
 from instant_nurec.utils.misc import unpack_optional
 from instant_nurec.utils.nn_extensions import TypedModuleList
@@ -64,6 +69,7 @@ class KelvinDecoderReturn:
     # Allowing all dynamic layers
     static_layer: KelvinStaticLayer | None
     dynamic_layers: list[KelvinDynamicLayer]
+    supervision_pack: SupervisionPack
 
 
 @dataclass(kw_only=True, slots=True)
@@ -315,6 +321,7 @@ class KelvinDPTDecoder(nn.Module):
         depth_and_dconf = self.depth_head(img_feats, output_shape=(H, W), chunk_size=self.config.dpt_chunk_size)
         depth_and_dconf = rearrange(depth_and_dconf, "(B V) C H W -> B V C H W", B=B, V=V)
         pred_depth = torch.exp(depth_and_dconf[:, :, 0].unsqueeze(-1) - math.log(scene_rescale))  # (B, V, H, W, 1)
+        pred_distance_confidence = torch.exp(depth_and_dconf[:, :, 1].unsqueeze(-1)) + 1.0
 
         # Forward and activate context
         img_rgb = rearrange(img_rgb, "B V H W C -> (B V) C H W")
@@ -369,41 +376,38 @@ class KelvinDPTDecoder(nn.Module):
             context_next_flow_list: list[torch.Tensor] = []
             context_dynamic_mask_list: list[torch.Tensor] = []
             for bidx in range(B):
-                dynamic_track = CuboidTracks.Ops.subset_from_mask(
-                    cuboid_tracks[bidx], cuboid_tracks[bidx].tracks_flags & TrackFlags.DYNAMIC != 0
-                )
+                batch_cuboid_tracks = cuboid_tracks[bidx]
                 context_xyz = (
                     pred_depth[bidx].detach()
                     / renderings[bidx].distance_to_depth_scale
                     * renderings[bidx].rays[..., 3:]
                     + renderings[bidx].rays[..., :3]
                 )
-                # Auxiliary association via car-ray-cuboid intersection on movable rays. This serves
-                # as a fallback when point-cuboid intersection misses (e.g. due to inaccurate depth).
-                # Rays with multiple intersections are deemed ambiguous (-1).
-                movable_mask = context_dynamic_mask[bidx]
-                aux_ray_intersection_result = dynamic_track.ray_intersection(
-                    renderings[bidx].rays[..., :3][movable_mask],
-                    renderings[bidx].rays[..., 3:][movable_mask],
-                    source_timestamps_us[bidx, ..., 0][movable_mask],
-                    max_intersections_per_ray=2,
+                tracks_idx = associate_points_with_cuboid_tracks(
+                    points=context_xyz,
+                    points_timestamps_us=source_timestamps_us[bidx],
+                    points_dynamic_mask=context_dynamic_mask[bidx].unsqueeze(-1),
+                    cuboid_tracks=batch_cuboid_tracks,
+                    cuboids_dims_padding=self.cuboids_dims_padding,
                 )
-                aux_movable_tracks_idx = aux_ray_intersection_result.intersections_tracks_idx[..., 0]
-                aux_movable_tracks_idx[aux_ray_intersection_result.intersections_cnt != 1] = -1
-                aux_tracks_idx = torch.full_like(movable_mask, -1, dtype=aux_movable_tracks_idx.dtype)
-                aux_tracks_idx[movable_mask] = aux_movable_tracks_idx
+                # Association runs against all tracks so overlapping static
+                # cuboids participate in nearest-box selection. Only dynamic
+                # assignments are retained for motion.
+                dynamic_track_mask = (batch_cuboid_tracks.tracks_flags & TrackFlags.DYNAMIC) != 0
+                if dynamic_track_mask.numel() > 0:
+                    is_dynamic_track = dynamic_track_mask[tracks_idx.clamp_min(0).to(torch.long)]
+                    tracks_idx.masked_fill_(~is_dynamic_track, -1)
 
                 dynamic_mask, (prev_world_points, next_world_points) = warp_points_with_cuboid_tracks(
                     points=context_xyz,
                     source_timestamps_us=source_timestamps_us[bidx],
                     target_timestamps_us_list=[prev_target_timestamps_us[bidx], next_target_timestamps_us[bidx]],
-                    dynamic_tracks=dynamic_track,
-                    aux_tracks_idx=aux_tracks_idx,
-                    cuboids_dims_padding=self.cuboids_dims_padding,
+                    cuboid_tracks=batch_cuboid_tracks,
+                    tracks_idx=tracks_idx,
                 )
                 context_prev_flow_list.append(prev_world_points - context_xyz)
                 context_next_flow_list.append(next_world_points - context_xyz)
-                context_dynamic_mask_list.append(dynamic_mask)
+                context_dynamic_mask_list.append(dynamic_mask.squeeze(-1))
 
             # Replace with ones from gt cuboids.
             context_prev_flow = torch.stack(context_prev_flow_list, dim=0)
@@ -494,6 +498,25 @@ class KelvinDPTDecoder(nn.Module):
                 KelvinDecoderReturn(
                     static_layer=static_layer,
                     dynamic_layers=[dynamic_layer],
+                    supervision_pack=SupervisionPack(
+                        context_depth=pred_depth[bidx],
+                        context_distance_confidence=pred_distance_confidence[bidx],
+                        context_rgb=context_rgb[bidx],
+                        context_world_normal=context_world_normal[bidx],
+                        context_semantic_logits=context_semantic_logits[bidx],
+                        motion_supervisions=[
+                            MotionSupervision(
+                                context_flow=context_prev_flow[bidx],
+                                source_timestamps_us=source_timestamps_us[bidx],
+                                target_timestamps_us=prev_target_timestamps_us[bidx],
+                            ),
+                            MotionSupervision(
+                                context_flow=context_next_flow[bidx],
+                                source_timestamps_us=source_timestamps_us[bidx],
+                                target_timestamps_us=next_target_timestamps_us[bidx],
+                            ),
+                        ],
+                    ),
                 )
             )
 

--- a/instant_nurec/model/blocks/dav3.py
+++ b/instant_nurec/model/blocks/dav3.py
@@ -13,12 +13,137 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
+import re
+
+from collections.abc import Callable
+
 import torch
 import torch.nn as nn
 
 from instant_nurec.model.blocks.attention import AttentionBlock
 from instant_nurec.model.blocks.layers import FeedForwardMLP
 from instant_nurec.utils.geometry import so3_matrix_to_quat
+
+
+_WeightTarget = str | Callable[[re.Match[str]], str] | None
+_DAV3_WEIGHT_RULES: tuple[tuple[str, _WeightTarget], ...] = (
+    (r"model\.backbone\.pretrained\.patch_embed\.(.*)", r"PATCH_EMBED.\1"),
+    (r"model\.backbone\.pretrained\.blocks\.(.*)", r"BACKBONE.blocks.\1"),
+    (r"model\.backbone\.pretrained\.norm\.(.*)", r"BACKBONE.norm_layer.\1"),
+    (r"model\.head\.projects\.(\d+)\.(.*)", r"DPT_REASSEMBLE.proj_layers.\1.\2"),
+    (r"model\.head\.resize_layers\.(\d+)\.(.*)", r"DPT_REASSEMBLE.resize_layers.\1.\2"),
+    (r"model\.head\.norm\.(.*)", r"DPT_REASSEMBLE.norm_layer.\1"),
+    (
+        r"model\.head\.scratch\.layer(\d+)_rn\.(.*)",
+        lambda match: f"DPT_REASSEMBLE.output_layers.{int(match.group(1)) - 1}.{match.group(2)}",
+    ),
+    (
+        r"model\.head\.scratch\.refinenet(\d+)\.(resConfUnit[12])\.(conv[12])\.(.*)",
+        lambda match: (
+            f"DPT_DEPTH_HEAD.refinement_blocks.{int(match.group(1)) - 1}."
+            f"{'res_block' if match.group(2) == 'resConfUnit1' else 'main_block'}."
+            f"{'1' if match.group(3) == 'conv1' else '3'}.{match.group(4)}"
+        ),
+    ),
+    (
+        r"model\.head\.scratch\.refinenet(\d+)\.out_conv\.(.*)",
+        lambda match: f"DPT_DEPTH_HEAD.refinement_blocks.{int(match.group(1)) - 1}.out_conv.{match.group(2)}",
+    ),
+    (
+        r"model\.head\.scratch\.refinenet(\d+)_aux\.(resConfUnit[12])\.(conv[12])\.(.*)",
+        lambda match: (
+            f"DPT_RAYS_HEAD.refinement_blocks.{int(match.group(1)) - 1}."
+            f"{'res_block' if match.group(2) == 'resConfUnit1' else 'main_block'}."
+            f"{'1' if match.group(3) == 'conv1' else '3'}.{match.group(4)}"
+        ),
+    ),
+    (
+        r"model\.head\.scratch\.refinenet(\d+)_aux\.out_conv\.(.*)",
+        lambda match: f"DPT_RAYS_HEAD.refinement_blocks.{int(match.group(1)) - 1}.out_conv.{match.group(2)}",
+    ),
+    (r"model\.head\.scratch\.output_conv1\.(.*)", r"DPT_DEPTH_HEAD.before_conv.\1"),
+    (r"model\.head\.scratch\.output_conv2\.(.*)", r"DPT_DEPTH_HEAD.after_conv.\1"),
+    (r"model\.head\.scratch\.output_conv1_aux\.3\.(.*)", r"DPT_RAYS_HEAD.before_conv.\1"),
+    (
+        r"model\.head\.scratch\.output_conv2_aux\.3\.(\d+)\.(.*)",
+        lambda match: (
+            f"DPT_RAYS_HEAD.after_conv.{ {0: 0, 2: 1, 5: 3}[int(match.group(1))] }.{match.group(2)}"
+        ),
+    ),
+    (r"model\.head\.scratch\.output_conv1_aux\.(.*)", None),
+    (r"model\.head\.scratch\.output_conv2_aux\.(.*)", None),
+    (r"model\.cam_enc\.(.*)", r"CAMERA_ENCODER.\1"),
+    (r"model\.cam_dec\.(.*)", None),
+    (r"model\.gs_head\.(.*)", None),
+)
+
+
+def convert_dav3_state_dict(
+    state_dict: dict[str, torch.Tensor],
+    *,
+    patch_embed_name: str | None,
+    backbone_name: str | None,
+    dpt_reassemble_name: str | None,
+    dpt_depth_head_name: str | None,
+    dpt_rays_head_name: str | None,
+    camera_encoder_name: str | None,
+) -> dict[str, torch.Tensor]:
+    """Map an official Depth Anything V3 checkpoint into Instant NuRec modules."""
+
+    names = {
+        "PATCH_EMBED": patch_embed_name,
+        "BACKBONE": backbone_name,
+        "DPT_REASSEMBLE": dpt_reassemble_name,
+        "DPT_DEPTH_HEAD": dpt_depth_head_name,
+        "DPT_RAYS_HEAD": dpt_rays_head_name,
+        "CAMERA_ENCODER": camera_encoder_name,
+    }
+    compiled_rules = tuple((re.compile(pattern), target) for pattern, target in _DAV3_WEIGHT_RULES)
+    converted: dict[str, torch.Tensor] = {}
+    for key, value in state_dict.items():
+        mapped: dict[str, torch.Tensor] | None = None
+        for pattern, target in compiled_rules:
+            match = pattern.fullmatch(key)
+            if match is None:
+                continue
+            if target is None:
+                mapped = {}
+            elif isinstance(target, str):
+                mapped = {match.expand(target): value}
+            else:
+                mapped = {target(match): value}
+            break
+
+        if mapped is None and key.startswith("model.backbone.pretrained."):
+            source_key = key.removeprefix("model.backbone.pretrained.")
+            if source_key == "cls_token":
+                mapped = {"BACKBONE.cls_tokens": value.squeeze(1)}
+            elif source_key == "pos_embed":
+                class_position = value[:, :1]
+                image_position = value[:, 1:]
+                grid_size = math.isqrt(image_position.shape[1])
+                if grid_size * grid_size != image_position.shape[1]:
+                    raise ValueError("DAv3 positional embedding is not a square image grid")
+                mapped = {
+                    "BACKBONE.cls_pos_embed": class_position.squeeze(1),
+                    "BACKBONE.img_pos_embed": image_position.squeeze(0).reshape(
+                        grid_size, grid_size, image_position.shape[2]
+                    ),
+                }
+            elif source_key == "camera_token":
+                mapped = {"BACKBONE.default_global_cls_tokens": value.moveaxis(0, 1)}
+        if mapped is None:
+            raise ValueError(f"Unknown DAv3 checkpoint key: {key}")
+
+        for mapped_key, mapped_value in mapped.items():
+            for placeholder, replacement in names.items():
+                if placeholder not in mapped_key:
+                    continue
+                if replacement is not None:
+                    converted[mapped_key.replace(placeholder, replacement)] = mapped_value
+                break
+    return converted
 
 
 class CameraEncoder(nn.Module):

--- a/instant_nurec/model/blocks/layers.py
+++ b/instant_nurec/model/blocks/layers.py
@@ -66,6 +66,7 @@ class LayerNorm2d(nn.Module):
 
     def __init__(self, n_dim: int, eps: float = 1e-6) -> None:
         super().__init__()
+        self.n_dim = n_dim
         self.weight = nn.Parameter(torch.ones(n_dim))
         self.bias = nn.Parameter(torch.zeros(n_dim))
         self.eps = eps
@@ -77,8 +78,6 @@ class LayerNorm2d(nn.Module):
         Returns:
             (B, C, H, W) tensor
         """
-        u = x.mean(1, keepdim=True)
-        s = (x - u).pow(2).mean(1, keepdim=True)
-        x = (x - u) / torch.sqrt(s + self.eps)
-        x = self.weight[:, None, None] * x + self.bias[:, None, None]
-        return x
+        x = x.permute(0, 2, 3, 1)
+        x = nn.functional.layer_norm(x, (self.n_dim,), self.weight, self.bias, self.eps)
+        return x.permute(0, 3, 1, 2)

--- a/instant_nurec/model/inference.py
+++ b/instant_nurec/model/inference.py
@@ -42,7 +42,10 @@ from instant_nurec.primitives.kelvin_primitive import (
 from instant_nurec.utils.batch import DataAndRenderingBatch
 from instant_nurec.utils.geometry import tquat_to_se3_matrix
 from instant_nurec.utils.misc import unpack_optional
-from instant_nurec.utils.motion import warp_points_with_cuboid_tracks
+from instant_nurec.utils.motion import (
+    associate_points_with_cuboid_tracks,
+    warp_points_with_cuboid_tracks,
+)
 from instant_nurec.utils.sensor import to_simple_pinhole_model_parameters
 from instant_nurec.utils.types import TrackFlags
 
@@ -118,8 +121,7 @@ class KelvinInferenceModel(nn.Module):
         c2w = c2w.unsqueeze(0)  # (1, V, 4, 4)
 
         pinhole_parameters = [
-            to_simple_pinhole_model_parameters(rendering.sensor_model_parameters[vidx])
-            for vidx in range(data.b)
+            to_simple_pinhole_model_parameters(rendering.sensor_model_parameters[vidx]) for vidx in range(data.b)
         ]
         fov_list = []
         for p in pinhole_parameters:
@@ -129,9 +131,7 @@ class KelvinInferenceModel(nn.Module):
         fov = torch.tensor(fov_list, dtype=torch.float32, device=rgb.device).unsqueeze(0)
 
         camera_idxs = (
-            torch.tensor([meta.unique_sensor_idx for meta in data.meta], dtype=torch.int64)
-            .to(rgb.device)
-            .unsqueeze(0)
+            torch.tensor([meta.unique_sensor_idx for meta in data.meta], dtype=torch.int64).to(rgb.device).unsqueeze(0)
         )
 
         return rgb, c2w, fov, rays, distance_to_depth_scale, camera_idxs
@@ -149,8 +149,8 @@ class KelvinInferenceModel(nn.Module):
         Without ``cuboid_tracks_b``: dynamic_mask is purely the semantic
         argmax-equals-MOVABLE.
 
-        With ``cuboid_tracks_b``: refine via point-cuboid intersection
-        (and fallback ray-cuboid intersection on movable rays).
+        With ``cuboid_tracks_b``: associate points using the same two-pass
+        cuboid contract as training, then keep only dynamic-track assignments.
         """
         # Single-batch slice: dense outputs have shapes (V, H, W, 3) and
         # (V, H, W); point-query outputs have shapes (N, 3) and (N,).
@@ -160,42 +160,34 @@ class KelvinInferenceModel(nn.Module):
         if cuboid_tracks_b is None:
             return semantic_v == self._semantic_movable_value()
 
-        dynamic_track = CuboidTracks.Ops.subset_from_mask(
-            cuboid_tracks_b, cuboid_tracks_b.tracks_flags & TrackFlags.DYNAMIC != 0
-        )
-
         movable_mask = semantic_v == self._semantic_movable_value()
-        rays = rendering_camera.rays  # (V, H, W, 6)
         ray_ts = unpack_optional(rendering_camera.rays_timestamps_us)  # (V, H, W, 1)
         if source_indices is not None:
             # The sparse decoder carries each Gaussian's flattened source-pixel
-            # index so cuboid-track association uses the aligned ray and time.
+            # index so cuboid-track association uses the aligned time.
             source_indices_v = source_indices[0].long()
-            rays = rays.reshape(-1, 6)[source_indices_v]
             ray_ts = ray_ts.reshape(-1, 1)[source_indices_v]
 
-        aux_ray_intersection_result = dynamic_track.ray_intersection(
-            rays[..., :3][movable_mask],
-            rays[..., 3:][movable_mask],
-            ray_ts[..., 0][movable_mask],
-            max_intersections_per_ray=2,
+        tracks_idx = associate_points_with_cuboid_tracks(
+            points=gs_xyz_v,
+            points_timestamps_us=ray_ts,
+            points_dynamic_mask=movable_mask.unsqueeze(-1),
+            cuboid_tracks=cuboid_tracks_b,
+            cuboids_dims_padding=self.cuboids_dims_padding,
         )
-        aux_movable_tracks_idx = aux_ray_intersection_result.intersections_tracks_idx[..., 0]
-        aux_movable_tracks_idx[aux_ray_intersection_result.intersections_cnt != 1] = -1
-        aux_tracks_idx = torch.full_like(movable_mask, -1, dtype=aux_movable_tracks_idx.dtype)
-        aux_tracks_idx[movable_mask] = aux_movable_tracks_idx
+        dynamic_track_mask = (cuboid_tracks_b.tracks_flags & TrackFlags.DYNAMIC) != 0
+        if dynamic_track_mask.numel() > 0:
+            is_dynamic_track = dynamic_track_mask[tracks_idx.clamp_min(0).to(torch.long)]
+            tracks_idx.masked_fill_(~is_dynamic_track, -1)
 
-        prev_target_ts = ray_ts.clone()  # placeholder -- only dynamic_mask is used downstream
-        next_target_ts = ray_ts.clone()
         dynamic_mask, _ = warp_points_with_cuboid_tracks(
             points=gs_xyz_v,
             source_timestamps_us=ray_ts,
-            target_timestamps_us_list=[prev_target_ts, next_target_ts],
-            dynamic_tracks=dynamic_track,
-            aux_tracks_idx=aux_tracks_idx,
-            cuboids_dims_padding=self.cuboids_dims_padding,
+            target_timestamps_us_list=[ray_ts],
+            cuboid_tracks=cuboid_tracks_b,
+            tracks_idx=tracks_idx,
         )
-        return dynamic_mask
+        return dynamic_mask.squeeze(-1)
 
     @staticmethod
     def _semantic_movable_value() -> int:

--- a/instant_nurec/model/kelvin.py
+++ b/instant_nurec/model/kelvin.py
@@ -30,10 +30,12 @@ from instant_nurec.model.backbone.decoders import KelvinDPTDecoder
 from instant_nurec.model.backbone.encoders import KelvinDAv3Encoder
 from instant_nurec.model.backbone.sky import CubemapDecoderSky
 from instant_nurec.model.post_processing import PerCameraAffinePostProcessing
+from instant_nurec.model.supervision import SupervisionPack
 from instant_nurec.primitives.kelvin_primitive import KelvinInstantNuRecPrimitive
 from instant_nurec.utils.motion import TimeRemapping
 from instant_nurec.utils.batch import DataAndRenderingBatch
 from instant_nurec.utils.misc import unpack_optional
+from instant_nurec.utils.types import RayFlags
 
 
 logger = logging.getLogger(__name__)
@@ -57,16 +59,49 @@ class KelvinInstantNuRec(nn.Module):
         self.encoder = KelvinDAv3Encoder(config.encoder, config)
         self.decoder = KelvinDPTDecoder(config.decoder, config)
         self.sky = CubemapDecoderSky(config.sky, config)
-        self.post_processing = PerCameraAffinePostProcessing(
-            embed_dim=config.encoder.embed_dim, init_token_scale=0.02
+        self.post_processing = (
+            PerCameraAffinePostProcessing(embed_dim=config.encoder.embed_dim, init_token_scale=0.02)
+            if config.post_processing.enabled
+            else None
         )
         self.scene_rescale = self.config.scene_rescale
         self.cuboids_dims_padding = torch.nn.Buffer(torch.tensor(self.config.track_padding_m, dtype=torch.float32))
+        if config.freeze_encoder:
+            for parameter in self.encoder.parameters():
+                parameter.requires_grad = False
 
     def prepare_context(
         self,
         context: list[DataAndRenderingBatch],
     ) -> list[DataAndRenderingBatch]:
+        for batch in context:
+            camera = batch.data.camera
+            rendering = batch.rendering.camera if batch.rendering is not None else None
+            if camera is None or rendering is None:
+                continue
+            labels = camera.labels
+            if labels.normals is not None or labels.metric_distance is None:
+                continue
+            points = rendering.rays[..., :3] + labels.metric_distance * rendering.rays[..., 3:]
+            normals = torch.zeros_like(points)
+            normals[:, 1:-1, 1:-1] = torch.nn.functional.normalize(
+                torch.cross(
+                    points[:, 2:, 1:-1] - points[:, :-2, 1:-1],
+                    points[:, 1:-1, 2:] - points[:, 1:-1, :-2],
+                    dim=-1,
+                ),
+                dim=-1,
+            )
+            valid = (
+                (labels.metric_distance[:, 2:, 1:-1] > 0)
+                & (labels.metric_distance[:, :-2, 1:-1] > 0)
+                & (labels.metric_distance[:, 1:-1, 2:] > 0)
+                & (labels.metric_distance[:, 1:-1, :-2] > 0)
+            )
+            normals[:, 1:-1, 1:-1][~valid.squeeze(-1)] = 0
+            labels.normals = normals
+            if labels.flags is not None:
+                labels.flags[:, 1:-1, 1:-1][valid] |= int(RayFlags.VALID_NORMAL)
         return context
 
     @staticmethod
@@ -101,6 +136,12 @@ class KelvinInstantNuRec(nn.Module):
         camera_idxs: torch.Tensor,
     ) -> torch.Tensor:
         # This affine transform is also used by the static PLY inference path.
+        if self.post_processing is None:
+            B = encoded_latent.deepest.shape[0]
+            n_cameras = torch.unique(camera_idxs[0]).numel()
+            affine = torch.zeros(B, n_cameras, 3, 4, device=encoded_latent.deepest.device, dtype=torch.float32)
+            affine[..., :3, :3] = torch.eye(3, device=affine.device)
+            return affine
         _, affine_latents = self.post_processing.transform_tokens(
             rearrange(encoded_latent.deepest, "B V h w C -> B (V h w) C"), camera_idxs
         )
@@ -130,7 +171,16 @@ class KelvinInstantNuRec(nn.Module):
         context: list[DataAndRenderingBatch],
         cuboid_tracks: list[CuboidTracks] | None,
     ) -> list[KelvinInstantNuRecPrimitive]:
-        # Add assertions about input context -- num_images and num_views should match
+        primitives, _ = self.reconstruct_with_supervision(context, cuboid_tracks)
+        return primitives
+
+    def reconstruct_with_supervision(
+        self,
+        context: list[DataAndRenderingBatch],
+        cuboid_tracks: list[CuboidTracks] | None,
+    ) -> tuple[list[KelvinInstantNuRecPrimitive], list[SupervisionPack]]:
+        """Reconstruct primitives and retain the dense training predictions."""
+
         num_imgs, num_views, camera_idxs, time_remappings = self._grab_metainfo(context)
 
         encoded_latent = self.encoder.encode(context, self.scene_rescale)
@@ -147,5 +197,13 @@ class KelvinInstantNuRec(nn.Module):
         sky_cubemaps = self.sky.decode(encoded_latent, context).contiguous()
 
         affine_matrix = self._compute_affine_matrix(encoded_latent, camera_idxs)
+        packs = [decoder_return.supervision_pack for decoder_return in decoder_returns]
+        for pack, sky_cubemap in zip(packs, sky_cubemaps):
+            pack.predicted_sky_cubemap = sky_cubemap
+        return self._build_primitives(context, decoder_returns, sky_cubemaps, affine_matrix), packs
 
-        return self._build_primitives(context, decoder_returns, sky_cubemaps, affine_matrix)
+    def update_step_train_batch_start(self, global_step: int) -> None:
+        if self.post_processing is not None:
+            self.post_processing.set_detach_linear_grad(
+                global_step < self.config.post_processing.optimization_start_global_step
+            )

--- a/instant_nurec/model/post_processing.py
+++ b/instant_nurec/model/post_processing.py
@@ -52,6 +52,7 @@ class PerCameraAffinePostProcessing(nn.Module):
             allow_legacy_state_dict=True,
         )
         self.affine_token = nn.Parameter(torch.randn(self.embed_dim) * self.init_token_scale)
+        self._detach_linear_grad = False
 
     def _transform_tokens_cross_attention(
         self, x: torch.Tensor, camera_idxs: torch.Tensor
@@ -102,12 +103,21 @@ class PerCameraAffinePostProcessing(nn.Module):
             affine_bias: (B, n_affine_tokens, 3)
         """
         affine: torch.Tensor = self.affine_linear(x.float())  # (B, n_affine_tokens, 3 * 4)
+        if self._detach_linear_grad:
+            affine = affine.detach()
         affine_matrix, affine_bias = affine.split([3 * 3, 3], dim=-1)
         affine_matrix = (
             rearrange(affine_matrix, "B n (a b) -> B n a b", a=3, b=3)
             + torch.eye(3, device=x.device, dtype=x.dtype)[None, None]
         )
         return affine_matrix, affine_bias
+
+    def zero_init(self) -> None:
+        self.affine_linear.weight.data.zero_()
+        self.affine_linear.bias.data.zero_()
+
+    def set_detach_linear_grad(self, detach: bool) -> None:
+        self._detach_linear_grad = detach
 
     def forward(self, *args, **kwargs):
         raise NotImplementedError("Please use transform_tokens or decode_affine instead.")

--- a/instant_nurec/model/supervision.py
+++ b/instant_nurec/model/supervision.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Differentiable predictions consumed by the training losses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(kw_only=True, slots=True)
+class MotionSupervision:
+    context_flow: torch.Tensor
+    source_timestamps_us: torch.Tensor
+    target_timestamps_us: torch.Tensor
+    reference_flow: torch.Tensor | None = None
+
+
+@dataclass(kw_only=True, slots=True)
+class SupervisionPack:
+    """Differentiable supervision produced by the full model."""
+
+    context_depth: torch.Tensor | None = None
+    context_distance_confidence: torch.Tensor | None = None
+    context_rgb: torch.Tensor | None = None
+    context_world_normal: torch.Tensor | None = None
+    context_semantic_logits: torch.Tensor | None = None
+    motion_supervisions: list[MotionSupervision] | None = None
+    predicted_sky_cubemap: torch.Tensor | None = None
+    reference_sky_cubemap: torch.Tensor | None = None
+    reference_sky_cubemap_mask: torch.Tensor | None = None

--- a/instant_nurec/predict/render_preview.py
+++ b/instant_nurec/predict/render_preview.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import inspect
+import os
 
 from dataclasses import dataclass
 from pathlib import Path
@@ -30,9 +31,23 @@ class RenderPreviewStats:
     sky_contribution_mean: float
 
 
+def _configure_gsplat_build() -> None:
+    """Limit gsplat's fallback JIT build to Instant NuRec's render contract.
+
+    Upstream gsplat otherwise builds every renderer and a broad set of channel
+    specializations.  Instant NuRec uses only calibrated 3DGUT with RGB (three
+    channels) and RGB-d (four channels).  ``setdefault`` keeps explicit user or
+    deployment build choices authoritative.
+    """
+
+    os.environ.setdefault("BUILD_3DGUT", "1")
+    os.environ.setdefault("NUM_CHANNELS", "3,4")
+
+
 def require_gsplat():
     """Import and return gsplat's rasterizer before reconstruction starts."""
 
+    _configure_gsplat_build()
     try:
         from gsplat import rasterization
     except (ImportError, OSError) as exc:  # pragma: no cover - depends on optional install
@@ -102,15 +117,7 @@ def _looks_like_ftheta(parameters: object) -> bool:
 def _ftheta_gsplat_parameters(parameters: object) -> tuple[object, object, object]:
     """Convert NCore F-theta parameters to public gsplat's host types."""
 
-    external_distortion = getattr(parameters, "external_distortion_parameters", None)
-    if external_distortion is None:
-        external_distortion = getattr(parameters, "external_distortion", None)
-    if external_distortion is not None:
-        raise NotImplementedError(
-            "F-theta rendering with external windshield distortion is not "
-            "supported by this public calibrated-render path."
-        )
-
+    _configure_gsplat_build()
     try:
         from gsplat.rendering import (
             FThetaCameraDistortionParameters,
@@ -152,6 +159,85 @@ def _ftheta_gsplat_parameters(parameters: object) -> tuple[object, object, objec
     return ftheta_coeffs, rolling_shutter, RollingShutterType.GLOBAL
 
 
+def _external_distortion_gsplat_parameters(parameters: object) -> object | None:
+    """Convert NCore's bivariate windshield model to the gsplat host object."""
+
+    external = getattr(parameters, "external_distortion_parameters", None)
+    if external is None:
+        external = getattr(parameters, "external_distortion", None)
+    if external is None:
+        return None
+    required = (
+        "reference_poly",
+        "horizontal_poly",
+        "vertical_poly",
+        "horizontal_poly_inverse",
+        "vertical_poly_inverse",
+    )
+    if not all(hasattr(external, name) for name in required):
+        raise TypeError(f"Unsupported external distortion model: {type(external).__name__}")
+    _configure_gsplat_build()
+    try:
+        from gsplat.rendering import (
+            BivariateWindshieldModelParameters,
+            ExternalDistortionReferencePolynomial,
+        )
+    except (ImportError, OSError) as exc:  # pragma: no cover - optional install
+        raise RuntimeError("The pinned gsplat build is required for windshield distortion") from exc
+
+    reference_name = getattr(
+        external.reference_poly,
+        "name",
+        str(external.reference_poly).rsplit(".", maxsplit=1)[-1],
+    )
+    try:
+        reference_poly = ExternalDistortionReferencePolynomial[reference_name]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported external-distortion reference polynomial: {external.reference_poly!r}") from exc
+
+    result = BivariateWindshieldModelParameters()
+    result.reference_poly = reference_poly
+    for name in required[1:]:
+        values = torch.as_tensor(getattr(external, name), dtype=torch.float32, device="cpu")
+        if values.numel() > BivariateWindshieldModelParameters.MAX_COEFFS:
+            raise ValueError(
+                f"{name} has {values.numel()} coefficients; gsplat supports at most "
+                f"{BivariateWindshieldModelParameters.MAX_COEFFS}"
+            )
+        setattr(result, name, values)
+    return result
+
+
+def _reference_ut_parameters() -> object:
+    """Return the reference 3DGUT unscented-transform profile."""
+
+    _configure_gsplat_build()
+    try:
+        from gsplat.rendering import UnscentedTransformParameters
+    except (ImportError, OSError) as exc:  # pragma: no cover - optional install
+        raise RuntimeError("The pinned gsplat build is required for calibrated rendering") from exc
+    return UnscentedTransformParameters(
+        alpha=1.0,
+        beta=2.0,
+        kappa=0.0,
+        in_image_margin_factor=0.1,
+        require_all_sigma_points_valid=True,
+    )
+
+
+def _reference_renderer_config() -> object:
+    """Select the reference parallel-batch eval3d rasterizer."""
+
+    _configure_gsplat_build()
+    try:
+        from gsplat.rendering import RendererConfig_ParallelBatch
+    except (ImportError, OSError) as exc:  # pragma: no cover - optional install
+        raise RuntimeError(
+            "The pinned gsplat build with ParallelBatch support is required for calibrated rendering"
+        ) from exc
+    return RendererConfig_ParallelBatch()
+
+
 @torch.inference_mode()
 def render_composited_frame(
     primitive: KelvinInstantNuRecPrimitive,
@@ -187,6 +273,7 @@ def render_composited_frame(
 
     rasterization = require_gsplat()
     ftheta_coeffs, rolling_shutter, global_shutter = _ftheta_gsplat_parameters(sensor_parameters)
+    external_distortion_coeffs = _external_distortion_gsplat_parameters(sensor_parameters)
     focal = float(sensor_parameters.angle_to_pixeldist_poly[1])
     cx, cy = (float(value) for value in sensor_parameters.principal_point)
     intrinsics = torch.tensor(
@@ -223,10 +310,13 @@ def render_composited_frame(
         camera_model="ftheta",
         packed=False,
         with_ut=True,
+        ut_params=_reference_ut_parameters(),
+        renderer_config=_reference_renderer_config(),
         with_eval3d=True,
         global_z_order=False,
         rays=world_rays.unsqueeze(0),
         ftheta_coeffs=ftheta_coeffs,
+        external_distortion_coeffs=external_distortion_coeffs,
         rolling_shutter=rolling_shutter,
         viewmats_rs=(world_to_camera_end.unsqueeze(0) if rolling_shutter != global_shutter else None),
     )

--- a/instant_nurec/primitives/kelvin_primitive.py
+++ b/instant_nurec/primitives/kelvin_primitive.py
@@ -269,6 +269,9 @@ class KelvinDynamicLayer(KelvinLayer):
     max_densities: torch.Tensor
     keyframe_positions: torch.Tensor
     keyframe_timestamps_us: torch.Tensor
+    falloff: bool = True
+
+    FALLOFF_GAUSSIAN_EXP = 10.0
 
     def __post_init__(self):
         super().__post_init__()
@@ -315,11 +318,63 @@ class KelvinDynamicLayer(KelvinLayer):
 
     @classmethod
     def concatenate(cls, layers: Sequence[Self]) -> Self:
+        if not layers:
+            raise ValueError("Cannot concatenate an empty dynamic-layer sequence")
+        if any(layer.falloff != layers[0].falloff for layer in layers[1:]):
+            raise ValueError("All concatenated dynamic layers must use the same falloff setting")
         return cls(
             max_densities=torch.cat([layer.max_densities for layer in layers], dim=0),
             keyframe_positions=torch.cat([layer.keyframe_positions for layer in layers], dim=0),
             keyframe_timestamps_us=torch.cat([layer.keyframe_timestamps_us for layer in layers], dim=0),
+            falloff=layers[0].falloff,
             **asdict(KelvinLayer._concatenate_base(layers)),
+        )
+
+    def interpolate(self, timestamp_us: int) -> KelvinStaticLayer:
+        """Interpolate piecewise motion and apply edge-segment falloff."""
+
+        if timestamp_us < 0:
+            raise ValueError("Timestamp must be non-negative")
+        query = torch.full(
+            (len(self), 1),
+            timestamp_us,
+            dtype=self.keyframe_timestamps_us.dtype,
+            device=self.device(),
+        )
+        indices = torch.searchsorted(self.keyframe_timestamps_us, query).clamp(1, self.n_keyframes - 1)
+        left_timestamps = torch.gather(self.keyframe_timestamps_us, 1, indices - 1)
+        right_timestamps = torch.gather(self.keyframe_timestamps_us, 1, indices)
+        alpha = (query - left_timestamps) / (right_timestamps - left_timestamps)
+
+        left_positions = torch.gather(
+            self.keyframe_positions,
+            1,
+            (indices - 1).expand(-1, 3)[:, None],
+        )[:, 0]
+        right_positions = torch.gather(
+            self.keyframe_positions,
+            1,
+            indices.expand(-1, 3)[:, None],
+        )[:, 0]
+        positions = torch.lerp(left_positions, right_positions, alpha)
+
+        densities = self.max_densities
+        if self.falloff:
+            leftmost = torch.where(indices == 1)[0]
+            rightmost = torch.where(indices == self.n_keyframes - 1)[0]
+            factor = torch.ones_like(densities)
+            factor[leftmost] *= 1.0 - torch.exp(
+                -((1.0 + torch.clamp(alpha[leftmost], min=-1.0)) ** self.FALLOFF_GAUSSIAN_EXP)
+            )
+            factor[rightmost] *= torch.exp(-(alpha[rightmost] ** self.FALLOFF_GAUSSIAN_EXP))
+            densities = densities * factor
+
+        return KelvinStaticLayer(
+            positions=positions,
+            densities=densities,
+            rotations=self.rotations,
+            scales=self.scales,
+            rgb=self.rgb,
         )
 
 

--- a/instant_nurec/training/__init__.py
+++ b/instant_nurec/training/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from instant_nurec.training.system import TrainingSystem
+
+__all__ = ["TrainingSystem"]

--- a/instant_nurec/training/callbacks.py
+++ b/instant_nurec/training/callbacks.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import threading
+
+from pathlib import Path
+from types import FrameType
+from typing import Any
+
+from pytorch_lightning import LightningModule, Trainer
+from pytorch_lightning.callbacks import Callback
+
+
+logger = logging.getLogger(__name__)
+
+
+class PreemptionInterrupt(RuntimeError):
+    """Raised after a requested preemption checkpoint is safely published."""
+
+
+class AtomicCheckpointAndExitOnSignalCallback(Callback):
+    """Checkpoint after the current batch and exit when a signal is received.
+
+    The signal handler only sets a flag. All checkpoint work happens at a
+    Lightning batch boundary, collectively across ranks. The checkpoint is
+    written to ``<path>.tmp`` and atomically renamed on rank zero, allowing an
+    outer host/Slurm script to requeue the job without requiring ``scontrol``
+    inside the training container.
+    """
+
+    def __init__(
+        self,
+        checkpoint_path: Path,
+        signal_type: int | None = signal.SIGUSR1,
+        check_every_n_batches: int = 1,
+    ) -> None:
+        super().__init__()
+        if check_every_n_batches < 1:
+            raise ValueError("check_every_n_batches must be at least 1")
+        self.checkpoint_path = Path(checkpoint_path)
+        self.signal_type = signal_type
+        self.check_every_n_batches = check_every_n_batches
+        self.preempting = False
+        self._previous_handler: Any = None
+        self._signal_handler = self._mark_preempting
+        self._install_signal_handler()
+
+    def _install_signal_handler(self) -> None:
+        if self.signal_type is None or threading.current_thread() is not threading.main_thread():
+            return
+        if self._previous_handler is None:
+            self._previous_handler = signal.getsignal(self.signal_type)
+        signal.signal(self.signal_type, self._signal_handler)
+
+    def _mark_preempting(self, signum: int, frame: FrameType | None) -> None:
+        del signum, frame
+        # Keep the Python signal handler side-effect-free apart from the flag;
+        # logging and I/O happen at the next synchronized batch boundary.
+        self.preempting = True
+
+    def teardown(self, trainer: Trainer, pl_module: LightningModule, stage: str) -> None:
+        del trainer, pl_module, stage
+        if (
+            self.signal_type is not None
+            and self._previous_handler is not None
+            and threading.current_thread() is threading.main_thread()
+            and signal.getsignal(self.signal_type) == self._signal_handler
+        ):
+            signal.signal(self.signal_type, self._previous_handler)
+
+    def on_train_batch_end(
+        self,
+        trainer: Trainer,
+        pl_module: LightningModule,
+        outputs: Any,
+        batch: Any,
+        batch_idx: int,
+    ) -> None:
+        del pl_module, outputs, batch
+        if batch_idx % self.check_every_n_batches == 0:
+            self._check_preempting(trainer, restart_validation=False)
+
+    def on_validation_batch_end(
+        self,
+        trainer: Trainer,
+        pl_module: LightningModule,
+        outputs: Any,
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> None:
+        del pl_module, outputs, batch, dataloader_idx
+        if batch_idx % self.check_every_n_batches == 0:
+            self._check_preempting(trainer, restart_validation=True)
+
+    def _check_preempting(self, trainer: Trainer, *, restart_validation: bool) -> None:
+        # A host launcher normally signals rank zero, but reduce across all
+        # ranks as well so forwarding the signal to any worker is sufficient.
+        self.preempting = trainer.strategy.reduce_boolean_decision(self.preempting, all=False)
+        if not self.preempting:
+            # Some JIT extensions replace process signal handlers. Reinstalling
+            # it at batch boundaries keeps preemption reliable.
+            self._install_signal_handler()
+            return
+
+        logger.warning("Saving atomic preemption checkpoint to %s.", self.checkpoint_path)
+
+        # on_train_batch_end runs after ``processed`` but before ``completed``
+        # advances. Make the checkpoint represent a completed batch so
+        # Lightning does not replay it. Validation is deliberately restarted
+        # from its beginning because epoch metrics cannot be resumed exactly.
+        train_progress = trainer.fit_loop.epoch_loop.batch_progress
+        train_progress.total.completed = train_progress.total.processed
+        train_progress.current.completed = train_progress.current.processed
+        validation_progress = trainer.fit_loop.epoch_loop.val_loop.batch_progress
+        validation_progress.reset()
+        if restart_validation:
+            # Lightning 2.6 recognizes a mid-evaluation restart only when the
+            # checkpoint contains one started but not yet processed batch. An
+            # all-zero progress state is instead classified as a checkpoint on
+            # the last train batch, which makes TrainingEpochLoop skip the next
+            # validation run entirely. Store the minimal interrupted-batch
+            # sentinel; EvaluationLoop.reset_on_restart() clears it before the
+            # validation dataloader is replayed from batch zero.
+            validation_progress.increment_ready()
+            validation_progress.increment_started()
+
+        if trainer.is_global_zero:
+            self.checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+        trainer.strategy.barrier("preemption_checkpoint_directory")
+
+        temporary_path = Path(f"{self.checkpoint_path}.tmp")
+        trainer.save_checkpoint(temporary_path)
+        if trainer.is_global_zero:
+            os.replace(temporary_path, self.checkpoint_path)
+        trainer.strategy.barrier("preemption_checkpoint_publish")
+
+        if trainer.is_global_zero:
+            experiment = getattr(trainer.logger, "experiment", None)
+            mark_preempting = getattr(experiment, "mark_preempting", None)
+            if callable(mark_preempting):
+                mark_preempting()
+
+        raise PreemptionInterrupt(f"checkpoint saved to {self.checkpoint_path}")

--- a/instant_nurec/training/data.py
+++ b/instant_nurec/training/data.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+import weakref
+
+from pytorch_lightning import LightningDataModule
+from pytorch_lightning.callbacks import Callback
+import torch
+from torch.utils.data import BatchSampler, DataLoader, RandomSampler, Sampler
+
+from instant_nurec.config_schema.dataset import NCoreInstantNuRecDatasetConfig
+from instant_nurec.config_schema.train import TrainingConfig
+from instant_nurec.datasets.instantnurec_ncore import NCoreInstantNuRecDataset
+from instant_nurec.datasets.mixture import NCoreMixtureDataset
+from instant_nurec.utils.batch import InstantNuRecDataBatch
+
+
+logger = logging.getLogger(__name__)
+
+
+class SkipBatchSampler(BatchSampler):
+    """Skip completed batches while preserving the original epoch length.
+
+    ``sampler`` deliberately remains the first constructor argument. Lightning
+    reconstructs custom batch samplers with an injected ``DistributedSampler``
+    for DDP and preserves ``first_batch_idx`` from the captured constructor
+    arguments.
+    """
+
+    def __init__(
+        self,
+        sampler: Sampler,
+        batch_size: int,
+        drop_last: bool = False,
+        first_batch_idx: int = 0,
+    ) -> None:
+        super().__init__(sampler, batch_size, drop_last)
+        if first_batch_idx < 0:
+            raise ValueError(f"first_batch_idx must be non-negative, got {first_batch_idx}")
+        self.first_batch_idx = first_batch_idx
+
+    def __iter__(self):
+        for batch_idx, batch in enumerate(super().__iter__()):
+            if batch_idx >= self.first_batch_idx:
+                yield batch
+
+    # Do not subtract ``first_batch_idx`` here. Lightning restores its loop
+    # progress from the checkpoint and needs the original number of batches to
+    # continue emitting epoch-global batch indices (and scheduler progress).
+
+
+class TrainingDataModule(LightningDataModule):
+    def __init__(self, config: TrainingConfig):
+        super().__init__()
+        self.config = config
+        self.train_dataset: NCoreInstantNuRecDataset | NCoreMixtureDataset | None = None
+        self.val_dataset: NCoreInstantNuRecDataset | NCoreMixtureDataset | None = None
+        self._next_train_batch_idx = 0
+
+    def state_dict(self) -> dict[str, int]:
+        """Persist the first not-yet-completed train batch for mid-epoch resume."""
+
+        return {"next_train_batch_idx": self._next_train_batch_idx}
+
+    def load_state_dict(self, state_dict: dict) -> None:
+        self._next_train_batch_idx = int(state_dict.get("next_train_batch_idx", 0))
+
+    def _make_dataset(self, dataset_config):
+        if not isinstance(dataset_config, NCoreInstantNuRecDatasetConfig):
+            return NCoreMixtureDataset(
+                dataset_config,
+                global_seed=self.config.seed,
+                retry_on_error=True,
+            )
+        return NCoreInstantNuRecDataset(
+            dataset_config,
+            frame_width=dataset_config.camera_subsampler.frame_width,
+            frame_height=dataset_config.camera_subsampler.frame_height,
+            n_frames_per_sample=dataset_config.frame_batch_sampler.n_frames_per_sample,
+            global_seed=self.config.seed,
+            retry_on_error=True,
+        )
+
+    def train_dataloader(self) -> DataLoader:
+        dataset_config = self.config.dataset.train
+        assert dataset_config is not None
+        if self.train_dataset is None:
+            self.train_dataset = self._make_dataset(dataset_config)
+        trainer = getattr(self, "trainer", None)
+        if trainer is not None:
+            self.train_dataset.set_rng_epoch(trainer.current_epoch)
+            self.train_dataset.set_epoch(trainer.current_epoch)
+
+        if self._next_train_batch_idx:
+            logger.info("Skipping %d completed train batches after resume.", self._next_train_batch_idx)
+
+        # Seed the single-process RandomSampler exactly like the distributed
+        # sampler (global seed + epoch). This makes the underlying permutation
+        # reconstructible after a restart. In distributed runs Lightning sees
+        # RandomSampler and injects its DistributedSampler into
+        # SkipBatchSampler, retaining first_batch_idx.
+        epoch = trainer.current_epoch if trainer is not None else 0
+        generator = torch.Generator().manual_seed(self.config.seed + epoch)
+        batch_sampler = SkipBatchSampler(
+            sampler=RandomSampler(self.train_dataset, generator=generator),
+            batch_size=self.config.system.train_batch_size,
+            first_batch_idx=self._next_train_batch_idx,
+        )
+        return DataLoader(
+            self.train_dataset,
+            num_workers=self.config.system.train_num_workers,
+            pin_memory=True,
+            batch_sampler=batch_sampler,
+            # Dataloaders are recreated each epoch to propagate rng_epoch into
+            # workers, exactly as in the reference Lightning implementation.
+            persistent_workers=False,
+            collate_fn=InstantNuRecDataBatch.collate_fn,
+        )
+
+    def val_dataloader(self) -> DataLoader | list:
+        dataset_config = self.config.dataset.val
+        if dataset_config is None:
+            # Lightning DataModule hooks must return an iterable collection,
+            # not None, when a phase intentionally has no validation split.
+            return []
+        if self.val_dataset is None:
+            self.val_dataset = self._make_dataset(dataset_config)
+        trainer = getattr(self, "trainer", None)
+        if trainer is not None:
+            # Validation samples are deliberately epoch-independent.  Only the
+            # augmentation epoch changes; rng_epoch stays at its default -1.
+            self.val_dataset.set_epoch(trainer.current_epoch)
+        return DataLoader(
+            self.val_dataset,
+            batch_size=self.config.system.val_batch_size,
+            num_workers=self.config.system.val_num_workers,
+            shuffle=False,
+            pin_memory=False,
+            persistent_workers=False,
+            collate_fn=InstantNuRecDataBatch.collate_fn,
+        )
+
+
+class ResumableDataModuleCallback(Callback):
+    """Advance the data-module cursor before any batch checkpoint is saved."""
+
+    def __init__(self, datamodule: TrainingDataModule) -> None:
+        super().__init__()
+        self._datamodule = weakref.ref(datamodule)
+
+    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx: int) -> None:
+        del trainer, pl_module, outputs, batch
+        if (datamodule := self._datamodule()) is not None:
+            # Lightning resumes with an epoch-global batch_idx, including after
+            # repeated mid-epoch interruptions.
+            datamodule._next_train_batch_idx = batch_idx + 1
+
+    def on_train_epoch_end(self, trainer, pl_module) -> None:
+        del trainer, pl_module
+        if (datamodule := self._datamodule()) is not None:
+            datamodule._next_train_batch_idx = 0

--- a/instant_nurec/training/losses.py
+++ b/instant_nurec/training/losses.py
@@ -1,0 +1,311 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+from torchvision.transforms.functional import gaussian_blur
+
+from instant_nurec.config_schema.train import TrainingLossConfig
+from instant_nurec.model.supervision import SupervisionPack
+from instant_nurec.primitives.kelvin_primitive import KelvinSemanticClass
+from instant_nurec.training.renderer import RenderOutput
+from instant_nurec.utils.batch import DataAndRenderingBatch
+from instant_nurec.utils.misc import unpack_optional
+from instant_nurec.utils.types import RayFlags
+
+
+@dataclass(kw_only=True, slots=True)
+class LossReturn:
+    total_value: torch.Tensor
+    values: dict[str, torch.Tensor]
+    skipped: tuple[str, ...]
+
+
+def _masked_mean(value: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+    if mask is None:
+        return value.mean()
+    while mask.ndim < value.ndim:
+        mask = mask.unsqueeze(-1)
+    mask = mask.expand_as(value)
+    return (value * mask).sum() / mask.sum().clamp_min(1)
+
+
+def _weighted_masked_mean(
+    value: torch.Tensor,
+    mask: torch.Tensor,
+    weights: torch.Tensor,
+) -> torch.Tensor:
+    """Zero weighted-out values while retaining them in the denominator."""
+
+    while mask.ndim < value.ndim:
+        mask = mask.unsqueeze(-1)
+    while weights.ndim < value.ndim:
+        weights = weights.unsqueeze(-1)
+    expanded_mask = mask.expand_as(value)
+    expanded_weights = weights.expand_as(value)
+    return (value * expanded_mask * expanded_weights).sum() / expanded_mask.sum().clamp_min(1)
+
+
+def _quantile_mean(value: torch.Tensor, quantile: float = 0.98) -> torch.Tensor:
+    flat = value.flatten()
+    keep = int(flat.numel() * quantile)
+    if keep == 0:
+        return value.new_tensor(0.0)
+    return flat[flat.argsort()[:keep]].mean()
+
+
+def _semantic_targets(labels) -> torch.Tensor:
+    flags = unpack_optional(labels.flags)
+    targets = torch.full(flags.shape[:-1], int(KelvinSemanticClass.OTHERS), dtype=torch.long, device=flags.device)
+    # Reference priority (last write wins): ROAD < SKY < MOVABLE < EGO.
+    targets[labels.get_mask_flags_all(RayFlags.ROAD_SEMANTIC).squeeze(-1)] = int(KelvinSemanticClass.ROAD)
+    targets[labels.get_mask_flags_all(RayFlags.SKY_SEMANTIC).squeeze(-1)] = int(KelvinSemanticClass.SKY)
+    targets[labels.get_mask_flags_all(RayFlags.VEHICLE_SEMANTIC).squeeze(-1)] = int(KelvinSemanticClass.MOVABLE)
+    targets[labels.get_mask_flags_all(RayFlags.EGO_SEMANTIC).squeeze(-1)] = int(KelvinSemanticClass.EGO)
+    return targets
+
+
+def _required(value, name: str):
+    if value is None:
+        raise RuntimeError(f"Configured training loss requires {name}, but it is unavailable")
+    return value
+
+
+class TrainingLosses(torch.nn.Module):
+    """Loss profile for the two-phase full-model training recipe."""
+
+    def __init__(self, config: TrainingLossConfig):
+        super().__init__()
+        self.config = config
+        self._lpips = None
+        if config.lpips > 0:
+            try:
+                import lpips
+            except ImportError as exc:
+                raise RuntimeError("LPIPS render loss requires the training extra") from exc
+            self._lpips = lpips.LPIPS(net="vgg")
+            self._lpips.eval()
+            for parameter in self._lpips.parameters():
+                parameter.requires_grad = False
+
+    def _context_losses(
+        self,
+        pack: SupervisionPack,
+        context: DataAndRenderingBatch,
+    ) -> tuple[dict[str, torch.Tensor], list[str]]:
+        labels = unpack_optional(context.data.camera).labels
+        rendering = unpack_optional(unpack_optional(context.rendering).camera)
+        values: dict[str, torch.Tensor] = {}
+        skipped: list[str] = []
+        if self.config.primitive_rgb > 0:
+            context_rgb = _required(pack.context_rgb, "model context RGB")
+            reference_rgb = _required(labels.rgb, "context RGB labels")
+            values["primitive_rgb"] = (context_rgb - reference_rgb).abs().mean()
+
+        geometry_enabled = self.config.primitive_distance > 0 or self.config.primitive_distance_gradient > 0
+        if geometry_enabled:
+            gt_distance = _required(labels.metric_distance, "context metric-distance labels")
+            context_depth = _required(pack.context_depth, "model context depth")
+            pred_distance = context_depth / rendering.distance_to_depth_scale
+            valid = (
+                (gt_distance > self.config.distance_min_m)
+                & (gt_distance < self.config.primitive_distance_max_m)
+                & labels.get_mask_flags_none(RayFlags.INVALID)
+            )
+            if valid.any():
+                if self.config.primitive_distance > 0:
+                    values["primitive_distance"] = _quantile_mean((pred_distance - gt_distance).abs()[valid])
+                if self.config.primitive_distance_gradient > 0:
+                    gradient_valid = valid & (
+                        gt_distance < self.config.primitive_distance_gradient_max_m
+                    )
+                    gradient_terms = []
+                    for stride in (1, 2, 4, 8):
+                        pred = pred_distance[:, ::stride, ::stride]
+                        gt = gt_distance[:, ::stride, ::stride]
+                        mask = gradient_valid[:, ::stride, ::stride]
+                        residual = pred - gt
+                        du = torch.diff(residual, dim=2, prepend=residual[:, :, :1]).clamp(-100, 100)
+                        dv = torch.diff(residual, dim=1, prepend=residual[:, :1]).clamp(-100, 100)
+                        mask_u = mask & torch.roll(mask, 1, dims=2)
+                        mask_v = mask & torch.roll(mask, 1, dims=1)
+                        mask_u[:, :, 0] = False
+                        mask_v[:, 0] = False
+                        if mask_u.any():
+                            gradient_terms.append(du[mask_u.expand_as(du)].abs())
+                        if mask_v.any():
+                            gradient_terms.append(dv[mask_v.expand_as(dv)].abs())
+                    if gradient_terms:
+                        values["primitive_distance_gradient"] = torch.cat(gradient_terms).mean()
+            else:
+                skipped.extend(
+                    name
+                    for name, weight in (
+                        ("primitive_distance", self.config.primitive_distance),
+                        ("primitive_distance_gradient", self.config.primitive_distance_gradient),
+                    )
+                    if weight > 0
+                )
+        if self.config.primitive_semantics > 0:
+            semantic_logits = _required(pack.context_semantic_logits, "model context semantic logits")
+            _required(labels.flags, "context semantic flags")
+            targets = _semantic_targets(labels)
+            values["primitive_semantics"] = F.cross_entropy(
+                semantic_logits.moveaxis(-1, 1),
+                targets,
+            )
+
+        if self.config.primitive_normal > 0 and pack.context_world_normal is not None and labels.normals is not None:
+            valid = labels.get_mask_flags_all(RayFlags.VALID_NORMAL)
+            valid &= labels.get_mask_flags_none(RayFlags.SKY_SEMANTIC | RayFlags.INVALID)
+            if valid.any():
+                cosine = (pack.context_world_normal * labels.normals).sum(dim=-1)
+                values["primitive_normal"] = (1.0 - cosine)[valid.squeeze(-1)].mean()
+            else:
+                skipped.append("primitive_normal")
+        elif self.config.primitive_normal > 0:
+            skipped.append("primitive_normal")
+
+        if self.config.primitive_velocity > 0 and pack.motion_supervisions:
+            valid_motion = [motion for motion in pack.motion_supervisions if motion.reference_flow is not None]
+            if valid_motion:
+                pred = torch.cat([motion.context_flow for motion in valid_motion], dim=-1)
+                target = torch.cat([unpack_optional(motion.reference_flow) for motion in valid_motion], dim=-1)
+                moving = torch.linalg.vector_norm(target.reshape(*target.shape[:-1], -1, 3), dim=-1).amax(dim=-1) > 0.01
+                if moving.any():
+                    vehicle = labels.get_mask_flags_all(RayFlags.VEHICLE_SEMANTIC).squeeze(-1)
+                    weights = torch.where(vehicle, 1.0, 0.1)
+                    values["primitive_velocity"] = _weighted_masked_mean(
+                        (pred - target).abs(),
+                        moving,
+                        weights,
+                    )
+                else:
+                    skipped.append("primitive_velocity")
+            else:
+                skipped.append("primitive_velocity")
+        elif self.config.primitive_velocity > 0:
+            skipped.append("primitive_velocity")
+
+        if self.config.primitive_sky_cubemap > 0:
+            predicted_sky = _required(pack.predicted_sky_cubemap, "model sky cubemap")
+            reference_sky = _required(pack.reference_sky_cubemap, "reference sky cubemap")
+            reference_sky_mask = _required(pack.reference_sky_cubemap_mask, "reference sky cubemap mask")
+            predicted_smoothed = gaussian_blur(
+                predicted_sky.permute(0, 3, 1, 2),
+                kernel_size=[29, 29],
+            ).permute(0, 2, 3, 1)
+            target = reference_sky.clone()
+            target_mask = reference_sky_mask[..., 0].bool()
+            target[~target_mask] = predicted_smoothed[~target_mask]
+            values["primitive_sky_cubemap"] = (predicted_sky - target).abs().mean()
+        return values, skipped
+
+    def _render_losses(
+        self,
+        output: RenderOutput | None,
+        supervision: DataAndRenderingBatch | None,
+    ) -> tuple[dict[str, torch.Tensor], list[str]]:
+        values: dict[str, torch.Tensor] = {}
+        skipped: list[str] = []
+        enabled = {
+            "rgb": self.config.rgb,
+            "lpips": self.config.lpips,
+            "distance": self.config.distance,
+            "background": self.config.background,
+        }
+        if output is None or supervision is None:
+            configured = [name for name, weight in enabled.items() if weight > 0]
+            if configured:
+                raise RuntimeError(
+                    "Configured render losses require rendered supervision; "
+                    f"missing output for: {', '.join(configured)}"
+                )
+            return values, skipped
+        labels = unpack_optional(supervision.data.camera).labels
+        valid = labels.get_mask_flags_all(RayFlags.RGB_LABEL) & labels.get_mask_flags_none(RayFlags.INVALID)
+        synthetic = labels.get_mask_flags_all(RayFlags.SYNTHETIC)
+        if self.config.rgb > 0:
+            reference_rgb = _required(labels.rgb, "supervision RGB labels")
+            valid_compact = valid.squeeze(-1)
+            synthetic_compact = synthetic.squeeze(-1)[valid_compact]
+            predicted_rgb = output.rgb.reshape_as(reference_rgb)
+            squared_error = F.mse_loss(
+                predicted_rgb[valid_compact],
+                reference_rgb[valid_compact],
+                reduction="none",
+            )
+            nonsynthetic_term = squared_error * (~synthetic_compact)[:, None]
+            synthetic_term = 0.25 * squared_error * synthetic_compact[:, None]
+            values["rgb"] = (nonsynthetic_term + synthetic_term).mean()
+
+        if self.config.lpips > 0:
+            reference_rgb = _required(labels.rgb, "supervision RGB labels")
+            pred = torch.where(valid.expand_as(output.rgb), output.rgb, reference_rgb)
+            pred = pred.permute(0, 3, 1, 2) * 2 - 1
+            target = reference_rgb.permute(0, 3, 1, 2) * 2 - 1
+            longest = max(pred.shape[-2:])
+            if longest > 512:
+                scale = 512 / longest
+                shape = (int(pred.shape[-2] * scale), int(pred.shape[-1] * scale))
+                pred = F.interpolate(pred, shape, mode="bilinear", align_corners=False)
+                target = F.interpolate(target, shape, mode="bilinear", align_corners=False)
+            values["lpips"] = self._lpips(pred, target).mean()
+
+        if self.config.distance > 0 and labels.metric_distance is not None:
+            gt = labels.metric_distance
+            distance_valid = (
+                (gt > self.config.distance_min_m)
+                & (gt < self.config.render_distance_max_m)
+                & labels.get_mask_flags_none(RayFlags.INVALID | RayFlags.HARMONIZED)
+            )
+            if distance_valid.any():
+                expected = output.distance / output.opacity.clamp_min(1.0e-6)
+                error = (
+                    expected.clamp_min(self.config.distance_min_m).reciprocal()
+                    - gt.clamp_min(self.config.distance_min_m).reciprocal()
+                ).square()
+                values["distance"] = _weighted_masked_mean(
+                    error,
+                    distance_valid,
+                    ~synthetic,
+                )
+            else:
+                skipped.append("distance")
+        elif self.config.distance > 0:
+            # Render distance is one of the official allow-missing losses.
+            skipped.append("distance")
+
+        if self.config.background > 0:
+            sky = labels.get_mask_flags_all(RayFlags.SKY_SEMANTIC)
+            bg_valid = labels.get_mask_flags_none(
+                RayFlags.INVALID | RayFlags.HARMONIZED | RayFlags.SYNTHETIC
+            )
+            if bg_valid.any():
+                foreground_target = (~sky).float()
+                values["background"] = _masked_mean(
+                    (output.opacity.clamp(0, 1) - foreground_target).square(), bg_valid
+                )
+            else:
+                skipped.append("background")
+        return values, skipped
+
+    def forward(
+        self,
+        pack: SupervisionPack,
+        context: DataAndRenderingBatch,
+        output: RenderOutput | None = None,
+        supervision: DataAndRenderingBatch | None = None,
+    ) -> LossReturn:
+        context_values, context_skipped = self._context_losses(pack, context)
+        render_values, render_skipped = self._render_losses(output, supervision)
+        values = context_values | render_values
+        weights = self.config.model_dump()
+        if not values:
+            raise RuntimeError("No training loss is active for this batch; check labels and loss weights")
+        total = sum(value * float(weights[name]) for name, value in values.items())
+        return LossReturn(total_value=total, values=values, skipped=tuple(context_skipped + render_skipped))

--- a/instant_nurec/training/optim.py
+++ b/instant_nurec/training/optim.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+import math
+
+import torch
+
+from instant_nurec.config_schema.train import TrainingOptimizerConfig, TrainingSchedulerConfig
+
+
+logger = logging.getLogger(__name__)
+
+
+class CosineWithWarmupPBScheduler(torch.optim.lr_scheduler.LRScheduler):
+    """Progress-based schedule used by the reference training recipe."""
+
+    def __init__(self, optimizer: torch.optim.Optimizer, config: TrainingSchedulerConfig, last_epoch: int = -1):
+        self.warmup_factor = config.warmup_factor
+        self.warmup_steps = config.warmup_steps
+        self.cosine_factor = config.cosine_factor
+        self.cosine_factor_progress = config.cosine_factor_progress
+        self._current_epoch = 0
+        self._total_epochs = 0
+        self._current_local_step = 0
+        self._total_local_steps = 0
+        super().__init__(optimizer, last_epoch)
+
+    def set_progress(self, epoch: int, total_epochs: int, local_step: int, total_local_steps: int) -> None:
+        self._current_epoch = epoch
+        self._total_epochs = total_epochs
+        self._current_local_step = local_step
+        self._total_local_steps = total_local_steps
+
+    def get_lr(self) -> list[float]:
+        if self._step_count <= 1:
+            return [float(group["initial_lr"]) * 1.0e-6 for group in self.optimizer.param_groups]
+        if self._total_local_steps <= 0 or self._total_epochs <= 0:
+            raise RuntimeError("set_progress() must be called before stepping the training scheduler")
+        current_global_step = self._current_epoch * self._total_local_steps + self._current_local_step
+        if current_global_step < self.warmup_steps:
+            denominator = max(self.warmup_steps - 1, 1)
+            warmup_progress = current_global_step / denominator
+            factor = self.warmup_factor + (1.0 - self.warmup_factor) * warmup_progress
+        else:
+            denominator = max(self._total_epochs * self._total_local_steps - self.warmup_steps, 1)
+            progress = (current_global_step - self.warmup_steps) / denominator
+            progress = min(progress / self.cosine_factor_progress, 1.0)
+            factor = self.cosine_factor + (1.0 - self.cosine_factor) * (1.0 + math.cos(math.pi * progress)) / 2.0
+        return [float(group["initial_lr"]) * factor for group in self.optimizer.param_groups]
+
+
+def make_optimizer(
+    parameters,
+    config: TrainingOptimizerConfig,
+) -> tuple[torch.optim.Optimizer, str]:
+    kwargs = {
+        "lr": config.lr,
+        "eps": config.eps,
+        "betas": config.betas,
+        "weight_decay": config.weight_decay,
+    }
+    if config.implementation in ("auto", "apex-fused-adam"):
+        try:
+            from apex.optimizers import FusedAdam
+
+            return FusedAdam(parameters, **kwargs), "apex-fused-adam"
+        except (ImportError, RuntimeError) as exc:
+            if config.implementation == "apex-fused-adam":
+                raise RuntimeError(
+                    "Exact optimizer-kernel matching requires apex.optimizers.FusedAdam; install NVIDIA Apex "
+                    "or select implementation=torch-adam for a numerically non-bitwise fallback."
+                ) from exc
+            logger.warning("Apex FusedAdam is unavailable; using torch.optim.Adam (not bitwise equivalent).")
+    return torch.optim.Adam(parameters, **kwargs), "torch-adam"

--- a/instant_nurec/training/renderer.py
+++ b/instant_nurec/training/renderer.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+from torch.utils.checkpoint import checkpoint
+
+from instant_nurec.predict.render_preview import (
+    _configure_gsplat_build,
+    _external_distortion_gsplat_parameters,
+    _ftheta_gsplat_parameters,
+    _reference_renderer_config,
+    _reference_ut_parameters,
+    _looks_like_ftheta,
+    require_gsplat,
+)
+from instant_nurec.primitives.kelvin_primitive import KelvinInstantNuRecPrimitive
+from instant_nurec.utils.batch import DataAndRenderingBatch
+from instant_nurec.utils.cubemap import sample_sky_cubemap
+from instant_nurec.utils.geometry import se3_matrix_inverse, tquat_to_se3_matrix
+from instant_nurec.utils.misc import unpack_optional
+from instant_nurec.utils.types import RayFlags
+
+
+@dataclass(kw_only=True, slots=True)
+class RenderOutput:
+    rgb: torch.Tensor
+    opacity: torch.Tensor
+    distance: torch.Tensor
+    sky_rgb: torch.Tensor
+
+
+def _gather_gaussians(primitive: KelvinInstantNuRecPrimitive, timestamp_us: int):
+    static = primitive.static_layer
+    positions = [static.positions]
+    rotations = [static.rotations]
+    scales = [static.scales]
+    densities = [static.densities]
+    rgbs = [static.rgb]
+    for dynamic in primitive.dynamic_layers:
+        if len(dynamic) == 0:
+            continue
+        interpolated = dynamic.interpolate(timestamp_us)
+        positions.append(interpolated.positions)
+        rotations.append(interpolated.rotations)
+        scales.append(interpolated.scales)
+        densities.append(interpolated.densities)
+        rgbs.append(interpolated.rgb)
+    return tuple(torch.cat(values, dim=0).float() for values in (positions, rotations, scales, densities, rgbs))
+
+
+def _camera_kwargs(parameters: object, device: torch.device) -> tuple[torch.Tensor, dict]:
+    _configure_gsplat_build()
+    external_distortion = _external_distortion_gsplat_parameters(parameters)
+    if _looks_like_ftheta(parameters):
+        coeffs, rolling, global_shutter = _ftheta_gsplat_parameters(parameters)
+        focal = float(parameters.angle_to_pixeldist_poly[1])
+        cx, cy = (float(value) for value in parameters.principal_point)
+        K = torch.tensor([[focal, 0, cx], [0, focal, cy], [0, 0, 1]], device=device, dtype=torch.float32)
+        return K, {
+            "camera_model": "ftheta",
+            "ftheta_coeffs": coeffs,
+            "rolling_shutter": rolling,
+            "external_distortion_coeffs": external_distortion,
+            "_global_shutter": global_shutter,
+        }
+    required = ("focal_length", "principal_point", "radial_coeffs")
+    if not all(hasattr(parameters, name) for name in required):
+        raise TypeError(f"Unsupported training camera model: {type(parameters).__name__}")
+    fx, fy = (float(value) for value in parameters.focal_length)
+    cx, cy = (float(value) for value in parameters.principal_point)
+    K = torch.tensor([[fx, 0, cx], [0, fy, cy], [0, 0, 1]], device=device, dtype=torch.float32)
+    from gsplat.rendering import RollingShutterType
+
+    shutter_name = getattr(parameters.shutter_type, "name", str(parameters.shutter_type).rsplit(".", 1)[-1])
+    rolling = RollingShutterType[shutter_name]
+    is_fisheye = not hasattr(parameters, "tangential_coeffs")
+    camera_kwargs = {
+        "camera_model": "fisheye" if is_fisheye else "pinhole",
+        "radial_coeffs": torch.as_tensor(parameters.radial_coeffs, device=device, dtype=torch.float32)[None, None],
+        "external_distortion_coeffs": external_distortion,
+        "rolling_shutter": rolling,
+        "_global_shutter": RollingShutterType.GLOBAL,
+    }
+    if not is_fisheye:
+        camera_kwargs["tangential_coeffs"] = torch.as_tensor(
+            parameters.tangential_coeffs,
+            device=device,
+            dtype=torch.float32,
+        )[None, None]
+    return K, camera_kwargs
+
+
+def _render_supervision_frame(
+    primitive: KelvinInstantNuRecPrimitive,
+    supervision: DataAndRenderingBatch,
+    frame_index: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Render and postprocess one complete supervision frame."""
+
+    rasterization = require_gsplat()
+    rendering = unpack_optional(unpack_optional(supervision.rendering).camera)
+    camera_data = unpack_optional(supervision.data.camera)
+    frame_meta = camera_data.meta[frame_index]
+    rays = rendering.rays[frame_index].float().contiguous()
+    height, width = rays.shape[:2]
+    parameters = rendering.sensor_model_parameters[frame_index]
+    K, camera_kwargs = _camera_kwargs(parameters, rays.device)
+    global_shutter = camera_kwargs.pop("_global_shutter")
+    c2w_start = tquat_to_se3_matrix(rendering.poses_tquat_startend[frame_index, 0], unbatch=True).float()
+    c2w_end = tquat_to_se3_matrix(rendering.poses_tquat_startend[frame_index, 1], unbatch=True).float()
+    w2c_start = se3_matrix_inverse(c2w_start, unbatch=True)
+    w2c_end = se3_matrix_inverse(c2w_end, unbatch=True)
+    center_timestamp = int(rendering.timestamps_startend_us_cpu[frame_index].sum().item() // 2)
+    means, quats, scales, densities, colors = _gather_gaussians(primitive, center_timestamp)
+    rendered, alpha, _ = rasterization(
+        means=means[None],
+        quats=quats[None],
+        scales=scales[None],
+        opacities=densities[:, 0][None],
+        colors=colors[None],
+        viewmats=w2c_start[None, None],
+        Ks=K[None, None],
+        width=width,
+        height=height,
+        near_plane=0.2,
+        far_plane=torch.finfo(torch.float32).max,
+        radius_clip=0.0,
+        eps2d=0.5477225575051661**2,
+        sh_degree=None,
+        tile_size=None,
+        # Match the reference 3DGUT `RGB-d` contract: return opacity-weighted,
+        # along-ray hit distance here and normalize it exactly once in the
+        # render distance loss.
+        render_mode="RGB-d",
+        packed=False,
+        sparse_grad=False,
+        absgrad=False,
+        with_ut=True,
+        ut_params=_reference_ut_parameters(),
+        renderer_config=_reference_renderer_config(),
+        with_eval3d=True,
+        global_z_order=False,
+        rays=rays,
+        viewmats_rs=(w2c_end[None, None] if camera_kwargs["rolling_shutter"] != global_shutter else None),
+        **camera_kwargs,
+    )
+    foreground = rendered[0, 0, ..., :3].clamp(0.0, 1.0)
+    distance = rendered[0, 0, ..., 3:4]
+    opacity = alpha[0, 0]
+    sky = sample_sky_cubemap(primitive.sky_cubemap, rays[..., 3:])
+    # Only labeled GT-sky rays update the cubemap through render losses;
+    # foreground rays see a detached sky value.
+    sky_mask = camera_data.labels.get_mask_flags_all(RayFlags.SKY_SEMANTIC)[frame_index].float()
+    sky_for_composite = sky * sky_mask + sky.detach() * (1.0 - sky_mask)
+    composed = foreground + (1.0 - opacity) * sky_for_composite
+    if not 0 <= frame_meta.unique_sensor_idx < len(primitive.affine_matrix):
+        raise IndexError(
+            f"Camera unique_sensor_idx={frame_meta.unique_sensor_idx} has no affine token "
+            f"(available: 0..{len(primitive.affine_matrix) - 1})"
+        )
+    affine = primitive.affine_matrix[frame_meta.unique_sensor_idx].float()
+    composed = torch.einsum("...p,qp->...q", composed, affine[:, :3]) + affine[:, 3]
+    return composed.clamp(0.0, 1.0), opacity, distance, sky
+
+
+def render_supervision(
+    primitive: KelvinInstantNuRecPrimitive,
+    supervision: DataAndRenderingBatch,
+) -> RenderOutput:
+    """Differentiably render all supervision frames with calibrated world rays."""
+
+    camera_data = unpack_optional(supervision.data.camera)
+    outputs_rgb, outputs_opacity, outputs_distance, outputs_sky = [], [], [], []
+    for frame_index in range(len(camera_data.meta)):
+        rgb, opacity, distance, sky = checkpoint(
+            _render_supervision_frame,
+            primitive,
+            supervision,
+            frame_index,
+            use_reentrant=False,
+        )
+        outputs_rgb.append(rgb)
+        outputs_opacity.append(opacity)
+        outputs_distance.append(distance)
+        outputs_sky.append(sky)
+    return RenderOutput(
+        rgb=torch.stack(outputs_rgb),
+        opacity=torch.stack(outputs_opacity),
+        distance=torch.stack(outputs_distance),
+        sky_rgb=torch.stack(outputs_sky),
+    )

--- a/instant_nurec/training/run.py
+++ b/instant_nurec/training/run.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+
+from pathlib import Path
+from typing import Sequence
+
+import yaml
+import torch
+
+from pytorch_lightning import Trainer, seed_everything
+from pytorch_lightning.callbacks import Callback, ModelCheckpoint
+from pytorch_lightning.loggers import CSVLogger, WandbLogger
+
+from instant_nurec.config_schema.train import TrainingConfig
+from instant_nurec.training.callbacks import AtomicCheckpointAndExitOnSignalCallback, PreemptionInterrupt
+from instant_nurec.training.data import ResumableDataModuleCallback, TrainingDataModule
+from instant_nurec.training.system import TrainingSystem
+
+
+logger = logging.getLogger(__name__)
+
+
+def _is_distributed_run(config: TrainingConfig) -> bool:
+    if config.system.num_nodes > 1:
+        return True
+    devices = config.system.devices
+    if isinstance(devices, int):
+        if devices == -1:
+            return torch.cuda.device_count() > 1
+        return devices > 1
+    if devices == "auto":
+        if config.system.accelerator == "cpu":
+            return False
+        return torch.cuda.device_count() > 1
+    if devices == "-1":
+        return torch.cuda.device_count() > 1
+    return len([item for item in devices.split(",") if item.strip()]) > 1
+
+
+def resolve_training_strategy(config: TrainingConfig) -> str:
+    """Apply the reference find-unused requirement to distributed runs."""
+
+    strategy = config.system.strategy
+    if _is_distributed_run(config) and strategy in {
+        "auto",
+        "ddp",
+        "ddp_find_unused_parameters_false",
+    }:
+        return "ddp_find_unused_parameters_true"
+    return strategy
+
+
+def load_training_config(path: Path) -> TrainingConfig:
+    payload = yaml.safe_load(path.read_text())
+    if not isinstance(payload, dict):
+        raise ValueError(f"Training config must be a YAML mapping: {path}")
+    return TrainingConfig.model_validate(payload)
+
+
+def make_training_logger(config: TrainingConfig, out_dir: Path):
+    if config.logger.name == "csv":
+        return CSVLogger(save_dir=out_dir, name="logs")
+    return WandbLogger(
+        name=config.logger.run_name,
+        save_dir=out_dir,
+        offline=config.logger.offline,
+        id=config.run_id,
+        project=config.logger.project,
+        entity=config.logger.entity or None,
+        log_model=config.logger.log_model,
+        group=config.logger.group or None,
+        tags=config.logger.tags,
+        job_type=config.logger.job_type or None,
+        resume="allow",
+    )
+
+
+def initialize_resume_logger_before_distributed_setup(config: TrainingConfig, training_logger) -> bool:
+    """Initialize a resumed W&B run before Lightning enters DDP setup.
+
+    Lightning lazily creates logger experiments inside its setup hook, between
+    distributed collectives.  If a resumed W&B client blocks there, rank zero
+    never enters the matching barrier while all other ranks wait in NCCL.
+    External launchers already expose the global rank, so initialize W&B on
+    rank zero before ``Trainer.fit`` creates the process group instead.
+
+    Returns whether this process initialized the logger, which also keeps the
+    rank policy directly testable without starting a distributed job.
+    """
+
+    if config.logger.name != "wandb" or config.resume_from_checkpoint is None:
+        return False
+
+    external_rank = next(
+        (
+            int(value)
+            for name in ("RANK", "SLURM_PROCID", "OMPI_COMM_WORLD_RANK")
+            if (value := os.environ.get(name)) is not None
+        ),
+        None,
+    )
+    if external_rank not in {None, 0}:
+        return False
+    if external_rank is None and _is_distributed_run(config):
+        logger.warning(
+            "Cannot identify the external global rank before distributed setup; "
+            "leaving resumed W&B initialization to Lightning."
+        )
+        return False
+
+    logger.info("Initializing resumed W&B run before distributed setup on global rank zero.")
+    _ = training_logger.experiment
+    logger.info("Resumed W&B run initialized before distributed setup.")
+    return True
+
+
+def make_checkpoint_callback(config: TrainingConfig, out_dir: Path) -> ModelCheckpoint:
+    if config.system.save_every_n_train_steps is not None:
+        return ModelCheckpoint(
+            dirpath=out_dir / "checkpoints",
+            filename="epoch={epoch:02d}-step={step}",
+            save_last=True,
+            save_top_k=-1,
+            every_n_train_steps=config.system.save_every_n_train_steps,
+            # The signal callback also publishes last.ckpt. Keep a single
+            # rolling resume target instead of creating last-v1.ckpt.
+            enable_version_counter=False,
+        )
+    return ModelCheckpoint(
+        dirpath=out_dir / "checkpoints",
+        filename="epoch={epoch:02d}-psnr={val/psnr:.2f}",
+        save_last=True,
+        save_top_k=config.system.save_top_k,
+        monitor=config.system.checkpoint_monitor,
+        mode=config.system.checkpoint_mode,
+        every_n_epochs=1,
+        auto_insert_metric_name=False,
+        enable_version_counter=False,
+    )
+
+
+def make_training_callbacks(
+    config: TrainingConfig,
+    out_dir: Path,
+    datamodule: TrainingDataModule,
+) -> list[Callback]:
+    """Build callbacks in checkpoint-safe order.
+
+    The data cursor must advance before either the signal callback or regular
+    ModelCheckpoint observes the DataModule state.
+    """
+
+    callbacks: list[Callback] = [ResumableDataModuleCallback(datamodule)]
+    if config.system.save_on_preemption:
+        callbacks.append(AtomicCheckpointAndExitOnSignalCallback(out_dir / "checkpoints" / "last.ckpt"))
+    callbacks.append(make_checkpoint_callback(config, out_dir))
+    return callbacks
+
+
+def run_training(config: TrainingConfig) -> Path:
+    seed_everything(config.seed, workers=True)
+    effective_strategy = resolve_training_strategy(config)
+    if effective_strategy != config.system.strategy:
+        logger.info(
+            "Using %s instead of %s because the model has conditionally unused parameters in distributed training.",
+            effective_strategy,
+            config.system.strategy,
+        )
+        config.system.strategy = effective_strategy
+    out_dir = Path(config.out_dir) / config.run_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "resolved.yaml").write_text(yaml.safe_dump(config.model_dump(mode="json"), sort_keys=False))
+    datamodule = TrainingDataModule(config)
+    training_logger = make_training_logger(config, out_dir)
+    initialize_resume_logger_before_distributed_setup(config, training_logger)
+    trainer = Trainer(
+        default_root_dir=out_dir,
+        accelerator=config.system.accelerator,
+        devices=config.system.devices,
+        num_nodes=config.system.num_nodes,
+        strategy=config.system.strategy,
+        precision=config.system.precision,
+        max_epochs=config.system.max_epochs,
+        deterministic=config.system.deterministic,
+        logger=training_logger,
+        callbacks=make_training_callbacks(config, out_dir, datamodule),
+        # A resumed W&B run already has its config. Avoid a second rank-zero
+        # config update between distributed collectives after setup.
+        enable_autolog_hparams=config.resume_from_checkpoint is None,
+        log_every_n_steps=config.system.log_every_n_steps,
+        limit_train_batches=config.system.limit_train_batches,
+        limit_val_batches=config.system.limit_val_batches,
+        use_distributed_sampler=True,
+        # Required for the official epoch/item/global-seed dataset RNG.
+        reload_dataloaders_every_n_epochs=1,
+    )
+    system = TrainingSystem(config)
+    trainer.fit(
+        system,
+        datamodule=datamodule,
+        ckpt_path=str(config.resume_from_checkpoint) if config.resume_from_checkpoint else None,
+    )
+    return out_dir
+
+
+def make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Train Instant NuRec models from NCore V4 data")
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR"])
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = make_parser().parse_args(argv)
+    logging.basicConfig(level=getattr(logging, args.log_level))
+    config = load_training_config(args.config)
+    try:
+        output = run_training(config)
+    except PreemptionInterrupt as error:
+        logger.warning("Training preempted cleanly: %s", error)
+        return 1
+    logger.info("Training completed: %s", output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/instant_nurec/training/system.py
+++ b/instant_nurec/training/system.py
@@ -1,0 +1,355 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+
+from pathlib import Path
+from typing import Literal
+
+import torch
+
+from pytorch_lightning import LightningModule
+from torchmetrics.image import PeakSignalNoiseRatio
+
+from instant_nurec.config_schema.train import TrainingConfig
+from instant_nurec.datasets.tracks import CuboidTracks, TrackFlags
+from instant_nurec.model.kelvin import KelvinInstantNuRec
+from instant_nurec.model.blocks.dav3 import convert_dav3_state_dict
+from instant_nurec.training.losses import LossReturn, TrainingLosses
+from instant_nurec.training.optim import CosineWithWarmupPBScheduler, make_optimizer
+from instant_nurec.training.renderer import render_supervision
+from instant_nurec.utils.batch import InstantNuRecDataBatch
+from instant_nurec.utils.cubemap import unproject_to_sky_cubemap
+from instant_nurec.utils.geometry import tquat_to_se3_matrix
+from instant_nurec.utils.misc import unpack_optional
+from instant_nurec.utils.motion import (
+    associate_points_with_cuboid_tracks,
+    warp_points_with_cuboid_tracks,
+)
+from instant_nurec.utils.types import RayFlags
+
+
+logger = logging.getLogger(__name__)
+
+
+class BroadcastExceptions:
+    """Coordinate rank-local exceptions before DDP synchronization points."""
+
+    def __init__(self, trainer):
+        self.trainer = trainer
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        del exc_type, traceback
+        failed = self.trainer.strategy.reduce_boolean_decision(exc_value is not None, all=False)
+        if failed:
+            self.trainer.should_stop = True
+            if exc_value is not None:
+                return False
+            raise RuntimeError(
+                f"[rank{self.trainer.global_rank}] aborting training because another rank raised an exception"
+            )
+        return False
+
+
+class TrainingSystem(LightningModule):
+    """Lightning manual-optimization system for full-model training."""
+
+    automatic_optimization = False
+
+    def __init__(self, config: TrainingConfig):
+        super().__init__()
+        self.config = config
+        self.model = KelvinInstantNuRec(config.model)
+        self.loss = TrainingLosses(unpack_optional(config.loss))
+        self.optimizer_implementation = "unconfigured"
+        self._weights_initialized = False
+        self._warned_skipped_losses: set[str] = set()
+        self.save_hyperparameters(config.model_dump(mode="json"))
+
+    def setup(self, stage: str) -> None:
+        del stage
+        # Keep independent state so Lightning can reset/synchronize train and
+        # validation metrics with the same lifecycle as the reference system.
+        self.train_psnr = PeakSignalNoiseRatio(data_range=1)
+        self.validation_psnr = PeakSignalNoiseRatio(data_range=1)
+
+    def configure_optimizers(self):
+        optimizer, implementation = make_optimizer(
+            (parameter for parameter in self.model.parameters() if parameter.requires_grad),
+            self.config.system.optimizer,
+        )
+        self.optimizer_implementation = implementation
+        scheduler = CosineWithWarmupPBScheduler(optimizer, self.config.system.scheduler)
+        return {"optimizer": optimizer, "lr_scheduler": {"scheduler": scheduler, "interval": "step"}}
+
+    def on_train_epoch_start(self) -> None:
+        """Match the per-rank, per-epoch runtime RNG contract used by reference training."""
+
+        if torch.distributed.is_initialized():
+            base_seed = int(os.environ.get("PL_GLOBAL_SEED", 0))
+            rank = torch.distributed.get_rank()
+            torch.manual_seed(base_seed + self.current_epoch * torch.distributed.get_world_size() + rank)
+
+    @staticmethod
+    def _read_raw_state_dict(path: Path) -> dict[str, torch.Tensor]:
+        if path.suffix == ".safetensors":
+            from safetensors.torch import load_file
+
+            return load_file(str(path))
+        checkpoint = torch.load(path, map_location="cpu", weights_only=False)
+        return checkpoint.get("state_dict", checkpoint)
+
+    @classmethod
+    def _read_full_state_dict(cls, path: Path) -> dict[str, torch.Tensor]:
+        return {key.removeprefix("model."): value for key, value in cls._read_raw_state_dict(path).items()}
+
+    def _initialize_from_dav3(self, path: Path) -> None:
+        source = self._read_raw_state_dict(path)
+        encoder_state = convert_dav3_state_dict(
+            source,
+            patch_embed_name="patch_embed_img",
+            backbone_name="vit",
+            dpt_reassemble_name=None,
+            dpt_depth_head_name=None,
+            dpt_rays_head_name=None,
+            camera_encoder_name="embed_camera",
+        )
+        encoder_state.pop("vit.default_global_cls_tokens", None)
+        self.model.encoder.load_state_dict(encoder_state, strict=True)
+
+        decoder_state = convert_dav3_state_dict(
+            source,
+            patch_embed_name=None,
+            backbone_name=None,
+            dpt_reassemble_name="depth_head.reassemble",
+            dpt_depth_head_name="depth_head.fusion_head",
+            dpt_rays_head_name=None,
+            camera_encoder_name=None,
+        )
+        context_init = [0.0] * 3 + [0.0, -1.0, 0.0] + [math.nan] * self.model.decoder.n_semantic_classes
+        self.model.decoder.context_head.zero_init(context_init)
+        self.model.decoder.gaussians_head.zero_init([math.nan] * 8)
+        current_decoder_state = self.model.decoder.state_dict()
+        current_decoder_state.update(decoder_state)
+        self.model.decoder.load_state_dict(current_decoder_state, strict=True)
+        logger.info("Initialized encoder and depth head from DAv3 checkpoint %s.", path)
+
+    def initialize_weights(self) -> None:
+        paths = self.config.model.init_weights_paths
+        if not paths:
+            logger.warning("No initialization checkpoint configured; training starts from random weights.")
+            if self.model.post_processing is not None:
+                self.model.post_processing.zero_init()
+            self._weights_initialized = True
+            return
+        full_key = next((key for key in ("full", "tokengs") if key in paths), None)
+        if full_key is not None:
+            state_dict = self._read_full_state_dict(Path(paths[full_key]))
+            # The reference recipe reinitializes the dense Gaussian head for full-model
+            # and current-format TokenGS initialization, in either phase.
+            state_dict = {
+                key: value for key, value in state_dict.items() if not key.startswith("decoder.gaussians_head.")
+            }
+            incompatible = self.model.load_state_dict(state_dict, strict=False)
+            logger.info(
+                "Initialized full model from %s (%d missing, %d unexpected keys).",
+                paths[full_key],
+                len(incompatible.missing_keys),
+                len(incompatible.unexpected_keys),
+            )
+        else:
+            unsupported = set(paths) - {"dav3"}
+            if unsupported:
+                raise ValueError(f"Unsupported component initialization keys: {sorted(unsupported)}")
+            if "dav3" not in paths:
+                raise ValueError("Component initialization requires init_weights_paths.dav3")
+            self._initialize_from_dav3(Path(paths["dav3"]))
+        if self.model.post_processing is not None:
+            self.model.post_processing.zero_init()
+        self._weights_initialized = True
+
+    def on_fit_start(self) -> None:
+        # Lightning's sanity validation runs before ``on_train_start``.  Fresh
+        # phase-one and phase-two weights must therefore be initialized here,
+        # while restored runs keep the state loaded from their checkpoint.
+        if not self._weights_initialized and not self.trainer.ckpt_path:
+            self.initialize_weights()
+
+    def on_train_batch_start(self, batch: InstantNuRecDataBatch, batch_idx: int) -> None:
+        del batch, batch_idx
+        self.model.update_step_train_batch_start(self.global_step)
+
+    @staticmethod
+    def _prepare_sky_reference(pack, supervision) -> None:
+        camera = unpack_optional(supervision.data.camera)
+        rendering = unpack_optional(unpack_optional(supervision.rendering).camera)
+        if camera.labels.rgb is None or camera.labels.flags is None:
+            return
+        feature_mask = camera.labels.get_mask_flags_none(RayFlags.INVALID) & camera.labels.get_mask_flags_all(
+            RayFlags.SKY_SEMANTIC
+        )
+        reference, mask = unproject_to_sky_cubemap(
+            unpack_optional(pack.predicted_sky_cubemap).shape[1],
+            tquat_to_se3_matrix(rendering.poses_tquat_startend[:, 1], unbatch=False)[:, :3, :3],
+            rendering.sensor_model_parameters,
+            camera.labels.rgb,
+            feature_mask,
+        )
+        pack.reference_sky_cubemap = reference
+        pack.reference_sky_cubemap_mask = mask
+
+    def _prepare_motion_reference(self, pack, context, tracks: CuboidTracks | None) -> None:
+        if tracks is None or not pack.motion_supervisions:
+            pack.motion_supervisions = []
+            return
+        camera = unpack_optional(context.data.camera)
+        rendering = unpack_optional(unpack_optional(context.rendering).camera)
+        if camera.labels.metric_distance is None:
+            pack.motion_supervisions = []
+            return
+        dynamic = CuboidTracks.Ops.subset_from_mask(tracks, tracks.tracks_flags & TrackFlags.DYNAMIC != 0)
+        points = rendering.rays[..., :3] + camera.labels.metric_distance * rendering.rays[..., 3:]
+        for motion in pack.motion_supervisions:
+            tracks_idx = associate_points_with_cuboid_tracks(
+                points=points,
+                points_timestamps_us=motion.source_timestamps_us,
+                points_dynamic_mask=None,
+                cuboid_tracks=dynamic,
+                cuboids_dims_padding=self.model.cuboids_dims_padding,
+            )
+            _, warped = warp_points_with_cuboid_tracks(
+                points=points,
+                source_timestamps_us=motion.source_timestamps_us,
+                target_timestamps_us_list=[motion.target_timestamps_us],
+                cuboid_tracks=dynamic,
+                tracks_idx=tracks_idx,
+            )
+            motion.reference_flow = warped[0] - points
+
+    @staticmethod
+    def _render_psnr_inputs(render_output, supervision) -> tuple[torch.Tensor, torch.Tensor] | None:
+        if render_output is None or supervision is None or supervision.data.camera is None:
+            return None
+        labels = supervision.data.camera.labels
+        if labels.rgb is None:
+            return None
+        rgb_ray_mask = (
+            labels.get_mask_flags_all(RayFlags.RGB_LABEL) & labels.get_mask_flags_none(RayFlags.INVALID)
+        ).squeeze(-1)
+        return render_output.rgb[rgb_ray_mask], labels.rgb[rgb_ray_mask]
+
+    def _log_psnr(
+        self,
+        predicted_rgbs: list[torch.Tensor],
+        ground_truth_rgbs: list[torch.Tensor],
+        mode: Literal["train", "val"],
+    ) -> None:
+        if predicted_rgbs and ground_truth_rgbs:
+            psnr_metric = self.train_psnr if mode == "train" else self.validation_psnr
+            psnr_metric(torch.cat(predicted_rgbs, dim=0), torch.cat(ground_truth_rgbs, dim=0))
+            self.log(f"{mode}/psnr", psnr_metric, prog_bar=True)
+        elif mode == "val":
+            # Phase one does not render. Match the reference increasing placeholder
+            # so val/psnr remains available to ModelCheckpoint.
+            self.log("val/psnr", 0.1 * self.current_epoch, prog_bar=True)
+
+    def forward_losses(self, batch: InstantNuRecDataBatch, mode: Literal["train", "val"]) -> LossReturn:
+        batch.maybe_compute_rendering_data(device=self.device)
+        tracks = (
+            [CuboidTracks.Factory.from_pack(pack) for pack in batch.cuboid_tracks]
+            if batch.cuboid_tracks is not None
+            else None
+        )
+        batch.context = self.model.prepare_context(batch.context)
+        primitives, packs = self.model.reconstruct_with_supervision(batch.context, tracks)
+        per_item = []
+        component_values: dict[str, list[torch.Tensor]] = {}
+        skipped: list[str] = []
+        predicted_rgbs: list[torch.Tensor] = []
+        ground_truth_rgbs: list[torch.Tensor] = []
+        for index, (primitive, pack, context) in enumerate(zip(primitives, packs, batch.context)):
+            supervision = batch.supervision[index] if batch.supervision is not None else None
+            if supervision is not None:
+                self._prepare_sky_reference(pack, supervision)
+            self._prepare_motion_reference(pack, context, tracks[index] if tracks is not None else None)
+            render_output = None
+            if self.global_step >= self.config.system.enable_render_global_step:
+                if supervision is None:
+                    raise RuntimeError("Render-stage training requires independently sampled supervision frames")
+                render_output = render_supervision(primitive, supervision)
+            with torch.no_grad():
+                psnr_inputs = self._render_psnr_inputs(render_output, supervision)
+                if psnr_inputs is not None:
+                    predicted_rgb, ground_truth_rgb = psnr_inputs
+                    predicted_rgbs.append(predicted_rgb)
+                    ground_truth_rgbs.append(ground_truth_rgb)
+            result = self.loss(pack, context, render_output, supervision)
+            per_item.append(result.total_value)
+            skipped.extend(result.skipped)
+            for name, value in result.values.items():
+                component_values.setdefault(name, []).append(value)
+        self._log_psnr(predicted_rgbs, ground_truth_rgbs, mode)
+        # Official aggregation is a mean over batch elements, not a sum.
+        total = torch.stack(per_item).mean()
+        skipped_names = set(skipped)
+        new_skips = skipped_names - self._warned_skipped_losses
+        if new_skips:
+            logger.warning(
+                "Skipping training losses with unavailable labels/predictions: %s",
+                ", ".join(sorted(new_skips)),
+            )
+            self._warned_skipped_losses.update(new_skips)
+        return LossReturn(
+            total_value=total,
+            values={name: torch.stack(values).mean() for name, values in component_values.items()},
+            skipped=tuple(sorted(skipped_names)),
+        )
+
+    def training_step(self, batch: InstantNuRecDataBatch, batch_idx: int):
+        # Forward failures are reduced across ranks before any rank enters the
+        # gradient-synchronizing manual_backward barrier.
+        with BroadcastExceptions(self.trainer):
+            optimizer = self.optimizers(use_pl_optimizer=True)
+            optimizer.zero_grad()
+            result = self.forward_losses(batch, "train")
+
+        with BroadcastExceptions(self.trainer):
+            self.manual_backward(result.total_value)
+            raw_optimizer = optimizer.optimizer
+            if any(parameter.grad is not None for group in raw_optimizer.param_groups for parameter in group["params"]):
+                optimizer.step()
+            scheduler = self.lr_schedulers()
+            if isinstance(scheduler, CosineWithWarmupPBScheduler):
+                scheduler.set_progress(
+                    self.current_epoch,
+                    self.config.system.max_epochs,
+                    batch_idx,
+                    int(self.trainer.num_training_batches),
+                )
+                scheduler.step()
+            self.log("train/loss", result.total_value, prog_bar=True, on_step=True, sync_dist=False)
+            for name, value in result.values.items():
+                self.log(f"train/{name}", value, on_step=True, sync_dist=False)
+            self.log("train/lr", raw_optimizer.param_groups[0]["lr"], on_step=True)
+        return result.total_value.detach()
+
+    def validation_step(self, batch: InstantNuRecDataBatch, batch_idx: int):
+        del batch_idx
+        result = self.forward_losses(batch, "val")
+        self.log("val/loss", result.total_value, prog_bar=True, on_epoch=True, sync_dist=True)
+        return result.total_value
+
+    def on_save_checkpoint(self, checkpoint: dict) -> None:
+        checkpoint["training_contract"] = {
+            "reference_profile": self.config.reference_profile,
+            "phase": self.config.phase,
+            "optimizer_implementation": self.optimizer_implementation,
+            "world_size": self.trainer.world_size,
+        }

--- a/instant_nurec/utils/batch.py
+++ b/instant_nurec/utils/batch.py
@@ -31,6 +31,7 @@ from ncore.impl.common.transformations import PoseInterpolator
 from ncore.sensors import (
     CameraModel,
     FThetaCameraModel,
+    OpenCVPinholeCameraModel,
 )
 from instant_nurec.utils.misc import assert_same_type, collate_fn, unpack_optional
 from instant_nurec.utils.sensors import SensorModelComputations
@@ -41,11 +42,12 @@ from instant_nurec.utils.sensors.ncore_sensors_converters import (
 )
 from instant_nurec.utils.types import (
     CuboidTracksDataPack,
+    RayFlags,
     RigTrajectories,
 )
 
 
-ConcreteCameraModelsUnion: TypeAlias = FThetaCameraModel
+ConcreteCameraModelsUnion: TypeAlias = FThetaCameraModel | OpenCVPinholeCameraModel
 ConcreteSensorModelParametersUnion: TypeAlias = ConcreteCameraModelParametersUnion
 
 
@@ -253,11 +255,41 @@ class CameraFrameLabels:
     """
 
     rgb: torch.Tensor | None = None
+    metric_distance: torch.Tensor | None = None
+    normals: torch.Tensor | None = None
+    flags: torch.Tensor | None = None
 
     def __post_init__(self):
         if self.rgb is not None:
             assert self.rgb.ndim == 4 and self.rgb.shape[3] == 3, "RGB must be a 4D tensor (B, height, width, 3)"
             assert self.rgb.dtype == torch.float32, "RGB must be a float32 tensor"
+        for name, channels in (("metric_distance", 1), ("normals", 3), ("flags", 1)):
+            value = getattr(self, name)
+            if value is not None:
+                assert value.ndim == 4 and value.shape[-1] == channels, (
+                    f"{name} must have shape (B, H, W, {channels})"
+                )
+        if self.metric_distance is not None:
+            assert self.metric_distance.dtype == torch.float32
+        if self.normals is not None:
+            assert self.normals.dtype == torch.float32
+        if self.flags is not None:
+            assert self.flags.dtype in (torch.int32, torch.int64)
+
+    def get_mask_flags_all(self, flags: RayFlags) -> torch.Tensor:
+        if self.flags is None:
+            if self.rgb is None:
+                raise ValueError("Cannot infer label shape without RGB or flags")
+            return torch.ones((*self.rgb.shape[:-1], 1), dtype=torch.bool, device=self.rgb.device)
+        flag_value = int(flags)
+        return (self.flags & flag_value) == flag_value
+
+    def get_mask_flags_none(self, flags: RayFlags) -> torch.Tensor:
+        if self.flags is None:
+            if self.rgb is None:
+                raise ValueError("Cannot infer label shape without RGB or flags")
+            return torch.ones((*self.rgb.shape[:-1], 1), dtype=torch.bool, device=self.rgb.device)
+        return (self.flags & int(flags)) == 0
 
     @classmethod
     def collate_fn(
@@ -265,13 +297,34 @@ class CameraFrameLabels:
         seq: List[Self],
         device: torch.device = torch.device("cpu"),
     ) -> Self:
+        # Match the reference data contract: a camera without depth contributes
+        # zero distance when collated with cameras that do have depth.  Depth
+        # losses already treat zero as invalid, while keeping one dense tensor
+        # lets real and synthetic supervision frames share a batch.
+        metric_distance_seq = [item.metric_distance for item in seq]
+        if (
+            first_not_none_distance := next(
+                (distance for distance in metric_distance_seq if distance is not None), None
+            )
+        ) is not None:
+            metric_distance_seq = [
+                torch.zeros_like(first_not_none_distance) if distance is None else distance
+                for distance in metric_distance_seq
+            ]
+
         return cls(
             rgb=collate_fn([item.rgb for item in seq], device),
+            metric_distance=collate_fn(metric_distance_seq, device),
+            normals=collate_fn([item.normals for item in seq], device),
+            flags=collate_fn([item.flags for item in seq], device),
         )
 
     def to(self, *args, **kwargs) -> Self:
         return self.__class__(
             rgb=self.rgb.to(*args, **kwargs) if self.rgb is not None else None,
+            metric_distance=self.metric_distance.to(*args, **kwargs) if self.metric_distance is not None else None,
+            normals=self.normals.to(*args, **kwargs) if self.normals is not None else None,
+            flags=self.flags.to(*args, **kwargs) if self.flags is not None else None,
         )
 
     def __getitem__(self, item: Union[int, slice, torch.Tensor]) -> Self:
@@ -281,6 +334,9 @@ class CameraFrameLabels:
 
         return self.__class__(
             rgb=self.rgb[item] if self.rgb is not None else None,
+            metric_distance=self.metric_distance[item] if self.metric_distance is not None else None,
+            normals=self.normals[item] if self.normals is not None else None,
+            flags=self.flags[item] if self.flags is not None else None,
         )
 
 
@@ -667,15 +723,23 @@ class InstantNuRecDataBatch:
     """
 
     context: list[DataAndRenderingBatch]
+    supervision: list[DataAndRenderingBatch] | None = None
     cuboid_tracks: list[CuboidTracksDataPack] | None = None
     context_rig: list[RigTrajectories] | None = None
+    supervision_rig: list[RigTrajectories] | None = None
     meta: list[dict[str, Any]] | None = None
 
     def __post_init__(self):
+        if self.supervision is not None:
+            assert len(self.context) == len(self.supervision), "Number of context and supervision batches must match"
         if self.cuboid_tracks is not None:
             assert len(self.context) == len(self.cuboid_tracks), "Number of context and cuboid tracks must match"
         if self.context_rig is not None:
             assert len(self.context) == len(self.context_rig), "Number of context and context_rig must match"
+        if self.supervision_rig is not None:
+            assert len(self.context) == len(self.supervision_rig), (
+                "Number of context and supervision_rig batches must match"
+            )
 
     def __getitem__(self, item: Union[int, slice]) -> Self:
         """Allows indexing into the dataclass to get a subset of the data."""
@@ -684,8 +748,10 @@ class InstantNuRecDataBatch:
 
         return self.__class__(
             context=self.context[item],
+            supervision=self.supervision[item] if self.supervision is not None else None,
             cuboid_tracks=self.cuboid_tracks[item] if self.cuboid_tracks is not None else None,
             context_rig=self.context_rig[item] if self.context_rig is not None else None,
+            supervision_rig=self.supervision_rig[item] if self.supervision_rig is not None else None,
             meta=self.meta[item] if self.meta is not None else None,
         )
 
@@ -710,8 +776,10 @@ class InstantNuRecDataBatch:
 
         return self.__class__(
             context=_move_list(self.context),
+            supervision=_move_list(self.supervision),
             cuboid_tracks=_move_list(self.cuboid_tracks),
             context_rig=_move_list(self.context_rig),
+            supervision_rig=_move_list(self.supervision_rig),
             meta=self.meta,
         )
 
@@ -721,18 +789,20 @@ class InstantNuRecDataBatch:
 
         if self.context_rig is None:
             return
-        for data, rig in zip(self.context, self.context_rig):
-            # Do not re-compute if rendering data already exists.
-            if data.rendering is not None:
+        for batches, rigs in ((self.context, self.context_rig), (self.supervision, self.supervision_rig)):
+            if batches is None or rigs is None:
                 continue
-            camera_rendering_data = (
-                CameraFreePoseViewGeometry.from_rig_trajectories(rig)
-                .to(device=device)
-                .to_rendering_data(data.data.camera.to(device))
-                if data.data.camera is not None
-                else None
-            )
-            data.rendering = RenderingBatch(camera=camera_rendering_data)
+            for data, rig in zip(batches, rigs):
+                if data.rendering is not None:
+                    continue
+                camera_rendering_data = (
+                    CameraFreePoseViewGeometry.from_rig_trajectories(rig)
+                    .to(device=device)
+                    .to_rendering_data(data.data.camera.to(device))
+                    if data.data.camera is not None
+                    else None
+                )
+                data.rendering = RenderingBatch(camera=camera_rendering_data)
 
     @classmethod
     def collate_fn(
@@ -761,7 +831,9 @@ class InstantNuRecDataBatch:
 
         return cls(
             context=unpack_optional(_collate_vals(*[batch.context for batch in seq])),
+            supervision=_collate_vals(*[batch.supervision for batch in seq]),
             cuboid_tracks=_collate_vals(*[batch.cuboid_tracks for batch in seq]),
             context_rig=_collate_vals(*[batch.context_rig for batch in seq]),
+            supervision_rig=_collate_vals(*[batch.supervision_rig for batch in seq]),
             meta=_collate_vals(*[batch.meta for batch in seq]),
         )

--- a/instant_nurec/utils/cubemap.py
+++ b/instant_nurec/utils/cubemap.py
@@ -111,6 +111,29 @@ def sample_sky_cubemap(cubemap: torch.Tensor, directions: torch.Tensor) -> torch
 
     if cubemap.ndim != 4 or cubemap.shape[0] != 6 or cubemap.shape[1] != cubemap.shape[2]:
         raise ValueError(f"Expected cubemap shape (6, H, H, C), got {tuple(cubemap.shape)}")
+    if cubemap.is_cuda:
+        try:
+            import nvdiffrast.torch as dr
+        except (ImportError, OSError) as exc:  # pragma: no cover - optional CUDA dependency
+            raise RuntimeError(
+                "CUDA sky rendering requires nvdiffrast for seam-correct cube filtering; "
+                "install the render or training extra"
+            ) from exc
+        original_shape = directions.shape[:-1]
+        flat = directions.reshape(-1, 3).float()
+        # nvdiffrast uses OpenGL's +Y/-Y cube-face convention; the image
+        # coordinates have the opposite Y axis.
+        opengl_directions = torch.stack([flat[:, 0], -flat[:, 1], flat[:, 2]], dim=-1)
+        sampled = dr.texture(
+            cubemap.float()[None],
+            opengl_directions[None, None],
+            filter_mode="linear",
+            boundary_mode="cube",
+        )
+        return sampled[0, 0].reshape(*original_shape, cubemap.shape[-1])
+
+    # CPU fallback used by data utilities and unit tests. Runtime rendering is
+    # CUDA-only and takes the seam-correct nvdiffrast path above.
     face, uv = directions_to_cubemap_face_uv(directions)
     flat_face = face.reshape(-1)
     flat_uv = uv.reshape(-1, 2)
@@ -436,5 +459,3 @@ def rotate_sky_cubemap(cubemap: torch.Tensor, rotation: torch.Tensor) -> torch.T
             out[mask] = sampled[0, :, 0].T
 
     return out.reshape(6, H, H, C)
-
-

--- a/instant_nurec/utils/motion.py
+++ b/instant_nurec/utils/motion.py
@@ -20,6 +20,8 @@ from typing import TYPE_CHECKING
 
 import torch
 
+from instant_nurec.utils.misc import unpack_optional
+
 
 if TYPE_CHECKING:
     from instant_nurec.datasets.tracks import CuboidTracks
@@ -95,78 +97,155 @@ class TimeRemapping:
         return (timestamps_us - self.start_timestamp_us) / span
 
 
+def associate_points_with_cuboid_tracks(
+    points: torch.Tensor,
+    points_timestamps_us: torch.Tensor,
+    points_dynamic_mask: torch.Tensor | None,
+    cuboid_tracks: CuboidTracks,
+    cuboids_dims_padding: torch.Tensor | None,
+    second_pass_cuboids_dims_padding_scale: float = 6.0,
+    second_pass_chunk_size: int = 65536,
+) -> torch.Tensor:
+    """Associate world points with cuboid tracks at their timestamps.
+
+    The first pass uses the configured padding. Movable points that miss that
+    pass are checked against wider cuboids and assigned to the hit nearest its
+    original, unpadded bounding box.
+
+    All per-point scalar tensors use a trailing singleton dimension.
+    """
+    data_shape = points.shape[:-1]
+    expected_scalar_shape = data_shape + (1,)
+    assert points_timestamps_us.shape == expected_scalar_shape
+    if points_dynamic_mask is not None:
+        assert points_dynamic_mask.shape == expected_scalar_shape
+
+    if cuboid_tracks.n_tracks == 0:
+        return torch.full(
+            expected_scalar_shape,
+            -1,
+            device=points.device,
+            dtype=cuboid_tracks.tracks_packinfo.dtype,
+        )
+
+    points_ts = points_timestamps_us.squeeze(-1)
+    first_pass = cuboid_tracks.point_intersection_interpolate_pose(
+        points,
+        points_ts,
+        cuboids_dims_padding,
+        max_intersections_per_point=1,
+    )
+    tracks_idx = first_pass.intersections_tracks_idx
+
+    if points_dynamic_mask is None:
+        return tracks_idx
+
+    second_pass_mask = (points_dynamic_mask & (tracks_idx == -1)).squeeze(-1)
+    n_second_pass = int(second_pass_mask.sum().item())
+    if n_second_pass == 0:
+        return tracks_idx
+
+    if cuboids_dims_padding is None:
+        wide_cuboids_dims_padding = torch.full(
+            (3,),
+            second_pass_cuboids_dims_padding_scale,
+            device=points.device,
+            dtype=points.dtype,
+        )
+    else:
+        wide_cuboids_dims_padding = (
+            cuboids_dims_padding.to(device=points.device, dtype=points.dtype) * second_pass_cuboids_dims_padding_scale
+        )
+
+    cuboids_dims = cuboid_tracks.cuboids_dims.to(device=points.device, dtype=points.dtype)
+    second_pass_points = points[second_pass_mask]
+    second_pass_timestamps_us = points_ts[second_pass_mask]
+    best_tracks_idx = torch.full((n_second_pass, 1), -1, device=points.device, dtype=tracks_idx.dtype)
+    has_intersection = torch.zeros((n_second_pass, 1), device=points.device, dtype=torch.bool)
+    chunk_size = max(1, second_pass_chunk_size)
+    for start in range(0, n_second_pass, chunk_size):
+        end = min(start + chunk_size, n_second_pass)
+        second_pass = cuboid_tracks.point_intersection_interpolate_pose(
+            points=second_pass_points[start:end],
+            points_timestamps_us=second_pass_timestamps_us[start:end],
+            cuboids_dims_padding=wide_cuboids_dims_padding,
+            max_intersections_per_point=64,
+            with_local_points=True,
+        )
+        wide_tracks_idx = second_pass.intersections_tracks_idx
+        wide_points_local = unpack_optional(second_pass.intersections_points_local)
+        wide_valid_mask = wide_tracks_idx != -1
+        if not torch.any(wide_valid_mask):
+            continue
+
+        matched_dims = cuboids_dims[wide_tracks_idx.clamp_min(0).to(torch.long)]
+        distance_to_bbox = torch.linalg.norm(
+            (wide_points_local.abs() - matched_dims * 0.5).clamp_min(0.0),
+            dim=-1,
+        )
+        distance_to_bbox = torch.where(
+            wide_valid_mask,
+            distance_to_bbox,
+            torch.full_like(distance_to_bbox, torch.inf),
+        )
+        best_hit_idx = torch.argmin(distance_to_bbox, dim=-1, keepdim=True)
+        best_tracks_idx[start:end] = torch.gather(wide_tracks_idx, dim=-1, index=best_hit_idx)
+        has_intersection[start:end] = wide_valid_mask.any(dim=-1, keepdim=True)
+
+    tracks_idx[second_pass_mask] = torch.where(
+        has_intersection,
+        best_tracks_idx,
+        tracks_idx[second_pass_mask],
+    )
+    return tracks_idx
+
+
 def warp_points_with_cuboid_tracks(
     points: torch.Tensor,
     source_timestamps_us: torch.Tensor,
     target_timestamps_us_list: list[torch.Tensor],
-    dynamic_tracks: CuboidTracks,
-    aux_tracks_idx: torch.Tensor,
-    cuboids_dims_padding: torch.Tensor,
+    cuboid_tracks: CuboidTracks,
+    tracks_idx: torch.Tensor,
 ) -> tuple[torch.Tensor, list[torch.Tensor]]:
-    """
-    Associate each point with a dynamic cuboid track at its source timestamp, then warp
-    it to each given target timestamp using that track's interpolated pose.
+    """Warp track-associated points to each target timestamp.
 
-    Association uses point-cuboid intersection. For points that fail this association,
-    `aux_tracks_idx` (e.g. from a ray-cuboid intersection on the originating ray) is used
-    as a fallback.
-
-    Args:
-        points: [..., 3] world points at the source timestamps.
-        source_timestamps_us: [...] (or [..., 1]) source timestamps per point.
-        target_timestamps_us_list: list of target timestamp tensors, each [...] (or [..., 1]).
-        dynamic_tracks: dynamic CuboidTracks to associate against.
-        aux_tracks_idx: [...] fallback track ids for points whose point-cuboid
-            intersection returns -1; pass -1 for "no fallback" entries.
-        cuboids_dims_padding: 3D padding broadcastable to N_tracks x 3.
-
-    Returns:
-        - dynamic_mask: [...] bool, True for points associated with a track.
-        - warped_points_list: per target, a [..., 3] tensor where associated points are
-          warped to the corresponding target timestamp and unassociated points are unchanged.
+    All per-point scalar tensors use a trailing singleton dimension. Track
+    indices are expected to come from :func:`associate_points_with_cuboid_tracks`.
     """
     data_shape = points.shape[:-1]
+    expected_scalar_shape = data_shape + (1,)
+    assert source_timestamps_us.shape == expected_scalar_shape
+    for target_timestamps_us in target_timestamps_us_list:
+        assert target_timestamps_us.shape == expected_scalar_shape
+    assert tracks_idx.shape == expected_scalar_shape
 
-    def _squeeze_trailing_one(t: torch.Tensor) -> torch.Tensor:
-        # Accept either [...] or [..., 1] timestamp shapes for caller convenience.
-        if t.ndim == len(data_shape) + 1 and t.shape[-1] == 1:
-            return t.squeeze(-1)
-        return t
-
-    src_ts = _squeeze_trailing_one(source_timestamps_us)
-    tgt_ts_list = [_squeeze_trailing_one(t) for t in target_timestamps_us_list]
-
-    # Main association: point inside cuboid at source timestamp.
-    _, tracks_idx = dynamic_tracks.point_intersection_interpolate_pose(points, src_ts, cuboids_dims_padding)  # [...]
-
-    # Fallback association via aux idx (e.g. ray-cuboid for movable rays).
-    unassoc = tracks_idx == -1
-    tracks_idx[unassoc] = aux_tracks_idx[unassoc]
+    source_timestamps_us = source_timestamps_us.squeeze(-1)
+    target_timestamps_us_list = [timestamps.squeeze(-1) for timestamps in target_timestamps_us_list]
+    tracks_idx = tracks_idx.squeeze(-1)
 
     dynamic_mask = tracks_idx != -1
     sel = torch.where(dynamic_mask)
-    sel_tracks_idx = tracks_idx[sel]
+    sel_tracks_idx = tracks_idx[sel].to(dtype=cuboid_tracks.tracks_packinfo.dtype)
 
     warped_points_list: list[torch.Tensor]
 
-    # Shortcut if no dynamic points are found.
     if sel_tracks_idx.numel() == 0:
-        warped_points_list = [points.clone() for _ in tgt_ts_list]
-        return dynamic_mask, warped_points_list
+        warped_points_list = [points.clone() for _ in target_timestamps_us_list]
+        return dynamic_mask.unsqueeze(-1), warped_points_list
 
-    inv_current_pose = dynamic_tracks.interpolate_tracks_poses(
-        timestamps_us=src_ts[sel],
+    inv_current_pose = cuboid_tracks.interpolate_tracks_poses(
+        timestamps_us=source_timestamps_us[sel],
         tracks_idx=sel_tracks_idx,
     ).inv()
 
     warped_points_list = []
-    for tgt_ts in tgt_ts_list:
-        target_pose = dynamic_tracks.interpolate_tracks_poses(
-            timestamps_us=tgt_ts[sel],
+    for target_timestamps_us in target_timestamps_us_list:
+        target_pose = cuboid_tracks.interpolate_tracks_poses(
+            timestamps_us=target_timestamps_us[sel],
             tracks_idx=sel_tracks_idx,
         )
         new_points = points.clone()
         new_points[sel] = (target_pose * inv_current_pose) * new_points[sel]  # type: ignore[operator]
         warped_points_list.append(new_points)
 
-    return dynamic_mask, warped_points_list
+    return dynamic_mask.unsqueeze(-1), warped_points_list

--- a/instant_nurec/utils/ncore_utils.py
+++ b/instant_nurec/utils/ncore_utils.py
@@ -15,19 +15,193 @@
 
 from __future__ import annotations
 
+import concurrent.futures
+import io
 import json
 import logging
 
+from collections import defaultdict
+from pathlib import Path
+from typing import DefaultDict
+
 import numpy as np
 import PIL.Image as PILImage
+import zarr
+import zarr.storage
 
 from upath import UPath
 
 import ncore
 import ncore.data
 import ncore.data.v4
+import ncore.impl.data.stores as ncore_data_stores
 
 from instant_nurec.utils.types import HalfClosedInterval
+
+
+SEMANTIC_SEG_BASE_GROUP = "semantic_segmentation"
+DEPTH_BASE_GROUP = "depth"
+EGO_MASK_BASE_GROUP = "egomask"
+
+
+class AuxShardDataLoader:
+    """Read NCore camera labels from adjacent sharded auxiliary stores.
+
+    The naming convention is ``<data-shard>.aux.<signal>.zarr[.itar]``.
+    A signal-specific override replaces matching adjacent stores rather than
+    being loaded alongside them.
+    Stores are optional: an empty loader simply reports every signal absent.
+    """
+
+    def __init__(
+        self,
+        sequence_id: str,
+        dataset_paths: list[Path] | list[UPath],
+        open_consolidated: bool = True,
+        signal_override_paths: dict[str, UPath] | None = None,
+    ) -> None:
+        store_paths: set[UPath] = set()
+        signal_override_paths = signal_override_paths or {}
+        matched_override_keys: set[str] = set()
+        for raw_dataset_path in dataset_paths:
+            dataset_path = UPath(raw_dataset_path).absolute()
+            dataset_base_name = dataset_path.stem.split(".")[0]
+            for path in dataset_path.parent.iterdir():
+                path_signal_name: str | None = None
+                if path.is_file():
+                    supported = path.name.endswith(".zarr.itar")
+                    matches = path.name.startswith(dataset_base_name + ".aux.") or path.name.startswith(
+                        dataset_base_name + "-annotations"
+                    )
+                    if supported and matches:
+                        path_signal_name = path.name.split(".")[-3]
+                        store_paths.add(path)
+                elif path.is_dir() and path.name.endswith(".zarr") and path.name.startswith(
+                    dataset_base_name + ".aux."
+                ):
+                    path_signal_name = path.name.split(".")[-2]
+                    store_paths.add(path)
+
+                if path_signal_name is not None and path_signal_name in signal_override_paths:
+                    store_paths.discard(path)
+                    store_paths.add(signal_override_paths[path_signal_name])
+                    matched_override_keys.add(path_signal_name)
+
+        for unmatched_key in sorted(set(signal_override_paths) - matched_override_keys):
+            logging.warning(
+                "signal_override_paths entry %r -> %s had no effect: no native aux store matches "
+                "this signal name for sequence %r.",
+                unmatched_key,
+                signal_override_paths[unmatched_key],
+                sequence_id,
+            )
+
+        self.aux_shard_stores: list[zarr.storage.Store] = []
+        self.base_groups: DefaultDict[str, list[zarr.Group]] = defaultdict(list)
+
+        def open_store(store_path: UPath):
+            store = (
+                ncore_data_stores.IndexedTarStore(store_path, mode="r")
+                if store_path.is_file()
+                else zarr.storage.DirectoryStore(store_path)
+            )
+            root = (
+                ncore_data_stores.open_compressed_consolidated(store=store, mode="r")
+                if open_consolidated
+                else zarr.open(store=store, mode="r")
+            )
+            return root, store
+
+        loaded_groups: set[tuple[str, int]] = set()
+        loaded_sequence_id: str | None = None
+        loaded_shard_count: int | None = None
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            futures = [executor.submit(open_store, path) for path in store_paths]
+            for future in concurrent.futures.as_completed(futures):
+                root, store = future.result()
+                aux_sequence_id = root.attrs.get("sequence_id")
+                shard_id = root.attrs.get("shard_id")
+                shard_count = root.attrs.get("shard_count")
+                root_group_name = root.attrs.get("aux_root_group_name", "annotations")
+                if loaded_sequence_id is None:
+                    loaded_sequence_id = aux_sequence_id
+                    loaded_shard_count = shard_count
+                if loaded_sequence_id != aux_sequence_id or sequence_id != aux_sequence_id:
+                    raise ValueError(
+                        f"Aux sequence {aux_sequence_id!r} does not match source sequence {sequence_id!r}"
+                    )
+                if loaded_shard_count != shard_count:
+                    raise ValueError("Cannot combine auxiliary stores with different shard counts")
+                for group_name, group in root[root_group_name].items():
+                    if not isinstance(group, zarr.Group):
+                        continue
+                    key = (group_name, shard_id)
+                    if key in loaded_groups:
+                        raise ValueError(f"Aux group {group_name!r} is duplicated for shard {shard_id}")
+                    loaded_groups.add(key)
+                    self.base_groups[group_name].append(group)
+                self.aux_shard_stores.append(store)
+
+    def _has_base_group(self, group_name: str, sensor_id: str | None = None) -> bool:
+        if group_name not in self.base_groups:
+            return False
+        return sensor_id is None or any(sensor_id in group for group in self.base_groups[group_name])
+
+    def has_semantic_segmentation(self, camera_id: str | None = None) -> bool:
+        return self._has_base_group(SEMANTIC_SEG_BASE_GROUP, camera_id)
+
+    def get_semantic_segmentation_meta(self, camera_id: str) -> dict:
+        if not self.has_semantic_segmentation(camera_id):
+            raise KeyError(f"No semantic segmentation found for {camera_id}")
+        return dict(self.base_groups[SEMANTIC_SEG_BASE_GROUP][0][camera_id].attrs)
+
+    def get_semantic_segmentation(self, camera_id: str, timestamp_us: int) -> PILImage.Image:
+        for group in self.base_groups[SEMANTIC_SEG_BASE_GROUP]:
+            try:
+                dataset = group[camera_id][str(timestamp_us)]
+            except KeyError:
+                continue
+            return PILImage.open(io.BytesIO(dataset[()]), formats=[dataset.attrs["format"]])
+        raise KeyError(f"No semantic segmentation found for {camera_id} at {timestamp_us}")
+
+    def has_depth(self, camera_id: str | None = None) -> bool:
+        return self._has_base_group(DEPTH_BASE_GROUP, camera_id)
+
+    def get_depth_meta(self, camera_id: str) -> dict:
+        if not self.has_depth(camera_id):
+            raise KeyError(f"No depth found for {camera_id}")
+        return dict(self.base_groups[DEPTH_BASE_GROUP][0][camera_id].attrs)
+
+    def get_depth(self, camera_id: str, timestamp_us: int) -> np.ndarray:
+        metadata = self.get_depth_meta(camera_id)
+        for group in self.base_groups[DEPTH_BASE_GROUP]:
+            try:
+                dataset = group[camera_id][str(timestamp_us)]
+            except KeyError:
+                continue
+            if metadata.get("store_depth_as_png", False):
+                image = PILImage.open(io.BytesIO(dataset[()]), formats=["png"])
+                return np.asarray(image, dtype=np.float32) * float(metadata["max_depth_m"]) / 65535.0
+            return np.asarray(dataset, dtype=np.float32)
+        raise KeyError(f"No depth found for {camera_id} at {timestamp_us}")
+
+    def has_egomask(self, camera_id: str | None = None) -> bool:
+        return self._has_base_group(EGO_MASK_BASE_GROUP, camera_id)
+
+    def get_egomask(self, camera_id: str, timestamp_us: int = 0) -> np.ndarray:
+        for group in self.base_groups[EGO_MASK_BASE_GROUP]:
+            if camera_id not in group:
+                continue
+            frame_keys = list(group[camera_id].keys())
+            if not frame_keys:
+                continue
+            frame_key = "0" if timestamp_us == 0 and "0" in frame_keys else min(
+                frame_keys, key=lambda key: abs(int(key) - timestamp_us)
+            )
+            dataset = group[camera_id][frame_key]
+            image = PILImage.open(io.BytesIO(dataset[()]), formats=[dataset.attrs["format"]]).convert("L")
+            return np.asarray(image) > 0
+        raise KeyError(f"No ego mask found for {camera_id}")
 
 
 def get_mask_image(

--- a/instant_nurec/utils/sensors/kernel_types.py
+++ b/instant_nurec/utils/sensors/kernel_types.py
@@ -16,9 +16,9 @@
 """Dataclasses + enums consumed by the in-tree torch ray-gen
 (``ray_gen.py``).
 
-FTheta-only by design. OpenCVPinhole and OpenCVFisheye distortion
-models are intentionally not supported on the input side; the other
-distortion families are explicitly dropped.
+The public torch implementation supports the F-Theta and OpenCV pinhole
+camera models used by calibrated training inputs. Other
+projection families remain explicit unsupported cases.
 """
 
 from __future__ import annotations
@@ -265,6 +265,98 @@ class FThetaProjection(CameraProjection):
 
 
 @dataclass
+class OpenCVPinholeProjection(CameraProjection):
+    """OpenCV pinhole projection with reference-compatible packed parameters.
+
+    ``intrinsics`` stores ``[fx, fy, cx, cy, k1..k6, p1, p2, s1..s4,
+    width, height]``. Packing the fields matches the official sensor-kernel
+    representation and keeps all floating-point parameters on one device.
+    """
+
+    intrinsics: torch.Tensor  # (18,)
+
+    @classmethod
+    def from_components(
+        cls,
+        focal_length: torch.Tensor,
+        principal_point: torch.Tensor,
+        radial_coeffs: torch.Tensor,
+        tangential_coeffs: torch.Tensor,
+        thin_prism_coeffs: torch.Tensor,
+        resolution: torch.Tensor,
+    ) -> "OpenCVPinholeProjection":
+        intrinsics = torch.cat(
+            [
+                focal_length,
+                principal_point,
+                radial_coeffs,
+                tangential_coeffs,
+                thin_prism_coeffs,
+                resolution.to(dtype=torch.float32),
+            ]
+        )
+        if intrinsics.shape != (18,):
+            raise ValueError(
+                f"OpenCV pinhole intrinsics must have shape (18,), got {tuple(intrinsics.shape)}"
+            )
+        return cls(intrinsics=intrinsics)
+
+    @property
+    def focal_length(self) -> torch.Tensor:
+        return self.intrinsics[0:2]
+
+    @property
+    def principal_point(self) -> torch.Tensor:
+        return self.intrinsics[2:4]
+
+    @property
+    def radial_coeffs(self) -> torch.Tensor:
+        return self.intrinsics[4:10]
+
+    @property
+    def tangential_coeffs(self) -> torch.Tensor:
+        return self.intrinsics[10:12]
+
+    @property
+    def thin_prism_coeffs(self) -> torch.Tensor:
+        return self.intrinsics[12:16]
+
+    @property
+    def resolution(self) -> torch.Tensor:
+        return self.intrinsics[16:18]
+
+    def transform(
+        self,
+        image_domain_scale: float | tuple[float, float],
+        image_domain_offset: tuple[float, float] = (0.0, 0.0),
+        new_resolution: tuple[int, int] | None = None,
+    ) -> "OpenCVPinholeProjection":
+        """Return calibration transformed by image scaling and cropping."""
+        device = self.intrinsics.device
+        dtype = self.intrinsics.dtype
+        if isinstance(image_domain_scale, tuple):
+            scale = torch.tensor(image_domain_scale, device=device, dtype=dtype)
+        else:
+            scale = torch.tensor(
+                [image_domain_scale, image_domain_scale], device=device, dtype=dtype
+            )
+        offset = torch.tensor(image_domain_offset, device=device, dtype=dtype)
+        resolution = (
+            torch.tensor(new_resolution, device=device, dtype=dtype)
+            if new_resolution is not None
+            else self.resolution * scale
+        )
+        return OpenCVPinholeProjection.from_components(
+            focal_length=self.focal_length * scale,
+            principal_point=self.principal_point * scale - offset,
+            radial_coeffs=self.radial_coeffs.clone(),
+            tangential_coeffs=self.tangential_coeffs.clone(),
+            thin_prism_coeffs=self.thin_prism_coeffs.clone(),
+            resolution=resolution,
+        )
+
+
+@dataclass
 class Pose:
     """Static SE(3) pose."""
 
@@ -288,6 +380,7 @@ __all__ = [
     "FThetaPolynomialType",
     "FThetaProjection",
     "NoExternalDistortion",
+    "OpenCVPinholeProjection",
     "Pose",
     "ReferencePolynomial",
     "ShutterType",

--- a/instant_nurec/utils/sensors/ncore_sensors_converters.py
+++ b/instant_nurec/utils/sensors/ncore_sensors_converters.py
@@ -28,6 +28,7 @@ from instant_nurec.utils.sensors.kernel_types import (
     FThetaPolynomialType,
     FThetaProjection,
     NoExternalDistortion,
+    OpenCVPinholeProjection,
     Pose,
     ShutterType,
 )
@@ -36,6 +37,7 @@ from ncore.sensors import (
     BivariateWindshieldModel,
     CameraModel,
     FThetaCameraModel,
+    OpenCVPinholeCameraModel,
 )
 
 
@@ -83,11 +85,13 @@ class CameraModelConverter:
         if device is None:
             device = torch.device("cpu")
 
-        # Convert projection based on type. FTheta is the only supported
-        # input projection — Pinhole/Fisheye were intentionally dropped
-        # because Kelvin predict was never exercised with them.
+        # Convert projection based on type.
         projection: CameraProjection
-        if isinstance(camera_model, FThetaCameraModel):
+        if isinstance(camera_model, OpenCVPinholeCameraModel):
+            projection = CameraModelConverter._convert_opencv_pinhole(
+                camera_model, device
+            )
+        elif isinstance(camera_model, FThetaCameraModel):
             projection = CameraModelConverter._convert_ftheta(camera_model, device)
         else:
             raise TypeError(f"Unsupported camera model type: {type(camera_model).__name__}")
@@ -100,6 +104,21 @@ class CameraModelConverter:
             external_distortion=external_distortion,
             resolution=tuple(camera_model.resolution.tolist()),
             shutter_type=ShutterType(camera_model.shutter_type.value),
+        )
+
+    @staticmethod
+    def _convert_opencv_pinhole(
+        camera_model: OpenCVPinholeCameraModel,
+        device: torch.device,
+    ) -> OpenCVPinholeProjection:
+        """Convert NCore's OpenCV pinhole model to torch-kernel parameters."""
+        return OpenCVPinholeProjection.from_components(
+            focal_length=camera_model.focal_length.to(device),
+            principal_point=camera_model.principal_point.to(device),
+            radial_coeffs=camera_model.radial_coeffs.to(device),
+            tangential_coeffs=camera_model.tangential_coeffs.to(device),
+            thin_prism_coeffs=camera_model.thin_prism_coeffs.to(device),
+            resolution=camera_model.resolution.to(device),
         )
 
     @staticmethod

--- a/instant_nurec/utils/sensors/ray_gen.py
+++ b/instant_nurec/utils/sensors/ray_gen.py
@@ -20,8 +20,9 @@
 * ``camera_rays_to_image_points`` — forward camera projection (consumed
   by ``instant_nurec/utils/cubemap.py``).
 
-FTheta is the supported projection model. External distortion supports
-``NoExternalDistortion`` and NRE-compatible bivariate windshield models.
+F-Theta and OpenCV pinhole are supported projection models. External
+distortion supports ``NoExternalDistortion`` and calibrated bivariate
+windshield models.
 """
 
 from __future__ import annotations
@@ -36,6 +37,7 @@ from instant_nurec.utils.sensors.kernel_types import (
     FThetaPolynomialType,
     FThetaProjection,
     NoExternalDistortion,
+    OpenCVPinholeProjection,
     ShutterType,
 )
 
@@ -112,6 +114,77 @@ def _ftheta_image_points_to_camera_rays(
         [[0, 0, 1]], device=image_points.device, dtype=image_points.dtype
     )
     return cam_rays
+
+
+def _opencv_pinhole_compute_distortion(
+    xy: torch.Tensor,
+    projection: OpenCVPinholeProjection,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Evaluate OpenCV rational radial, tangential, and thin-prism terms."""
+    radial = projection.radial_coeffs.to(device=xy.device, dtype=xy.dtype)
+    tangential = projection.tangential_coeffs.to(device=xy.device, dtype=xy.dtype)
+    thin_prism = projection.thin_prism_coeffs.to(device=xy.device, dtype=xy.dtype)
+
+    xy_squared = torch.square(xy)
+    r_2 = torch.sum(xy_squared, dim=1)
+    xy_prod = xy[:, 0] * xy[:, 1]
+    a1 = 2.0 * xy_prod
+    a2 = r_2 + 2.0 * xy_squared[:, 0]
+    a3 = r_2 + 2.0 * xy_squared[:, 1]
+
+    radial_numerator = 1.0 + r_2 * (
+        radial[0] + r_2 * (radial[1] + r_2 * radial[2])
+    )
+    radial_denominator = 1.0 + r_2 * (
+        radial[3] + r_2 * (radial[4] + r_2 * radial[5])
+    )
+    radial_scale = radial_numerator / radial_denominator
+
+    delta_x = (
+        tangential[0] * a1
+        + tangential[1] * a2
+        + r_2 * (thin_prism[0] + r_2 * thin_prism[1])
+    )
+    delta_y = (
+        tangential[0] * a3
+        + tangential[1] * a1
+        + r_2 * (thin_prism[2] + r_2 * thin_prism[3])
+    )
+    return radial_scale, delta_x, delta_y, r_2
+
+
+def _opencv_pinhole_image_points_to_camera_rays(
+    image_points: torch.Tensor,
+    projection: OpenCVPinholeProjection,
+    *,
+    stop_mean_of_squares_error_px2: float = 1e-12,
+    max_iterations: int = 10,
+) -> torch.Tensor:
+    """OpenCV pinhole inverse projection using NCore's iterative solver."""
+    principal_point = projection.principal_point.to(
+        device=image_points.device, dtype=image_points.dtype
+    )
+    focal_length = projection.focal_length.to(
+        device=image_points.device, dtype=image_points.dtype
+    )
+    undistorted_target = (image_points - principal_point) / focal_length
+    camera_rays_2d = undistorted_target
+    for _ in range(max_iterations):
+        radial_scale, delta_x, delta_y, _ = _opencv_pinhole_compute_distortion(
+            camera_rays_2d, projection
+        )
+        next_camera_rays_2d = (
+            undistorted_target - torch.stack([delta_x, delta_y], dim=1)
+        ) / radial_scale[:, None]
+        residual = camera_rays_2d - next_camera_rays_2d
+        camera_rays_2d = next_camera_rays_2d
+        if torch.mean(torch.square(residual)).item() <= stop_mean_of_squares_error_px2:
+            break
+
+    camera_rays = torch.cat(
+        [camera_rays_2d, torch.ones_like(camera_rays_2d[:, :1])], dim=1
+    )
+    return torch.nn.functional.normalize(camera_rays, dim=1)
 
 
 def _generate_all_pixel_image_points(
@@ -239,6 +312,49 @@ def _ncore_ftheta_to_projection_and_resolution(
     return projection, resolution
 
 
+@torch._dynamo.disable
+def _ncore_opencv_pinhole_to_projection_and_resolution(
+    ncore_params: object,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> tuple[OpenCVPinholeProjection, tuple[int, int]]:
+    """Build torch-kernel pinhole parameters from NCore parameter storage."""
+    import numpy as np
+
+    def tensor(name: str) -> torch.Tensor:
+        return torch.tensor(
+            [float(value) for value in getattr(ncore_params, name)],
+            device=device,
+            dtype=dtype,
+        )
+
+    resolution_array = np.asarray(ncore_params.resolution).astype(np.int64).flatten()
+    resolution = (int(resolution_array[0]), int(resolution_array[1]))
+    projection = OpenCVPinholeProjection.from_components(
+        focal_length=tensor("focal_length"),
+        principal_point=tensor("principal_point"),
+        radial_coeffs=tensor("radial_coeffs"),
+        tangential_coeffs=tensor("tangential_coeffs"),
+        thin_prism_coeffs=tensor("thin_prism_coeffs"),
+        resolution=torch.tensor(resolution, device=device, dtype=dtype),
+    )
+    return projection, resolution
+
+
+def _looks_like_ncore_opencv_pinhole_parameters(parameters: object) -> bool:
+    return all(
+        hasattr(parameters, name)
+        for name in (
+            "focal_length",
+            "principal_point",
+            "radial_coeffs",
+            "tangential_coeffs",
+            "thin_prism_coeffs",
+            "resolution",
+        )
+    )
+
+
 @torch._dynamo.disable  # numpy / dataclass conversion from ncore params is outside the compiled path
 def _ncore_external_distortion_to_distortion(
     ncore_params: object, device: torch.device, dtype: torch.dtype
@@ -281,41 +397,13 @@ def _ncore_external_distortion_to_distortion(
     )
 
 
-def camera_rays_to_image_points(
-    camera_model_parameters: object,
+def _ftheta_camera_rays_to_image_points(
     cam_rays: torch.Tensor,
-) -> object:
-    """Forward FTheta camera projection: camera-frame rays → image points + valid mask.
-
-    Accepts an ncore ``FThetaCameraModelParameters`` (matching the libs API)
-    and returns an object with ``.image_points`` and ``.valid_flag``
-    attributes (matching ``ncore.sensors.CameraModel.ImagePointsReturn``).
-
-    Mirrors ``ncore.impl.sensors.camera.FThetaCameraModel._camera_rays_to_image_points_impl``.
-    """
-    cam_rays = cam_rays.to(dtype=torch.float32).contiguous()
+    projection: FThetaProjection,
+    resolution: tuple[int, int] | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
     device = cam_rays.device
     dtype = cam_rays.dtype
-
-    if isinstance(camera_model_parameters, FThetaProjection):
-        projection = camera_model_parameters
-        resolution = None  # caller didn't pass resolution; skip image-bounds check
-        external_distortion: ExternalDistortion = NoExternalDistortion()
-    else:
-        projection, resolution = _ncore_ftheta_to_projection_and_resolution(
-            camera_model_parameters, device, dtype
-        )
-        external_distortion = _ncore_external_distortion_to_distortion(
-            camera_model_parameters, device, dtype
-        )
-
-    if isinstance(external_distortion, BivariateWindshieldDistortion):
-        cam_rays = external_distortion.distort_camera_rays(cam_rays)
-    elif not isinstance(external_distortion, NoExternalDistortion):
-        raise NotImplementedError(
-            f"unsupported external distortion: {type(external_distortion).__name__}"
-        )
-
     ray_xy_norms = _numerically_stable_xy_norm(cam_rays)
     eps = torch.finfo(torch.float32).eps
     ray_xy_norms = torch.where(
@@ -355,6 +443,117 @@ def camera_rays_to_image_points(
     else:
         valid = valid_thetas
 
+    return image_points, valid
+
+
+def _opencv_pinhole_camera_rays_to_image_points(
+    cam_rays: torch.Tensor,
+    projection: OpenCVPinholeProjection,
+    resolution: tuple[int, int],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """OpenCV pinhole forward projection with NCore-compatible validity."""
+    image_points = torch.zeros_like(cam_rays[:, :2])
+    valid = cam_rays[:, 2] > 0.0
+    valid_idx = torch.where(valid)[0]
+    cam_rays_valid = torch.index_select(cam_rays, 0, valid_idx)
+
+    normalized = cam_rays_valid[:, :2] / cam_rays_valid[:, 2:3]
+    radial_scale, delta_x, delta_y, r_2 = _opencv_pinhole_compute_distortion(
+        normalized, projection
+    )
+    valid_radial = (radial_scale > 0.8) & (radial_scale < 1.2)
+
+    distorted = normalized[valid_radial] * radial_scale[valid_radial, None]
+    distorted = distorted + torch.stack(
+        [delta_x[valid_radial], delta_y[valid_radial]], dim=1
+    )
+    focal_length = projection.focal_length.to(
+        device=cam_rays.device, dtype=cam_rays.dtype
+    )
+    principal_point = projection.principal_point.to(
+        device=cam_rays.device, dtype=cam_rays.dtype
+    )
+    image_points[valid_idx[valid_radial]] = distorted * focal_length + principal_point
+
+    # NCore provides a bounded diagnostic location for excessive radial
+    # distortion, while keeping the point invalid.
+    invalid_radial = ~valid_radial
+    if torch.any(invalid_radial):
+        clipping_radius = float((resolution[0] ** 2 + resolution[1] ** 2) ** 0.5)
+        image_points[valid_idx[invalid_radial]] = (
+            normalized[invalid_radial]
+            / torch.sqrt(r_2[invalid_radial, None])
+            * clipping_radius
+            + principal_point
+        )
+
+    width, height = resolution
+    valid_x = (image_points[valid_idx, 0] >= 0.0) & (
+        image_points[valid_idx, 0] < width
+    )
+    valid_y = (image_points[valid_idx, 1] >= 0.0) & (
+        image_points[valid_idx, 1] < height
+    )
+    valid_points = valid_x & valid_y & valid_radial
+    valid[valid_idx[~valid_points]] = False
+    return image_points, valid
+
+
+def camera_rays_to_image_points(
+    camera_model_parameters: object,
+    cam_rays: torch.Tensor,
+) -> object:
+    """Project camera rays with F-Theta or OpenCV pinhole calibration.
+
+    The return object exposes ``image_points`` and ``valid_flag`` attributes,
+    matching ``ncore.sensors.CameraModel.ImagePointsReturn``.
+    """
+    cam_rays = cam_rays.to(dtype=torch.float32).contiguous()
+    device = cam_rays.device
+    dtype = cam_rays.dtype
+
+    projection: FThetaProjection | OpenCVPinholeProjection
+    resolution: tuple[int, int] | None
+    if isinstance(camera_model_parameters, FThetaProjection):
+        projection = camera_model_parameters
+        resolution = None
+        external_distortion: ExternalDistortion = NoExternalDistortion()
+    elif isinstance(camera_model_parameters, OpenCVPinholeProjection):
+        projection = camera_model_parameters
+        resolution = tuple(int(value) for value in projection.resolution.tolist())
+        external_distortion = NoExternalDistortion()
+    elif _looks_like_ncore_opencv_pinhole_parameters(camera_model_parameters):
+        projection, resolution = _ncore_opencv_pinhole_to_projection_and_resolution(
+            camera_model_parameters, device, dtype
+        )
+        external_distortion = _ncore_external_distortion_to_distortion(
+            camera_model_parameters, device, dtype
+        )
+    else:
+        projection, resolution = _ncore_ftheta_to_projection_and_resolution(
+            camera_model_parameters, device, dtype
+        )
+        external_distortion = _ncore_external_distortion_to_distortion(
+            camera_model_parameters, device, dtype
+        )
+
+    if isinstance(external_distortion, BivariateWindshieldDistortion):
+        cam_rays = external_distortion.distort_camera_rays(cam_rays)
+    elif not isinstance(external_distortion, NoExternalDistortion):
+        raise NotImplementedError(
+            f"unsupported external distortion: {type(external_distortion).__name__}"
+        )
+
+    if isinstance(projection, OpenCVPinholeProjection):
+        assert resolution is not None
+        image_points, valid = _opencv_pinhole_camera_rays_to_image_points(
+            cam_rays, projection, resolution
+        )
+    else:
+        image_points, valid = _ftheta_camera_rays_to_image_points(
+            cam_rays, projection, resolution
+        )
+
     class _ImagePointsReturn:
         pass
 
@@ -385,12 +584,12 @@ def image_points_to_world_rays_shutter_pose(
     ``image_points_to_world_rays_shutter_pose``.
 
     Returns ``(world_rays (N, 6), timestamps_us (N,) or None, poses_t or
-    None, poses_q or None)``. Camera ray gen is FTheta-only; ``return_poses``
-    is not implemented.
+    None, poses_q or None)``. ``return_poses`` is not implemented.
     """
-    if not isinstance(projection, FThetaProjection):
+    if not isinstance(projection, (FThetaProjection, OpenCVPinholeProjection)):
         raise NotImplementedError(
-            f"only FThetaProjection supported, got {type(projection).__name__}"
+            "only FThetaProjection and OpenCVPinholeProjection are supported, "
+            f"got {type(projection).__name__}"
         )
     if not isinstance(external_distortion, (NoExternalDistortion, BivariateWindshieldDistortion)):
         raise NotImplementedError(
@@ -416,8 +615,13 @@ def image_points_to_world_rays_shutter_pose(
             None,
         )
 
-    # Camera-frame rays via FTheta inverse projection.
-    cam_rays = _ftheta_image_points_to_camera_rays(image_points, projection)
+    # Camera-frame rays via the calibrated inverse projection.
+    if isinstance(projection, FThetaProjection):
+        cam_rays = _ftheta_image_points_to_camera_rays(image_points, projection)
+    else:
+        cam_rays = _opencv_pinhole_image_points_to_camera_rays(
+            image_points, projection
+        )
     if isinstance(external_distortion, BivariateWindshieldDistortion):
         cam_rays = external_distortion.undistort_camera_rays(cam_rays)
 

--- a/instant_nurec/utils/types.py
+++ b/instant_nurec/utils/types.py
@@ -28,6 +28,22 @@ import torch
 from ncore.data import ConcreteCameraModelParametersUnion
 
 
+class RayFlags(IntFlag):
+    """Per-ray label flags used by public training and rendering."""
+
+    RGB_LABEL = auto()
+    VALID_SEMANTIC = auto()
+    SKY_SEMANTIC = auto()
+    ROAD_SEMANTIC = auto()
+    VEHICLE_SEMANTIC = auto()
+    EGO_SEMANTIC = auto()
+    DROPPED = auto()
+    VALID_NORMAL = auto()
+    INVALID = auto()
+    HARMONIZED = auto()
+    SYNTHETIC = auto()
+
+
 
 @dataclass(slots=True)
 class HalfClosedInterval:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "instant_nurec"
 version = "0.1.0"
-description = "Standalone InstantNuRec Kelvin predict pipeline (ncorev4 ingest → Kelvin predict → 3D-Gaussian PLY export)."
+description = "InstantNuRec training and prediction on calibrated NCore V4 data."
 readme = "README.md"
 requires-python = ">=3.11,<3.12"
 license = { text = "Apache-2.0" }
@@ -33,10 +33,21 @@ dependencies = [
 [project.optional-dependencies]
 render = [
     "gsplat==1.5.3",
+    "nvdiffrast==0.4.0",
+]
+training = [
+    "gsplat==1.5.3",
+    "lpips==0.1.4",
+    "nvdiffrast==0.4.0",
+    "pytorch-lightning==2.6.5",
+    "safetensors==0.6.2",
+    "torchmetrics==1.7.0",
+    "wandb==0.28.2",
 ]
 
 [project.scripts]
 instant-nurec = "instant_nurec.cli:main"
+instant-nurec-train = "instant_nurec.training.run:main"
 
 [dependency-groups]
 dev = [
@@ -73,7 +84,11 @@ torch-scatter = { index = "pyg-torch-2.7.0-cu128" }
 # Newton noise floor and exposes explicit world-ray 3DGUT rendering.  Both are
 # required to render NCore calibration and rolling-shutter trajectories without
 # falling back to a pinhole approximation.
-gsplat = { git = "https://github.com/nerfstudio-project/gsplat.git", rev = "a337c3dcaca733ddc3e16bdc156c536aaf5e19ba" }
+gsplat = { git = "https://github.com/nerfstudio-project/gsplat.git", rev = "608e19ad1657815b685a14f1735ac830838c240e" }
+nvdiffrast = { git = "https://github.com/NVlabs/nvdiffrast.git", rev = "253ac4fcea7de5f396371124af597e6cc957bfae" }
+
+[tool.uv]
+no-build-isolation-package = ["nvdiffrast"]
 
 [tool.uv.extra-build-variables]
 # Match the PyPI install mode: package the CUDA sources and JIT-compile only

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -98,6 +98,7 @@ def stubbed_batch(monkeypatch):
 
     sensors_ncore.CameraModel = CameraModel
     sensors_ncore.FThetaCameraModel = type("FTC", (CameraModel,), {})
+    sensors_ncore.OpenCVPinholeCameraModel = type("OCVP", (CameraModel,), {})
     sensors_ncore.BivariateWindshieldModel = type("BWM", (), {})
     ncore_mod.sensors = sensors_ncore
 
@@ -459,6 +460,51 @@ def test_cam_labels_collate_fn_with_all_none(stubbed_batch):
     b = stubbed_batch.CameraFrameLabels()
     out = stubbed_batch.CameraFrameLabels.collate_fn([a, b])
     assert out.rgb is None
+    assert out.metric_distance is None
+
+
+@pytest.mark.parametrize("synthetic_first", [False, True])
+def test_cam_labels_collate_fills_missing_synthetic_depth_with_zero(stubbed_batch, synthetic_first):
+    mod = stubbed_batch
+    real_depth = torch.full((1, 4, 5, 1), 12.5, dtype=torch.float32)
+    real = _make_cam_labels(
+        mod,
+        metric_distance=real_depth,
+        flags=torch.full((1, 4, 5, 1), int(mod.RayFlags.RGB_LABEL), dtype=torch.int32),
+    )
+    synthetic = _make_cam_labels(
+        mod,
+        metric_distance=None,
+        flags=torch.full(
+            (1, 4, 5, 1),
+            int(mod.RayFlags.RGB_LABEL | mod.RayFlags.SYNTHETIC),
+            dtype=torch.int32,
+        ),
+    )
+
+    out = mod.CameraFrameLabels.collate_fn([synthetic, real] if synthetic_first else [real, synthetic])
+
+    assert out.metric_distance is not None
+    assert out.metric_distance.shape == (2, 4, 5, 1)
+    real_index = 1 if synthetic_first else 0
+    synthetic_index = 0 if synthetic_first else 1
+    torch.testing.assert_close(out.metric_distance[real_index : real_index + 1], real_depth)
+    assert torch.count_nonzero(out.metric_distance[synthetic_index : synthetic_index + 1]) == 0
+    assert out.flags is not None
+    assert out.get_mask_flags_all(mod.RayFlags.SYNTHETIC)[synthetic_index : synthetic_index + 1].all()
+
+
+def test_cam_labels_collate_rejects_mismatched_frame_shapes(stubbed_batch):
+    real = _make_cam_labels(
+        stubbed_batch,
+        metric_distance=torch.ones((1, 4, 5, 1), dtype=torch.float32),
+    )
+    differently_sized_synthetic = stubbed_batch.CameraFrameLabels(
+        rgb=torch.zeros((1, 3, 5, 3), dtype=torch.float32),
+    )
+
+    with pytest.raises(RuntimeError):
+        stubbed_batch.CameraFrameLabels.collate_fn([real, differently_sized_synthetic])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -46,6 +46,24 @@ from instant_nurec.config_schema.models import (
 from instant_nurec.config_schema.predict import PredictConfig, PrimitiveMergeConfig
 
 
+def test_default_predict_dataset_keeps_auxiliary_labels_disabled():
+    config = NCoreInstantNuRecDatasetConfig(ncore_json_paths=["/tmp/example.json"])
+
+    assert config.aux_data.enabled is False
+    assert config.aux_data.enabled_context is False
+    assert config.aux_data.depth is True
+
+
+def test_auxiliary_depth_accepts_official_clip_id_override_template():
+    template = "/depth/{{clip_id}}/{{clip_id}}.aux.depth.zarr.itar"
+    config = NCoreInstantNuRecDatasetConfig(
+        ncore_json_paths=["/tmp/example.json"],
+        aux_data={"enabled": True, "depth": template},
+    )
+
+    assert config.aux_data.depth == template
+
+
 # ---------------------------------------------------------------------------
 # PrimitiveMergeConfig
 # ---------------------------------------------------------------------------

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -135,9 +135,7 @@ def _fake_batch(V: int = 2, H: int = 4, W: int = 4):
     the masking branch can read from without a real dataloader."""
     from types import SimpleNamespace
 
-    timestamps_startend_us = torch.tensor(
-        [[0, 1_000_000]] * V, dtype=torch.int64
-    )  # (V, 2)
+    timestamps_startend_us = torch.tensor([[0, 1_000_000]] * V, dtype=torch.int64)  # (V, 2)
     rays = torch.zeros(V, H, W, 6)
     rays[..., 5] = 1.0  # rays_dir = (0,0,1) so xyz = origin + depth*z
     distance_to_depth_scale = torch.ones(V, H, W, 1)
@@ -149,10 +147,7 @@ def _fake_batch(V: int = 2, H: int = 4, W: int = 4):
     # the result of ``to_simple_pinhole_model_parameters`` (which gets
     # monkeypatched in the test fixture below), so a SimpleNamespace stand-in
     # is enough.
-    sensor_params = [
-        SimpleNamespace(resolution=(W, H), focal_length=(float(W), float(H)))
-        for _ in range(V)
-    ]
+    sensor_params = [SimpleNamespace(resolution=(W, H), focal_length=(float(W), float(H))) for _ in range(V)]
 
     rendering_camera = SimpleNamespace(
         rays=rays,
@@ -233,26 +228,17 @@ def test_reconstruct_with_tracks_keeps_unassociated_movable_gaussians(monkeypatc
             output[5].fill_(KelvinSemanticClass.MOVABLE.value)
             return tuple(output)
 
-    class _DynamicTrack:
-        def ray_intersection(self, origins, directions, timestamps, **kwargs):
-            del origins, directions, timestamps, kwargs
-            return SimpleNamespace(
-                intersections_tracks_idx=torch.zeros(2, 2, dtype=torch.int64),
-                intersections_cnt=torch.tensor([1, 0], dtype=torch.int64),
-            )
-
-    monkeypatch.setattr(
-        inference_mod.CuboidTracks.Ops,
-        "subset_from_mask",
-        lambda tracks, mask: _DynamicTrack(),
-    )
+    def _fake_associate(**kwargs):
+        assert kwargs["points_dynamic_mask"].all()
+        return torch.tensor([[0], [-1]], dtype=torch.int32)
 
     def _fake_warp(**kwargs):
         # The first MOVABLE Gaussian is associated with a dynamic track; the
         # second is parked/unassociated and must remain in the static export.
-        assert torch.equal(kwargs["aux_tracks_idx"].reshape(-1), torch.tensor([0, -1]))
-        return kwargs["aux_tracks_idx"] >= 0, []
+        assert torch.equal(kwargs["tracks_idx"].reshape(-1), torch.tensor([0, -1]))
+        return kwargs["tracks_idx"] >= 0, []
 
+    monkeypatch.setattr(inference_mod, "associate_points_with_cuboid_tracks", _fake_associate)
     monkeypatch.setattr(inference_mod, "warp_points_with_cuboid_tracks", _fake_warp)
 
     core = _AllMovableStaticCore(B=1, V=1, H=1, W=2, n_cams=1)
@@ -264,6 +250,34 @@ def test_reconstruct_with_tracks_keeps_unassociated_movable_gaussians(monkeypatc
     assert len(primitive.static_layer) == 1
     assert torch.equal(primitive.static_layer.positions, torch.tensor([[3.0, 4.0, 5.0]]))
     assert primitive.static_layer.semantic_class.item() == KelvinSemanticClass.MOVABLE.value
+
+
+def test_dynamic_mask_unassigns_static_tracks(monkeypatch):
+    from types import SimpleNamespace
+
+    from instant_nurec.model import inference as inference_mod
+    from instant_nurec.utils.types import TrackFlags
+
+    adapter = _make_adapter(_FakeStaticCore(B=1, V=1, H=1, W=2, n_cams=1))
+    rendering = _fake_batch(V=1, H=1, W=2).rendering.camera
+    xyz = torch.zeros(1, 1, 1, 2, 3)
+    semantic = torch.full((1, 1, 1, 2), KelvinSemanticClass.MOVABLE.value, dtype=torch.int64)
+    tracks = SimpleNamespace(tracks_flags=torch.tensor([int(TrackFlags.NONE), int(TrackFlags.DYNAMIC)]))
+
+    monkeypatch.setattr(
+        inference_mod,
+        "associate_points_with_cuboid_tracks",
+        lambda **kwargs: torch.tensor([[[[0], [1]]]], dtype=torch.int32),
+    )
+
+    def _fake_warp(**kwargs):
+        assert torch.equal(kwargs["tracks_idx"], torch.tensor([[[[-1], [1]]]], dtype=torch.int32))
+        return kwargs["tracks_idx"] != -1, []
+
+    monkeypatch.setattr(inference_mod, "warp_points_with_cuboid_tracks", _fake_warp)
+
+    dynamic_mask = adapter._compute_dynamic_mask(xyz, semantic, rendering, tracks)
+    assert torch.equal(dynamic_mask, torch.tensor([[[False, True]]]))
 
 
 def test_reconstruct_packages_sparse_point_query_output():
@@ -280,7 +294,7 @@ def test_reconstruct_packages_sparse_point_query_output():
     )
 
 
-def test_sparse_dynamic_mask_gathers_aligned_source_rays_and_timestamps(monkeypatch):
+def test_sparse_dynamic_mask_gathers_aligned_source_timestamps(monkeypatch):
     from types import SimpleNamespace
 
     from instant_nurec.model import inference as inference_mod
@@ -293,28 +307,16 @@ def test_sparse_dynamic_mask_gathers_aligned_source_rays_and_timestamps(monkeypa
     source_indices = torch.tensor([[4, 1]], dtype=torch.int64)
     captured = {}
 
-    class _DynamicTrack:
-        def ray_intersection(self, origins, directions, timestamps, **kwargs):
-            captured["origins"] = origins
-            captured["directions"] = directions
-            captured["ray_timestamps"] = timestamps
-            return SimpleNamespace(
-                intersections_tracks_idx=torch.zeros(2, 2, dtype=torch.int64),
-                intersections_cnt=torch.ones(2, dtype=torch.int64),
-            )
-
-    dynamic_track = _DynamicTrack()
-    monkeypatch.setattr(
-        inference_mod.CuboidTracks.Ops,
-        "subset_from_mask",
-        lambda tracks, mask: dynamic_track,
-    )
+    def _fake_associate(**kwargs):
+        captured["points"] = kwargs["points"]
+        captured["source_timestamps"] = kwargs["points_timestamps_us"]
+        captured["dynamic_mask"] = kwargs["points_dynamic_mask"]
+        return torch.tensor([[0], [-1]], dtype=torch.int32)
 
     def _fake_warp(**kwargs):
-        captured["points"] = kwargs["points"]
-        captured["source_timestamps"] = kwargs["source_timestamps_us"]
-        return torch.tensor([True, False]), []
+        return kwargs["tracks_idx"] != -1, []
 
+    monkeypatch.setattr(inference_mod, "associate_points_with_cuboid_tracks", _fake_associate)
     monkeypatch.setattr(inference_mod, "warp_points_with_cuboid_tracks", _fake_warp)
     xyz = torch.arange(6, dtype=torch.float32).reshape(1, 2, 3)
     semantic = torch.full((1, 2), KelvinSemanticClass.MOVABLE.value, dtype=torch.int64)
@@ -328,11 +330,9 @@ def test_sparse_dynamic_mask_gathers_aligned_source_rays_and_timestamps(monkeypa
         source_indices,
     )
 
-    flat_rays = rendering.rays.reshape(-1, 6)[source_indices[0]]
-    assert torch.equal(captured["origins"], flat_rays[:, :3])
-    assert torch.equal(captured["directions"], flat_rays[:, 3:])
-    assert torch.equal(captured["ray_timestamps"], torch.tensor([4, 1]))
     assert torch.equal(captured["source_timestamps"], torch.tensor([[4], [1]]))
+    assert captured["dynamic_mask"].all()
+    assert torch.equal(captured["points"], xyz[0])
     assert torch.equal(dynamic_mask, torch.tensor([True, False]))
 
 

--- a/tests/test_instantnurec_ncore.py
+++ b/tests/test_instantnurec_ncore.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from dataclasses import dataclass
+from pathlib import Path
 from types import SimpleNamespace
 
 import ncore.data
@@ -12,8 +13,11 @@ import numpy as np
 import pytest
 import torch
 
+from upath import UPath
+
 from instant_nurec.config_schema.dataset import NCoreInstantNuRecDatasetConfig
 from instant_nurec.datasets.instantnurec_ncore import NCoreInstantNuRecDataset
+from instant_nurec.utils import ncore_utils
 from instant_nurec.utils.types import FrameConversion, RigTrajectories
 
 
@@ -94,6 +98,59 @@ def _reference_rig() -> RigTrajectories:
     )
 
 
+def test_loader_resolves_official_aux_depth_clip_id_override(tmp_path, monkeypatch) -> None:
+    clip_id = "example-clip-0001"
+    source_path = tmp_path / "sequence.json"
+    source_path.write_text("{}")
+    data_shard = tmp_path / "clip.000.zarr.itar"
+    data_shard.touch()
+    depth_template = tmp_path / "depths" / "{{clip_id}}" / "{{clip_id}}.aux.depth.zarr.itar"
+    depth_override = tmp_path / "depths" / clip_id / f"{clip_id}.aux.depth.zarr.itar"
+    depth_override.parent.mkdir(parents=True)
+    depth_override.touch()
+    dataset = NCoreInstantNuRecDataset(
+        NCoreInstantNuRecDatasetConfig(
+            ncore_json_paths=[str(source_path)],
+            context_camera_ids=[CAMERA_ID],
+            supervision_camera_ids=[CAMERA_ID],
+            aux_data={"enabled": True, "depth": str(depth_template)},
+        ),
+        frame_width=784,
+        frame_height=448,
+        n_frames_per_sample=18,
+    )
+    pose_edge = SimpleNamespace(
+        T_source_target=np.eye(4, dtype=np.float64)[None],
+        timestamps_us=np.array([0], dtype=np.int64),
+    )
+    sequence_loader = SimpleNamespace(
+        sequence_id=clip_id,
+        pose_graph=SimpleNamespace(get_edge=lambda source, target: pose_edge),
+        get_camera_sensor=lambda camera_id: SimpleNamespace(camera_id=camera_id),
+    )
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        ncore_utils,
+        "parse_sequence_meta_file",
+        lambda path: (clip_id, None, [UPath(data_shard)]),
+    )
+    monkeypatch.setattr(ncore_utils, "create_sequence_loader", lambda **kwargs: sequence_loader)
+
+    class _AuxLoader:
+        def __init__(self, **kwargs) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(ncore_utils, "AuxShardDataLoader", _AuxLoader)
+
+    result = dataset._get_loaders_and_sensors(source_path, dataset.all_context_camera_ids)
+
+    assert "main" in result.aux_loaders
+    signal_override_paths = captured["signal_override_paths"]
+    assert isinstance(signal_override_paths, dict)
+    assert Path(signal_override_paths["depth"].path) == depth_override
+
+
 def test_load_full_camera_rig_keeps_all_exposures_without_images_or_rays(tmp_path, monkeypatch) -> None:
     source_path = tmp_path / "sequence.json"
     source_path.write_text("{}")
@@ -111,10 +168,12 @@ def test_load_full_camera_rig_keeps_all_exposures_without_images_or_rays(tmp_pat
         seen["camera_ids"] = camera_ids
         return SimpleNamespace(
             camera_sensors={camera_ids[0]: sensor},
-            T_rig_worlds_with_timestamps_us=(
-                np.tile(np.eye(4, dtype=np.float64), (3, 1, 1)),
-                np.array([0, 100_000, 200_000], dtype=np.int64),
-            ),
+            T_rig_worlds_with_timestamps_us={
+                "main": (
+                    np.tile(np.eye(4, dtype=np.float64), (3, 1, 1)),
+                    np.array([0, 100_000, 200_000], dtype=np.int64),
+                )
+            },
         )
 
     class _FakeSubsampler:
@@ -178,10 +237,12 @@ def test_load_full_camera_rig_rejects_mismatched_exposure_counts(tmp_path, monke
         del source
         return SimpleNamespace(
             camera_sensors={camera_ids[0]: sensor},
-            T_rig_worlds_with_timestamps_us=(
-                np.tile(np.eye(4, dtype=np.float64), (3, 1, 1)),
-                np.array([0, 100_000, 200_000], dtype=np.int64),
-            ),
+            T_rig_worlds_with_timestamps_us={
+                "main": (
+                    np.tile(np.eye(4, dtype=np.float64), (3, 1, 1)),
+                    np.array([0, 100_000, 200_000], dtype=np.int64),
+                )
+            },
         )
 
     monkeypatch.setattr(dataset, "_get_loaders_and_sensors", fake_load)
@@ -204,10 +265,12 @@ def test_load_full_camera_rig_pads_pose_coverage_at_source_boundaries(tmp_path, 
         del source
         return SimpleNamespace(
             camera_sensors={camera_ids[0]: sensor},
-            T_rig_worlds_with_timestamps_us=(
-                np.tile(np.eye(4, dtype=np.float64), (3, 1, 1)),
-                np.array([0, 100_000, 200_000], dtype=np.int64),
-            ),
+            T_rig_worlds_with_timestamps_us={
+                "main": (
+                    np.tile(np.eye(4, dtype=np.float64), (3, 1, 1)),
+                    np.array([0, 100_000, 200_000], dtype=np.int64),
+                )
+            },
         )
 
     monkeypatch.setattr(dataset, "_get_loaders_and_sensors", fake_load)
@@ -241,10 +304,12 @@ def test_load_full_camera_rig_rejects_truncated_reconstruction(tmp_path, monkeyp
         del source
         return SimpleNamespace(
             camera_sensors={camera_ids[0]: sensor},
-            T_rig_worlds_with_timestamps_us=(
-                np.tile(np.eye(4, dtype=np.float64), (2, 1, 1)),
-                np.array([0, 120_030_000], dtype=np.int64),
-            ),
+            T_rig_worlds_with_timestamps_us={
+                "main": (
+                    np.tile(np.eye(4, dtype=np.float64), (2, 1, 1)),
+                    np.array([0, 120_030_000], dtype=np.int64),
+                )
+            },
         )
 
     monkeypatch.setattr(dataset, "_get_loaders_and_sensors", fake_load)

--- a/tests/test_kelvin_primitive.py
+++ b/tests/test_kelvin_primitive.py
@@ -171,3 +171,22 @@ def test_preprocess_fills_unobserved_cubemap_with_pruned_road_color() -> None:
         output.sky_cubemap[:, 2:],
         torch.tensor([0.2, 0.2, 0.2]).expand(6, 2, 4, 3),
     )
+
+
+def test_dynamic_interpolation_uses_piecewise_motion_and_edge_falloff() -> None:
+    layer = KelvinDynamicLayer(
+        rotations=torch.tensor([[1.0, 0.0, 0.0, 0.0]]),
+        scales=torch.ones(1, 3),
+        rgb=torch.zeros(1, 3),
+        max_densities=torch.ones(1, 1),
+        keyframe_positions=torch.tensor([[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [3.0, 0.0, 0.0]]]),
+        keyframe_timestamps_us=torch.tensor([[10, 20, 30]], dtype=torch.int64),
+    )
+
+    middle = layer.interpolate(25)
+    torch.testing.assert_close(middle.positions, torch.tensor([[2.0, 0.0, 0.0]]))
+    assert 0.0 < middle.densities.item() < 1.0
+
+    before = layer.interpolate(0)
+    torch.testing.assert_close(before.positions, torch.tensor([[-1.0, 0.0, 0.0]]))
+    torch.testing.assert_close(before.densities, torch.zeros(1, 1))

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -77,10 +77,10 @@ def test_compute_frame_gap_two_cameras_independent():
     up among themselves — gaps are not crossed between cameras."""
     ts = torch.tensor(
         [
-            [0, 0],       # cam 0
-            [1000, 1000], # cam 0
-            [50, 50],     # cam 1
-            [9999, 9999], # cam 1
+            [0, 0],  # cam 0
+            [1000, 1000],  # cam 0
+            [50, 50],  # cam 1
+            [9999, 9999],  # cam 1
         ]
     )
     cam = torch.tensor([0, 0, 1, 1])
@@ -160,19 +160,123 @@ def test_timestamps_us_to_continuous_times_outside_range_extrapolates():
 
 
 # ---------------------------------------------------------------------------
-# warp_points_with_cuboid_tracks
+# Cuboid association and warping
 # ---------------------------------------------------------------------------
 
 
+class _IntersectionResult:
+    def __init__(self, tracks_idx: torch.Tensor, points_local: torch.Tensor | None = None):
+        self.intersections_tracks_idx = tracks_idx
+        self.intersections_points_local = points_local
+
+
+class _FakeAssociationTracks:
+    def __init__(self, first_pass_tracks_idx: torch.Tensor):
+        self.n_tracks = 2
+        self.tracks_packinfo = torch.tensor([[0, 2], [2, 2]], dtype=torch.int32)
+        self.cuboids_dims = torch.tensor([[2.0, 2.0, 2.0], [4.0, 4.0, 4.0]])
+        self.first_pass_tracks_idx = first_pass_tracks_idx
+        self.calls: list[dict] = []
+
+    def point_intersection_interpolate_pose(self, points, points_timestamps_us, cuboids_dims_padding, **kwargs):
+        self.calls.append(
+            {
+                "points": points.clone(),
+                "timestamps": points_timestamps_us.clone(),
+                "padding": None if cuboids_dims_padding is None else cuboids_dims_padding.clone(),
+                **kwargs,
+            }
+        )
+        if kwargs["max_intersections_per_point"] == 1:
+            return _IntersectionResult(self.first_pass_tracks_idx.clone())
+
+        tracks_idx = torch.full((len(points), 64), -1, dtype=torch.int32)
+        points_local = torch.zeros(len(points), 64, 3)
+        for row, point in enumerate(points):
+            tracks_idx[row, :2] = torch.tensor([0, 1], dtype=torch.int32)
+            if point[0] == 0:
+                # Track 1 is nearer its original bbox: distances are 1.0 and 0.1.
+                points_local[row, 0, 0] = 2.0
+                points_local[row, 1, 0] = 2.1
+            else:
+                # Track 0 is nearer its original bbox: distances are 0.2 and 3.0.
+                points_local[row, 0, 0] = 1.2
+                points_local[row, 1, 0] = 5.0
+        return _IntersectionResult(tracks_idx, points_local)
+
+
+def test_associate_points_first_pass_preserves_trailing_scalar_shape():
+    from instant_nurec.utils.motion import associate_points_with_cuboid_tracks
+
+    tracks = _FakeAssociationTracks(torch.tensor([[1], [-1]], dtype=torch.int32))
+    points = torch.zeros(2, 3)
+    timestamps = torch.tensor([[10], [20]], dtype=torch.int64)
+
+    result = associate_points_with_cuboid_tracks(points, timestamps, None, tracks, None)
+
+    assert torch.equal(result, torch.tensor([[1], [-1]], dtype=torch.int32))
+    assert tracks.calls[0]["max_intersections_per_point"] == 1
+    assert tracks.calls[0]["timestamps"].shape == (2,)
+
+
+def test_associate_points_empty_tracks_returns_typed_minus_one():
+    from instant_nurec.utils.motion import associate_points_with_cuboid_tracks
+
+    class _EmptyTracks:
+        n_tracks = 0
+        tracks_packinfo = torch.empty((0, 2), dtype=torch.int32)
+
+    points = torch.zeros(2, 3, 4, 3)
+    timestamps = torch.zeros(2, 3, 4, 1, dtype=torch.int64)
+    result = associate_points_with_cuboid_tracks(points, timestamps, None, _EmptyTracks(), None)
+    assert result.shape == (2, 3, 4, 1)
+    assert result.dtype == torch.int32
+    assert torch.all(result == -1)
+
+
+def test_associate_points_widened_second_pass_selects_nearest_original_bbox():
+    from instant_nurec.utils.motion import associate_points_with_cuboid_tracks
+
+    tracks = _FakeAssociationTracks(torch.full((2, 1), -1, dtype=torch.int32))
+    points = torch.tensor([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    timestamps = torch.zeros(2, 1, dtype=torch.int64)
+    movable = torch.ones(2, 1, dtype=torch.bool)
+    padding = torch.tensor([0.2, 0.1, 0.05])
+
+    result = associate_points_with_cuboid_tracks(
+        points,
+        timestamps,
+        movable,
+        tracks,
+        padding,
+        second_pass_chunk_size=1,
+    )
+
+    assert torch.equal(result, torch.tensor([[1], [0]], dtype=torch.int32))
+    assert len(tracks.calls) == 3
+    for call in tracks.calls[1:]:
+        assert call["max_intersections_per_point"] == 64
+        assert call["with_local_points"] is True
+        assert torch.allclose(call["padding"], padding * 6.0)
+
+
+def test_associate_points_second_pass_only_checks_movable_misses():
+    from instant_nurec.utils.motion import associate_points_with_cuboid_tracks
+
+    tracks = _FakeAssociationTracks(torch.full((2, 1), -1, dtype=torch.int32))
+    points = torch.tensor([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    timestamps = torch.zeros(2, 1, dtype=torch.int64)
+    movable = torch.tensor([[True], [False]])
+
+    result = associate_points_with_cuboid_tracks(points, timestamps, movable, tracks, None)
+
+    assert torch.equal(result, torch.tensor([[1], [-1]], dtype=torch.int32))
+    assert len(tracks.calls) == 2
+    assert torch.equal(tracks.calls[1]["points"], points[:1])
+    assert torch.equal(tracks.calls[1]["padding"], torch.full((3,), 6.0))
+
+
 class _FakePose:
-    """Stand-in for an SE3 pose object — supports .inv() and __mul__ returning
-    self-or-other in such a way that the warp formula leaves points unchanged.
-
-    We construct two flavors:
-      - identity-like (any * pose == pose, pose * point == point)
-      - shifting (pose * point == point + offset)
-    """
-
     def __init__(self, offset: torch.Tensor | None = None):
         self.offset = offset if offset is not None else torch.zeros(3)
 
@@ -182,121 +286,64 @@ class _FakePose:
     def __mul__(self, other):
         if isinstance(other, _FakePose):
             return _FakePose(offset=self.offset + other.offset)
-        # apply to points (broadcast)
         return other + self.offset
 
 
-class _FakeCuboidTracks:
-    """Duck-typed stand-in for CuboidTracks with the methods used by
-    ``warp_points_with_cuboid_tracks``."""
-
-    def __init__(self, tracks_idx: torch.Tensor, target_offsets: list[torch.Tensor] | None = None):
-        self._tracks_idx = tracks_idx
-        # Per-target offset vectors used in interpolate_tracks_poses for target ts.
-        # Source poses are always identity.
-        self._target_offsets = target_offsets or []
-        self._call_count = 0
-
-    def point_intersection_interpolate_pose(self, points, src_ts, padding):
-        # ignore points/src_ts; return precanned tracks_idx
-        return None, self._tracks_idx.clone()
+class _FakeWarpTracks:
+    def __init__(self, target_offsets: list[torch.Tensor] | None = None):
+        self.tracks_packinfo = torch.tensor([[0, 2]], dtype=torch.int32)
+        self.target_offsets = target_offsets or []
+        self.call_count = 0
 
     def interpolate_tracks_poses(self, timestamps_us, tracks_idx):
-        if self._call_count == 0:
-            # First call is the source (inv called outside) — return identity
-            self._call_count += 1
-            return _FakePose(offset=torch.zeros(3))
-        # Subsequent calls are target poses — return offset
-        offset = self._target_offsets[(self._call_count - 1) % max(1, len(self._target_offsets))]
-        self._call_count += 1
-        return _FakePose(offset=offset)
+        assert tracks_idx.dtype == self.tracks_packinfo.dtype
+        if self.call_count == 0:
+            self.call_count += 1
+            return _FakePose()
+        offset = self.target_offsets[self.call_count - 1]
+        self.call_count += 1
+        return _FakePose(offset)
 
 
-def test_warp_points_no_dynamic_short_circuits_with_clones():
-    """When tracks_idx is all -1 (no associations), the warp should just
-    return identical clones of the input for every target."""
+def test_warp_points_no_associations_short_circuits_with_clones():
     from instant_nurec.utils.motion import warp_points_with_cuboid_tracks
 
     points = torch.zeros(4, 3)
-    src_ts = torch.zeros(4, dtype=torch.int64)
-    tgt_ts = [torch.zeros(4, dtype=torch.int64), torch.zeros(4, dtype=torch.int64)]
-    aux = torch.full((4,), -1, dtype=torch.int64)  # no fallback
+    source = torch.zeros(4, 1, dtype=torch.int64)
+    targets = [torch.zeros(4, 1, dtype=torch.int64), torch.ones(4, 1, dtype=torch.int64)]
+    tracks_idx = torch.full((4, 1), -1, dtype=torch.int32)
 
-    fake_tracks = _FakeCuboidTracks(tracks_idx=torch.full((4,), -1, dtype=torch.int64))
-    cuboids_dims_padding = torch.zeros(1, 3)
+    dynamic_mask, warped = warp_points_with_cuboid_tracks(points, source, targets, _FakeWarpTracks(), tracks_idx)
 
-    dynamic_mask, warped = warp_points_with_cuboid_tracks(
-        points, src_ts, tgt_ts, fake_tracks, aux, cuboids_dims_padding
-    )
-    assert dynamic_mask.shape == (4,)
+    assert dynamic_mask.shape == (4, 1)
     assert not dynamic_mask.any()
     assert len(warped) == 2
-    for w, ts in zip(warped, tgt_ts):
-        # Identical to the input for unassociated points
-        assert torch.equal(w, points)
+    for result in warped:
+        assert torch.equal(result, points)
+        assert result.data_ptr() != points.data_ptr()
 
 
-def test_warp_points_falls_back_to_aux_when_main_returns_minus_one():
-    """If point_intersection_interpolate_pose returns -1 for an entry,
-    the function should fall back to aux_tracks_idx (and only -1 there
-    means no association)."""
+def test_warp_points_moves_only_assigned_points():
     from instant_nurec.utils.motion import warp_points_with_cuboid_tracks
 
     points = torch.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
-    src_ts = torch.zeros(2, dtype=torch.int64)
-    tgt_ts = [torch.zeros(2, dtype=torch.int64)]
-    aux = torch.tensor([0, -1], dtype=torch.int64)  # first falls back, second stays unassociated
+    source = torch.zeros(2, 1, dtype=torch.int64)
+    targets = [torch.ones(2, 1, dtype=torch.int64)]
+    tracks_idx = torch.tensor([[0], [-1]], dtype=torch.int64)
+    tracks = _FakeWarpTracks([torch.tensor([10.0, 0.0, 0.0])])
 
-    fake_tracks = _FakeCuboidTracks(
-        tracks_idx=torch.tensor([-1, -1], dtype=torch.int64),
-        target_offsets=[torch.tensor([10.0, 0.0, 0.0])],
-    )
-    cuboids_dims_padding = torch.zeros(1, 3)
+    dynamic_mask, warped = warp_points_with_cuboid_tracks(points, source, targets, tracks, tracks_idx)
 
-    dynamic_mask, warped = warp_points_with_cuboid_tracks(
-        points, src_ts, tgt_ts, fake_tracks, aux, cuboids_dims_padding
-    )
-    # First point gets associated (via aux), second stays unassociated.
-    assert dynamic_mask.tolist() == [True, False]
-    # The warped points: first point was at origin, gets pose (target * inv(source)) applied.
-    # source pose = identity (offset=0); target pose offset=10 → net offset = 10
-    # So warped[0] should be (10, 0, 0); warped[1] should still be (1, 1, 1).
-    assert torch.allclose(warped[0][0], torch.tensor([10.0, 0.0, 0.0]))
-    assert torch.equal(warped[0][1], points[1])
+    assert torch.equal(dynamic_mask, torch.tensor([[True], [False]]))
+    assert torch.equal(warped[0], torch.tensor([[10.0, 0.0, 0.0], [1.0, 1.0, 1.0]]))
 
 
-def test_warp_points_squeeze_trailing_one_branch():
-    """Source/target timestamps with shape [..., 1] are squeezed to [...]."""
+def test_warp_points_requires_trailing_singleton_scalar_shapes():
     from instant_nurec.utils.motion import warp_points_with_cuboid_tracks
 
     points = torch.zeros(3, 3)
-    # Squeezable timestamp shapes (..., 1)
-    src_ts = torch.zeros(3, 1, dtype=torch.int64)
-    tgt_ts = [torch.zeros(3, 1, dtype=torch.int64)]
-    aux = torch.full((3,), -1, dtype=torch.int64)
-
-    fake_tracks = _FakeCuboidTracks(tracks_idx=torch.full((3,), -1, dtype=torch.int64))
-    cuboids_dims_padding = torch.zeros(1, 3)
-
-    dynamic_mask, warped = warp_points_with_cuboid_tracks(
-        points, src_ts, tgt_ts, fake_tracks, aux, cuboids_dims_padding
-    )
-    assert dynamic_mask.shape == (3,)
-
-
-def test_warp_points_already_squeezed_timestamps_path():
-    """Plain (...) shape (no trailing 1) goes through the no-squeeze branch."""
-    from instant_nurec.utils.motion import warp_points_with_cuboid_tracks
-
-    points = torch.zeros(3, 3)
-    src_ts = torch.zeros(3, dtype=torch.int64)
-    tgt_ts = [torch.zeros(3, dtype=torch.int64)]
-    aux = torch.full((3,), -1, dtype=torch.int64)
-
-    fake_tracks = _FakeCuboidTracks(tracks_idx=torch.full((3,), -1, dtype=torch.int64))
-    cuboids_dims_padding = torch.zeros(1, 3)
-
-    dynamic_mask, warped = warp_points_with_cuboid_tracks(
-        points, src_ts, tgt_ts, fake_tracks, aux, cuboids_dims_padding
-    )
-    assert dynamic_mask.shape == (3,)
+    source = torch.zeros(3, dtype=torch.int64)
+    target = torch.zeros(3, 1, dtype=torch.int64)
+    tracks_idx = torch.full((3, 1), -1, dtype=torch.int32)
+    with pytest.raises(AssertionError):
+        warp_points_with_cuboid_tracks(points, source, [target], _FakeWarpTracks(), tracks_idx)

--- a/tests/test_ncore_sensors_converters.py
+++ b/tests/test_ncore_sensors_converters.py
@@ -80,11 +80,17 @@ def stubbed_converters(monkeypatch):
     class FThetaCameraModel(CameraModel):
         pass
 
+    class OpenCVPinholeCameraModel(CameraModel):
+        pass
+
+    captured["OpenCVPinholeCameraModel"] = OpenCVPinholeCameraModel
+
     class BivariateWindshieldModel:
         pass
 
     sensors_ncore.CameraModel = CameraModel
     sensors_ncore.FThetaCameraModel = FThetaCameraModel
+    sensors_ncore.OpenCVPinholeCameraModel = OpenCVPinholeCameraModel
     sensors_ncore.BivariateWindshieldModel = BivariateWindshieldModel
     ncore_mod.data = data_mod
     ncore_mod.sensors = sensors_ncore
@@ -124,6 +130,13 @@ def stubbed_converters(monkeypatch):
         kt.FThetaProjection,
         "from_components",
         _wrap_from_components(kt.FThetaProjection, "FThetaProjection"),
+    )
+    monkeypatch.setattr(
+        kt.OpenCVPinholeProjection,
+        "from_components",
+        _wrap_from_components(
+            kt.OpenCVPinholeProjection, "OpenCVPinholeProjection"
+        ),
     )
     monkeypatch.setattr(
         kt.BivariateWindshieldDistortion,
@@ -191,9 +204,44 @@ def _make_ftheta(model_cls, ShutterType, ref_poly):
     return m
 
 
+def _make_opencv_pinhole(model_cls, ShutterType):
+    m = model_cls()
+    m.focal_length = torch.tensor([1000.0, 990.0])
+    m.principal_point = torch.tensor([640.0, 360.0])
+    m.radial_coeffs = torch.arange(6, dtype=torch.float32) * 1e-3
+    m.tangential_coeffs = torch.tensor([1e-4, -2e-4])
+    m.thin_prism_coeffs = torch.arange(4, dtype=torch.float32) * 1e-5
+    m.resolution = torch.tensor([1280, 720])
+    m.shutter_type = _shutter_obj(ShutterType.GLOBAL)
+    m.external_distortion = None
+    return m
+
+
 # ---------------------------------------------------------------------------
 # convert() — projection branches
 # ---------------------------------------------------------------------------
+
+
+def test_convert_opencv_pinhole_preserves_full_calibration(stubbed_converters):
+    mod, captured, _ftheta, _bw, ShutterType, *_ = stubbed_converters
+    OpenCVPinholeCameraModel = captured["OpenCVPinholeCameraModel"]
+    cam = _make_opencv_pinhole(OpenCVPinholeCameraModel, ShutterType)
+
+    result = mod.CameraModelConverter.convert(cam)
+
+    pinhole_call = next(
+        call for call in captured["calls"] if call[0] == "OpenCVPinholeProjection"
+    )
+    torch.testing.assert_close(pinhole_call[1]["focal_length"], cam.focal_length)
+    torch.testing.assert_close(pinhole_call[1]["principal_point"], cam.principal_point)
+    torch.testing.assert_close(pinhole_call[1]["radial_coeffs"], cam.radial_coeffs)
+    torch.testing.assert_close(
+        pinhole_call[1]["tangential_coeffs"], cam.tangential_coeffs
+    )
+    torch.testing.assert_close(
+        pinhole_call[1]["thin_prism_coeffs"], cam.thin_prism_coeffs
+    )
+    assert result.resolution == (1280, 720)
 
 
 def test_convert_ftheta_angle_to_pixeldist_uses_forward_polynomial(stubbed_converters):
@@ -233,8 +281,7 @@ def test_convert_ftheta_pixeldist_to_angle_uses_backward_polynomial(stubbed_conv
 
 
 def test_convert_unsupported_camera_type_raises(stubbed_converters):
-    """Any non-FTheta camera model triggers ``TypeError`` — OpenCVPinhole /
-    OpenCVFisheye are intentionally not supported on the input side."""
+    """Unknown camera models remain explicit unsupported cases."""
     (mod, *_) = stubbed_converters
 
     class _Mystery:

--- a/tests/test_ncore_utils.py
+++ b/tests/test_ncore_utils.py
@@ -235,6 +235,87 @@ def test_create_sequence_loader_passes_args_to_v4_loader(stubbed_ncore_utils, tm
 
 
 # ---------------------------------------------------------------------------
+# AuxShardDataLoader
+# ---------------------------------------------------------------------------
+
+
+def _write_aux_store(path: Path, *, sequence_id: str, signal: str, source: str) -> None:
+    import zarr
+
+    root = zarr.open_group(str(path), mode="w")
+    root.attrs.update(
+        sequence_id=sequence_id,
+        shard_id=0,
+        shard_count=1,
+        aux_root_group_name="annotations",
+    )
+    group = root.require_group("annotations").require_group(signal)
+    group.attrs["source"] = source
+
+
+def test_aux_loader_replaces_matching_adjacent_signal_with_override(
+    stubbed_ncore_utils, tmp_path
+):
+    mod, _ = stubbed_ncore_utils
+    from upath import UPath
+
+    source = tmp_path / "clip.000.zarr"
+    source.mkdir()
+    _write_aux_store(
+        tmp_path / "clip.aux.depth.zarr",
+        sequence_id="clip-id",
+        signal="depth",
+        source="adjacent",
+    )
+    _write_aux_store(
+        tmp_path / "clip.aux.egomask.zarr",
+        sequence_id="clip-id",
+        signal="egomask",
+        source="adjacent",
+    )
+    override = tmp_path / "override.aux.depth.zarr"
+    _write_aux_store(
+        override,
+        sequence_id="clip-id",
+        signal="depth",
+        source="override",
+    )
+
+    loader = mod.AuxShardDataLoader(
+        sequence_id="clip-id",
+        dataset_paths=[UPath(source)],
+        open_consolidated=False,
+        signal_override_paths={"depth": UPath(override)},
+    )
+
+    assert len(loader.base_groups["depth"]) == 1
+    assert loader.base_groups["depth"][0].attrs["source"] == "override"
+    assert loader.base_groups["egomask"][0].attrs["source"] == "adjacent"
+
+
+def test_aux_loader_preserves_adjacent_discovery_without_override(stubbed_ncore_utils, tmp_path):
+    mod, _ = stubbed_ncore_utils
+    from upath import UPath
+
+    source = tmp_path / "clip.000.zarr"
+    source.mkdir()
+    _write_aux_store(
+        tmp_path / "clip.aux.depth.zarr",
+        sequence_id="clip-id",
+        signal="depth",
+        source="adjacent",
+    )
+
+    loader = mod.AuxShardDataLoader(
+        sequence_id="clip-id",
+        dataset_paths=[UPath(source)],
+        open_consolidated=False,
+    )
+
+    assert loader.base_groups["depth"][0].attrs["source"] == "adjacent"
+
+
+# ---------------------------------------------------------------------------
 # get_mask_image
 # ---------------------------------------------------------------------------
 

--- a/tests/test_opencv_pinhole.py
+++ b/tests/test_opencv_pinhole.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+from instant_nurec.utils.sensors.kernel_types import (
+    DynamicPose,
+    OpenCVPinholeProjection,
+    Pose,
+)
+from instant_nurec.utils.sensors.ncore_sensors_converters import CameraModelConverter
+from instant_nurec.utils.sensors.ray_gen import (
+    camera_rays_to_image_points,
+    image_points_to_world_rays_shutter_pose,
+)
+from ncore.data import OpenCVPinholeCameraModelParameters, ShutterType
+from ncore.sensors import CameraModel
+
+
+def _parameters() -> OpenCVPinholeCameraModelParameters:
+    return OpenCVPinholeCameraModelParameters(
+        resolution=np.array([1920, 1280], dtype=np.uint64),
+        shutter_type=ShutterType.GLOBAL,
+        external_distortion_parameters=None,
+        principal_point=np.array([960.0, 640.0], dtype=np.float32),
+        focal_length=np.array([1100.0, 1090.0], dtype=np.float32),
+        radial_coeffs=np.array([0.01, -0.005, 0.001, 0.002, -0.001, 0.0002], dtype=np.float32),
+        tangential_coeffs=np.array([0.0003, -0.0002], dtype=np.float32),
+        thin_prism_coeffs=np.array([0.0001, -0.00005, 0.00007, -0.00003], dtype=np.float32),
+    )
+
+
+def _identity_dynamic_pose() -> DynamicPose:
+    pose = Pose(
+        translation=torch.zeros(3),
+        rotation=torch.tensor([0.0, 0.0, 0.0, 1.0]),
+    )
+    return DynamicPose(start_pose=pose, end_pose=pose)
+
+
+def test_opencv_pinhole_inverse_projection_matches_ncore() -> None:
+    model = CameraModel.from_parameters(_parameters(), device="cpu")
+    converted = CameraModelConverter.convert(model)
+    image_points = torch.tensor(
+        [
+            [0.5, 0.5],
+            [960.5, 640.5],
+            [1919.5, 1279.5],
+            [400.25, 700.75],
+        ],
+        dtype=torch.float32,
+    )
+
+    world_rays, _, _, _ = image_points_to_world_rays_shutter_pose(
+        image_points=image_points,
+        projection=converted.projection,
+        external_distortion=converted.external_distortion,
+        resolution=converted.resolution,
+        shutter_type=converted.shutter_type,
+        dynamic_pose=_identity_dynamic_pose(),
+    )
+    expected = model.image_points_to_camera_rays(image_points)
+
+    torch.testing.assert_close(world_rays[:, :3], torch.zeros_like(expected))
+    torch.testing.assert_close(world_rays[:, 3:], expected, rtol=1e-6, atol=1e-7)
+
+
+def test_opencv_pinhole_forward_projection_and_validity_match_ncore() -> None:
+    parameters = _parameters()
+    model = CameraModel.from_parameters(parameters, device="cpu")
+    camera_rays = torch.tensor(
+        [
+            [0.0, 0.0, 1.0],
+            [0.2, -0.1, 1.0],
+            [-0.6, 0.4, 1.0],
+            [0.0, 0.0, -1.0],
+            [2.0, 2.0, 1.0],
+        ],
+        dtype=torch.float32,
+    )
+
+    actual = camera_rays_to_image_points(parameters, camera_rays)
+    expected = model.camera_rays_to_image_points(camera_rays)
+
+    torch.testing.assert_close(actual.image_points, expected.image_points, rtol=1e-6, atol=1e-6)
+    torch.testing.assert_close(actual.valid_flag, expected.valid_flag)
+
+
+def test_opencv_pinhole_projection_transform_preserves_distortion() -> None:
+    model = CameraModel.from_parameters(_parameters(), device="cpu")
+    projection = CameraModelConverter.convert(model).projection
+    assert isinstance(projection, OpenCVPinholeProjection)
+
+    transformed = projection.transform(
+        image_domain_scale=(0.5, 0.25),
+        image_domain_offset=(10.0, 20.0),
+        new_resolution=(950, 300),
+    )
+
+    torch.testing.assert_close(transformed.focal_length, torch.tensor([550.0, 272.5]))
+    torch.testing.assert_close(transformed.principal_point, torch.tensor([470.0, 140.0]))
+    torch.testing.assert_close(transformed.radial_coeffs, projection.radial_coeffs)
+    torch.testing.assert_close(transformed.tangential_coeffs, projection.tangential_coeffs)
+    torch.testing.assert_close(transformed.thin_prism_coeffs, projection.thin_prism_coeffs)
+    torch.testing.assert_close(transformed.resolution, torch.tensor([950.0, 300.0]))

--- a/tests/test_render_preview.py
+++ b/tests/test_render_preview.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 
 from enum import Enum
@@ -37,6 +38,23 @@ class _FakeRollingShutterType(Enum):
 class _FakeFThetaCameraDistortionParameters:
     def __init__(self, **kwargs: object) -> None:
         self.__dict__.update(kwargs)
+
+
+class _FakeUnscentedTransformParameters:
+    def __init__(self, **kwargs: object) -> None:
+        self.__dict__.update(kwargs)
+
+
+class _FakeRendererConfigParallelBatch:
+    pass
+
+
+class _FakeExternalDistortionReferencePolynomial(Enum):
+    PIXELDIST_TO_ANGLE = 0
+
+
+class _FakeBivariateWindshieldModelParameters:
+    MAX_COEFFS = 16
 
 
 def _ftheta_parameters(*, external_distortion: object | None = None) -> SimpleNamespace:
@@ -87,6 +105,30 @@ def _render_inputs(
         affine_matrix=torch.eye(3, 4).unsqueeze(0),
     )
     return primitive, context, rays, poses
+
+
+def test_gsplat_build_defaults_cover_rgb_and_rgb_distance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("BUILD_3DGUT", raising=False)
+    monkeypatch.delenv("NUM_CHANNELS", raising=False)
+
+    render_preview_module._configure_gsplat_build()
+
+    assert os.environ["BUILD_3DGUT"] == "1"
+    assert os.environ["NUM_CHANNELS"] == "3,4"
+
+
+def test_gsplat_build_defaults_preserve_explicit_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUILD_3DGUT", "0")
+    monkeypatch.setenv("NUM_CHANNELS", "3,4,8")
+
+    render_preview_module._configure_gsplat_build()
+
+    assert os.environ["BUILD_3DGUT"] == "0"
+    assert os.environ["NUM_CHANNELS"] == "3,4,8"
 
 
 def test_transparent_foreground_reveals_sky() -> None:
@@ -167,6 +209,16 @@ def test_composited_frame_uses_calibrated_ftheta_rolling_shutter_and_exact_rays(
     )
     setattr(fake_gsplat_rendering, "FThetaPolynomialType", _FakeFThetaPolynomialType)
     setattr(fake_gsplat_rendering, "RollingShutterType", _FakeRollingShutterType)
+    setattr(
+        fake_gsplat_rendering,
+        "UnscentedTransformParameters",
+        _FakeUnscentedTransformParameters,
+    )
+    setattr(
+        fake_gsplat_rendering,
+        "RendererConfig_ParallelBatch",
+        _FakeRendererConfigParallelBatch,
+    )
     monkeypatch.setitem(sys.modules, "gsplat", fake_gsplat)
     monkeypatch.setitem(sys.modules, "gsplat.rendering", fake_gsplat_rendering)
     monkeypatch.setattr(render_preview_module, "tquat_to_se3_matrix", fake_tquat_to_se3_matrix)
@@ -179,6 +231,13 @@ def test_composited_frame_uses_calibrated_ftheta_rolling_shutter_and_exact_rays(
     assert kwargs["camera_model"] == "ftheta"
     assert kwargs["packed"] is False
     assert kwargs["with_ut"] is True
+    assert isinstance(kwargs["ut_params"], _FakeUnscentedTransformParameters)
+    assert kwargs["ut_params"].alpha == 1.0
+    assert kwargs["ut_params"].beta == 2.0
+    assert kwargs["ut_params"].kappa == 0.0
+    assert kwargs["ut_params"].in_image_margin_factor == 0.1
+    assert kwargs["ut_params"].require_all_sigma_points_valid is True
+    assert isinstance(kwargs["renderer_config"], _FakeRendererConfigParallelBatch)
     assert kwargs["with_eval3d"] is True
     assert kwargs["global_z_order"] is False
     assert kwargs["rolling_shutter"] is _FakeRollingShutterType.ROLLING_TOP_TO_BOTTOM
@@ -208,16 +267,39 @@ def test_composited_frame_uses_calibrated_ftheta_rolling_shutter_and_exact_rays(
     torch.testing.assert_close(composed, torch.full((2, 3, 3), 0.4))
 
 
-def test_composited_frame_rejects_ftheta_external_windshield_distortion(
+def test_ftheta_external_windshield_distortion_is_converted(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    primitive, context, _, _ = _render_inputs(_ftheta_parameters(external_distortion=SimpleNamespace()))
-    fake_gsplat = ModuleType("gsplat")
-    setattr(fake_gsplat, "rasterization", lambda **_: None)
-    monkeypatch.setitem(sys.modules, "gsplat", fake_gsplat)
+    external = SimpleNamespace(
+        reference_poly=SimpleNamespace(name="PIXELDIST_TO_ANGLE"),
+        horizontal_poly=(1.0, 2.0),
+        vertical_poly=(3.0, 4.0),
+        horizontal_poly_inverse=(5.0, 6.0),
+        vertical_poly_inverse=(7.0, 8.0),
+    )
+    fake_gsplat_rendering = ModuleType("gsplat.rendering")
+    setattr(
+        fake_gsplat_rendering,
+        "BivariateWindshieldModelParameters",
+        _FakeBivariateWindshieldModelParameters,
+    )
+    setattr(
+        fake_gsplat_rendering,
+        "ExternalDistortionReferencePolynomial",
+        _FakeExternalDistortionReferencePolynomial,
+    )
+    monkeypatch.setitem(sys.modules, "gsplat.rendering", fake_gsplat_rendering)
 
-    with pytest.raises(NotImplementedError, match="external windshield distortion"):
-        render_preview_module.render_composited_frame(primitive, context)
+    converted = render_preview_module._external_distortion_gsplat_parameters(
+        _ftheta_parameters(external_distortion=external)
+    )
+
+    assert isinstance(converted, _FakeBivariateWindshieldModelParameters)
+    assert converted.reference_poly is _FakeExternalDistortionReferencePolynomial.PIXELDIST_TO_ANGLE
+    torch.testing.assert_close(converted.horizontal_poly, torch.tensor([1.0, 2.0]))
+    torch.testing.assert_close(converted.vertical_poly, torch.tensor([3.0, 4.0]))
+    torch.testing.assert_close(converted.horizontal_poly_inverse, torch.tensor([5.0, 6.0]))
+    torch.testing.assert_close(converted.vertical_poly_inverse, torch.tensor([7.0, 8.0]))
 
 
 def test_composited_frame_rejects_non_ftheta_before_loading_gsplat(

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -299,3 +299,67 @@ def test_sample_frame_batch_multi_interval_uses_min_start_max_end():
     )
     assert "a" in out
     assert len(out["a"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# UniformFrameBatchSampler (reference training sampler)
+# ---------------------------------------------------------------------------
+
+
+def _make_uniform_sampler(*, n_frames_per_sample: int = 3, **cfg_overrides):
+    from instant_nurec.config_schema.dataset import AdaptiveSequentialFrameBatchSamplerConfig
+    from instant_nurec.datasets.samplers import UniformFrameBatchSampler
+
+    base = {
+        "name": "uniform",
+        "n_samples_per_sequence": 8,
+        "frame_gap_timestamp_us": 10,
+    }
+    base.update(cfg_overrides)
+    config = AdaptiveSequentialFrameBatchSamplerConfig(**base)
+    return UniformFrameBatchSampler(config, n_frames_per_sample=n_frames_per_sample)
+
+
+def test_uniform_sampler_matches_reference_random_start_and_fixed_gap():
+    from instant_nurec.utils.types import HalfClosedInterval
+
+    sampler = _make_uniform_sampler()
+    result = sampler.sample_frame_batch(
+        sample_idx=0,
+        camera_frame_timestamps_us={"camera": np.arange(101, dtype=np.int64)},
+        time_intervals=[HalfClosedInterval(0, 100)],
+        rng=np.random.default_rng(42),
+    )
+
+    assert result == {"camera": [7, 17, 27]}
+
+
+def test_uniform_sampler_samples_valid_intervals_by_integer_cardinality():
+    from instant_nurec.utils.types import HalfClosedInterval
+
+    sampler = _make_uniform_sampler(n_frames_per_sample=2, frame_gap_timestamp_us=5)
+    timestamps = np.concatenate([np.arange(0, 11), np.arange(100, 121)])
+    result = sampler.sample_frame_batch(
+        sample_idx=0,
+        camera_frame_timestamps_us={"camera": timestamps},
+        time_intervals=[HalfClosedInterval(0, 10), HalfClosedInterval(100, 120)],
+        rng=np.random.default_rng(0),
+    )
+
+    first, second = (int(timestamps[index]) for index in result["camera"])
+    assert second - first == 5
+    assert (0 <= first <= 5) or (100 <= first <= 115)
+
+
+def test_uniform_sampler_rejects_context_span_that_is_too_short():
+    from instant_nurec.datasets.instantnurec_base import InstantNuRecDataError
+    from instant_nurec.utils.types import HalfClosedInterval
+
+    sampler = _make_uniform_sampler(n_frames_per_sample=3, frame_gap_timestamp_us=10)
+    with pytest.raises(InstantNuRecDataError, match="contiguous span of 20 us"):
+        sampler.sample_frame_batch(
+            sample_idx=0,
+            camera_frame_timestamps_us={"camera": np.arange(10)},
+            time_intervals=[HalfClosedInterval(0, 9)],
+            rng=np.random.default_rng(0),
+        )

--- a/tests/test_tracks.py
+++ b/tests/test_tracks.py
@@ -240,9 +240,7 @@ def test_cuboid_tracks_cuboids_dims_passthrough(stubbed_tracks):
     assert torch.equal(ct.cuboids_dims, ctd.cuboids_dims)
 
 
-def test_cuboid_tracks_to_device_chains_data_to_device(
-    stubbed_tracks, monkeypatch
-):
+def test_cuboid_tracks_to_device_chains_data_to_device(stubbed_tracks, monkeypatch):
     mod, types_mod = stubbed_tracks
     td = _make_tracks_data(types_mod)
     ctd = _make_cuboid_tracks_data(types_mod)
@@ -384,41 +382,83 @@ def test_ray_intersection_calls_vren_and_packs_result(stubbed_tracks, monkeypatc
 # ---------------------------------------------------------------------------
 
 
-def test_point_intersection_interpolate_pose_reshapes_and_rebuilds_se3(
-    stubbed_tracks, monkeypatch
-):
+def test_point_intersection_interpolate_pose_reshapes_and_rebuilds_se3(stubbed_tracks, monkeypatch):
     mod, _ = stubbed_tracks
     ct = _make_cuboid_tracks_with_two(stubbed_tracks)
 
     captured = {}
 
-    def _fake(points, points_ts, packinfo, poses_data, ts_us, padded_dims, max_n):
+    def _fake(**kwargs):
+        points = kwargs["points"]
         captured["points_shape"] = points.shape
-        captured["padded_dims"] = padded_dims
+        captured["padded_dims"] = kwargs["cuboids_dims"]
+        captured["max_intersections"] = kwargs["max_intersections_per_point"]
+        captured["return_local_points"] = kwargs["return_local_points"]
         return (
-            torch.zeros(points.shape[0], 7),
-            torch.zeros(points.shape[0], dtype=torch.long),
+            torch.zeros(points.shape[0], dtype=torch.int32),
+            torch.zeros(points.shape[0], 1, 7),
+            torch.zeros(points.shape[0], 1, dtype=torch.int32),
         )
 
-    monkeypatch.setattr(
-        mod, "_point_cuboidtracks_intersection_interpolate_pose", _fake
-    )
+    monkeypatch.setattr(mod, "_point_cuboidtracks_intersection_interpolate_pose", _fake)
 
     # Multi-dim input: (2, 3, 3)
     points = torch.zeros(2, 3, 3)
     points_ts = torch.zeros(2, 3, dtype=torch.int64)
     padding = torch.zeros(3)
 
-    poses, idx = ct.point_intersection_interpolate_pose(points, points_ts, padding)
+    result = ct.point_intersection_interpolate_pose(points, points_ts, padding)
     # Reshape preserves leading dims.
-    assert idx.shape == (2, 3)
-    # Returned SE3 wraps a tensor of shape (2, 3, 7).
-    assert poses.data.shape == (2, 3, 7)
+    assert result.intersections_cnt.shape == (2, 3)
+    assert result.intersections_tracks_idx.shape == (2, 3, 1)
+    # Returned SE3 wraps a tensor of shape (2, 3, 1, 7).
+    assert result.interpolated_poses.data.shape == (2, 3, 1, 7)
+    assert result.intersections_points_local is None
     # SUT flattens points to (N, 3) before passing to vren.
     assert captured["points_shape"] == (6, 3)
     # SUT adds cuboids_dims + padding before calling vren.
     expected_padded = ct.cuboids_dims + padding
     assert torch.equal(captured["padded_dims"], expected_padded)
+    assert captured["max_intersections"] == 1
+    assert captured["return_local_points"] is False
+
+
+def test_point_intersection_backend_records_multiple_hits_and_local_points():
+    from instant_nurec.datasets.ray_intersections import (
+        point_cuboidtracks_intersection_interpolate_pose,
+    )
+
+    points = torch.tensor([[0.0, 0.0, 0.0]])
+    timestamps = torch.tensor([5], dtype=torch.int64)
+    packinfo = torch.tensor([[0, 2], [2, 2]], dtype=torch.int32)
+    poses = torch.tensor(
+        [
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+            [0.25, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+            [0.25, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+    track_timestamps = torch.tensor([0, 10, 0, 10], dtype=torch.int64)
+    dimensions = torch.full((2, 3), 2.0)
+
+    counts, interpolated_poses, tracks_idx, points_local = point_cuboidtracks_intersection_interpolate_pose(
+        points,
+        timestamps,
+        packinfo,
+        poses,
+        track_timestamps,
+        dimensions,
+        max_track_n_poses=2,
+        max_intersections_per_point=2,
+        return_local_points=True,
+    )
+
+    assert torch.equal(counts, torch.tensor([2], dtype=torch.int32))
+    assert torch.equal(tracks_idx, torch.tensor([[0, 1]], dtype=torch.int32))
+    assert interpolated_poses.shape == (1, 2, 7)
+    assert points_local is not None
+    assert torch.allclose(points_local, torch.tensor([[[0.0, 0.0, 0.0], [-0.25, 0.0, 0.0]]]))
 
 
 # ---------------------------------------------------------------------------
@@ -562,9 +602,7 @@ def test_factory_from_numpy_rejects_invalid_timestamp_dtype(stubbed_tracks):
 # ---------------------------------------------------------------------------
 
 
-def test_interpolate_tracks_poses_returns_se3_with_right_shape(
-    stubbed_tracks, monkeypatch
-):
+def test_interpolate_tracks_poses_returns_se3_with_right_shape(stubbed_tracks, monkeypatch):
     mod, _ = stubbed_tracks
     ct = _make_cuboid_tracks_with_two(stubbed_tracks)
 
@@ -574,9 +612,7 @@ def test_interpolate_tracks_poses_returns_se3_with_right_shape(
     def _fake_searchsorted(ts_us, packinfo, query_ts, tracks_idx):
         return torch.full((query_ts.shape[0],), 1, dtype=torch.long)
 
-    monkeypatch.setattr(
-        mod, "_packed_searchsorted_indexed_vals", _fake_searchsorted
-    )
+    monkeypatch.setattr(mod, "_packed_searchsorted_indexed_vals", _fake_searchsorted)
 
     timestamps_us = torch.tensor([5, 10], dtype=torch.int64)
     tracks_idx = torch.tensor([0, 0], dtype=torch.long)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,833 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+from enum import Enum
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+import yaml
+from torchmetrics.image import PeakSignalNoiseRatio
+from torchvision.transforms.functional import gaussian_blur
+
+import instant_nurec.training.renderer as renderer_module
+import instant_nurec.training.run as training_run_module
+import instant_nurec.training.losses as losses_module
+from instant_nurec.config_schema.dataset import (
+    InstantNuRecSplitsConfig,
+    NCoreInstantNuRecDatasetConfig,
+)
+from instant_nurec.config_schema.train import (
+    TrainingConfig,
+    TrainingLoggerConfig,
+    TrainingLossConfig,
+    TrainingSchedulerConfig,
+    TrainingSystemConfig,
+)
+from instant_nurec.model.post_processing import PerCameraAffinePostProcessing
+from instant_nurec.model.blocks.layers import LayerNorm2d
+from instant_nurec.model.blocks.dav3 import convert_dav3_state_dict
+from instant_nurec.model.supervision import SupervisionPack
+from instant_nurec.primitives.kelvin_primitive import KelvinInstantNuRecPrimitive, KelvinStaticLayer
+from instant_nurec.training.losses import TrainingLosses
+from instant_nurec.training.optim import CosineWithWarmupPBScheduler
+from instant_nurec.training.renderer import RenderOutput, render_supervision
+from instant_nurec.training.run import (
+    initialize_resume_logger_before_distributed_setup,
+    make_checkpoint_callback,
+    make_training_logger,
+    resolve_training_strategy,
+)
+from instant_nurec.training.system import TrainingSystem
+from instant_nurec.utils.batch import (
+    CameraFrameLabels,
+    DataAndRenderingBatch,
+    DataBatch,
+    FrameMeta,
+    RenderingBatch,
+    RenderingData,
+)
+from instant_nurec.utils.types import RayFlags
+from ncore.data import OpenCVPinholeCameraModelParameters, ShutterType
+
+
+def _dataset_config() -> NCoreInstantNuRecDatasetConfig:
+    return NCoreInstantNuRecDatasetConfig(ncore_json_paths=["/tmp/example.json"])
+
+
+def test_render_phase_selects_official_loss_profile_and_ddp_strategy(tmp_path):
+    config = TrainingConfig(
+        out_dir=tmp_path,
+        phase="render",
+        dataset=InstantNuRecSplitsConfig(train=_dataset_config()),
+    )
+    assert config.system.enable_render_global_step == 0
+    assert config.system.strategy == "ddp_find_unused_parameters_true"
+    assert config.loss == TrainingLossConfig.render_phase()
+
+
+def test_context_phase_keeps_official_optimizer_defaults(tmp_path):
+    config = TrainingConfig(out_dir=tmp_path, dataset=InstantNuRecSplitsConfig(train=_dataset_config()))
+    assert config.system == TrainingSystemConfig()
+    assert config.system.optimizer.lr == 1.0e-4
+    assert config.system.optimizer.eps == 1.0e-15
+    assert config.system.optimizer.betas == (0.9, 0.99)
+    assert config.system.precision == "bf16-mixed"
+    assert config.logger == TrainingLoggerConfig()
+    assert config.loss == TrainingLossConfig.context_phase()
+
+
+def test_layer_norm_2d_uses_channel_last_fused_layer_norm(monkeypatch):
+    module = LayerNorm2d(3, eps=1.0e-5)
+    value = torch.arange(24, dtype=torch.float32).reshape(1, 3, 2, 4)
+    calls = []
+    original = torch.nn.functional.layer_norm
+
+    def tracking_layer_norm(input_value, normalized_shape, weight, bias, eps):
+        calls.append((tuple(input_value.shape), normalized_shape, eps))
+        return original(input_value, normalized_shape, weight, bias, eps)
+
+    monkeypatch.setattr(torch.nn.functional, "layer_norm", tracking_layer_norm)
+
+    actual = module(value)
+    expected = original(value.permute(0, 2, 3, 1), (3,), module.weight, module.bias, module.eps).permute(0, 3, 1, 2)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert calls == [((1, 2, 4, 3), (3,), 1.0e-5)]
+
+
+def test_train_epoch_reseeds_runtime_rng_by_epoch_and_rank(monkeypatch):
+    seeds = []
+    monkeypatch.setenv("PL_GLOBAL_SEED", "38")
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda: 4)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 2)
+    monkeypatch.setattr(torch, "manual_seed", seeds.append)
+
+    TrainingSystem.on_train_epoch_start(SimpleNamespace(current_epoch=3))
+
+    assert seeds == [52]
+
+
+def test_train_epoch_does_not_reseed_without_distributed_runtime(monkeypatch):
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: False)
+    monkeypatch.setattr(torch, "manual_seed", lambda seed: pytest.fail(f"unexpected seed {seed}"))
+
+    TrainingSystem.on_train_epoch_start(SimpleNamespace(current_epoch=3))
+
+
+def test_wandb_logger_uses_stable_run_id_for_resume(tmp_path, monkeypatch):
+    captured = {}
+
+    class FakeWandbLogger:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(training_run_module, "WandbLogger", FakeWandbLogger)
+    config = TrainingConfig(
+        out_dir=tmp_path,
+        run_id="stable-run-id",
+        dataset=InstantNuRecSplitsConfig(train=_dataset_config()),
+        logger=TrainingLoggerConfig(
+            name="wandb",
+            project="instant-nurec",
+            entity="example-org",
+            run_name="training-test",
+            group="training",
+            tags=["training"],
+            job_type="render",
+        ),
+    )
+
+    logger = make_training_logger(config, tmp_path / config.run_id)
+
+    assert isinstance(logger, FakeWandbLogger)
+    assert captured["id"] == "stable-run-id"
+    assert captured["resume"] == "allow"
+    assert captured["project"] == "instant-nurec"
+    assert captured["entity"] == "example-org"
+
+
+def test_resumed_wandb_initializes_on_external_global_rank_zero_before_ddp(tmp_path, monkeypatch):
+    accesses = []
+
+    class FakeLogger:
+        @property
+        def experiment(self):
+            accesses.append("experiment")
+            return object()
+
+    checkpoint = tmp_path / "last.ckpt"
+    config = TrainingConfig(
+        out_dir=tmp_path,
+        resume_from_checkpoint=checkpoint,
+        dataset=InstantNuRecSplitsConfig(train=_dataset_config()),
+        logger=TrainingLoggerConfig(name="wandb"),
+    )
+    monkeypatch.setenv("SLURM_PROCID", "0")
+
+    assert initialize_resume_logger_before_distributed_setup(config, FakeLogger())
+    assert accesses == ["experiment"]
+
+
+def test_resumed_wandb_remains_lazy_on_nonzero_external_rank(tmp_path, monkeypatch):
+    class FakeLogger:
+        @property
+        def experiment(self):
+            raise AssertionError("nonzero ranks must not initialize W&B")
+
+    checkpoint = tmp_path / "last.ckpt"
+    config = TrainingConfig(
+        out_dir=tmp_path,
+        resume_from_checkpoint=checkpoint,
+        dataset=InstantNuRecSplitsConfig(train=_dataset_config()),
+        logger=TrainingLoggerConfig(name="wandb"),
+    )
+    monkeypatch.setenv("SLURM_PROCID", "3")
+
+    assert not initialize_resume_logger_before_distributed_setup(config, FakeLogger())
+
+
+def test_fresh_wandb_run_keeps_lightning_lazy_initialization(tmp_path, monkeypatch):
+    class FakeLogger:
+        @property
+        def experiment(self):
+            raise AssertionError("fresh runs should keep Lightning's normal lazy initialization")
+
+    config = TrainingConfig(
+        out_dir=tmp_path,
+        dataset=InstantNuRecSplitsConfig(train=_dataset_config()),
+        logger=TrainingLoggerConfig(name="wandb"),
+    )
+    monkeypatch.setenv("SLURM_PROCID", "0")
+
+    assert not initialize_resume_logger_before_distributed_setup(config, FakeLogger())
+
+
+@pytest.mark.parametrize(("resume", "expected_autolog"), [(False, True), (True, False)])
+def test_trainer_autologs_hparams_only_for_fresh_runs(tmp_path, monkeypatch, resume, expected_autolog):
+    captured = {}
+
+    class FakeTrainer:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def fit(self, *args, **kwargs):
+            captured["fit_ckpt_path"] = kwargs["ckpt_path"]
+
+    checkpoint = tmp_path / "last.ckpt"
+    config = TrainingConfig(
+        out_dir=tmp_path,
+        resume_from_checkpoint=checkpoint if resume else None,
+        dataset=InstantNuRecSplitsConfig(train=_dataset_config()),
+    )
+    config.system.accelerator = "cpu"
+    config.system.devices = 1
+    monkeypatch.setattr(training_run_module, "Trainer", FakeTrainer)
+    monkeypatch.setattr(training_run_module, "seed_everything", lambda *args, **kwargs: None)
+    monkeypatch.setattr(training_run_module, "TrainingDataModule", lambda _config: object())
+    monkeypatch.setattr(training_run_module, "TrainingSystem", lambda _config: object())
+    monkeypatch.setattr(training_run_module, "make_training_logger", lambda *args: object())
+    monkeypatch.setattr(training_run_module, "make_training_callbacks", lambda *args: [])
+    monkeypatch.setattr(
+        training_run_module,
+        "initialize_resume_logger_before_distributed_setup",
+        lambda *args: False,
+    )
+
+    training_run_module.run_training(config)
+
+    assert captured["enable_autolog_hparams"] is expected_autolog
+    assert captured["fit_ckpt_path"] == (str(checkpoint) if resume else None)
+
+
+def test_training_run_id_can_be_shared_across_distributed_ranks(tmp_path, monkeypatch):
+    monkeypatch.setenv("INSTANT_NUREC_RUN_ID", "shared-run")
+
+    config = TrainingConfig(
+        out_dir=tmp_path,
+        run_id="rank-local-yaml-value",
+        dataset=InstantNuRecSplitsConfig(train=_dataset_config()),
+    )
+
+    assert config.run_id == "shared-run"
+
+
+def test_epoch_checkpoint_tracks_official_validation_psnr(tmp_path):
+    config = TrainingConfig(out_dir=tmp_path, dataset=InstantNuRecSplitsConfig(train=_dataset_config()))
+
+    checkpoint = make_checkpoint_callback(config, tmp_path / config.run_id)
+
+    assert checkpoint.monitor == "val/psnr"
+    assert checkpoint.mode == "max"
+    assert checkpoint.save_top_k == 2
+    assert checkpoint.save_last
+
+
+def test_fresh_weights_initialize_before_lightning_sanity_validation():
+    calls = []
+    system = SimpleNamespace(
+        _weights_initialized=False,
+        trainer=SimpleNamespace(ckpt_path=None),
+        initialize_weights=lambda: calls.append("initialized"),
+    )
+
+    TrainingSystem.on_fit_start(system)
+
+    assert calls == ["initialized"]
+
+
+def test_resume_skips_component_initialization_before_sanity_validation():
+    calls = []
+    system = SimpleNamespace(
+        _weights_initialized=False,
+        trainer=SimpleNamespace(ckpt_path="last.ckpt"),
+        initialize_weights=lambda: calls.append("initialized"),
+    )
+
+    TrainingSystem.on_fit_start(system)
+
+    assert calls == []
+
+
+def test_multigpu_context_forces_find_unused_ddp(tmp_path, monkeypatch):
+    config = TrainingConfig(
+        out_dir=tmp_path,
+        dataset=InstantNuRecSplitsConfig(train=_dataset_config()),
+    )
+    monkeypatch.setattr(training_run_module.torch.cuda, "device_count", lambda: 4)
+
+    assert resolve_training_strategy(config) == "ddp_find_unused_parameters_true"
+
+
+def test_single_gpu_context_keeps_lightning_auto_strategy(tmp_path, monkeypatch):
+    config = TrainingConfig(
+        out_dir=tmp_path,
+        dataset=InstantNuRecSplitsConfig(train=_dataset_config()),
+    )
+    monkeypatch.setattr(training_run_module.torch.cuda, "device_count", lambda: 1)
+
+    assert resolve_training_strategy(config) == "auto"
+
+
+def test_integer_all_devices_context_forces_find_unused_ddp(tmp_path, monkeypatch):
+    config = TrainingConfig(
+        out_dir=tmp_path,
+        dataset=InstantNuRecSplitsConfig(train=_dataset_config()),
+    )
+    config.system.devices = -1
+    monkeypatch.setattr(training_run_module.torch.cuda, "device_count", lambda: 4)
+
+    assert resolve_training_strategy(config) == "ddp_find_unused_parameters_true"
+
+
+@pytest.mark.parametrize(
+    ("filename", "phase", "enable_render_step"),
+    [
+        ("full_model_front_context.yaml", "context", 1_000_000),
+        ("full_model_front_render.yaml", "render", 0),
+    ],
+)
+def test_checked_in_training_configs_validate(filename, phase, enable_render_step):
+    path = Path(__file__).resolve().parents[1] / "configs" / "training" / filename
+    config = TrainingConfig.model_validate(yaml.safe_load(path.read_text()))
+
+    assert config.phase == phase
+    assert config.system.enable_render_global_step == enable_render_step
+    assert config.system.deterministic == "warn"
+    assert config.system.strategy == "ddp_find_unused_parameters_true"
+    assert config.system.checkpoint_monitor == "val/psnr"
+    assert config.system.checkpoint_mode == "max"
+    assert config.system.save_top_k == 2
+    assert config.logger.name == "wandb"
+    assert config.logger.project == "instant-nurec"
+    assert isinstance(config.dataset.train, NCoreInstantNuRecDatasetConfig)
+    dataset = config.dataset.train
+    assert dataset.frame_batch_sampler.name == "uniform"
+    assert dataset.frame_batch_sampler.frame_gap_timestamp_us == 500_000
+    assert dataset.frame_batch_sampler.n_samples_per_sequence == 10
+    assert dataset.supervision_frame_batch.n_frames_per_camera == 6
+    assert dataset.supervision_frame_batch.prepend_timestamps_us == 100_000
+    assert dataset.supervision_frame_batch.append_timestamps_us == 100_000
+
+
+def test_dav3_state_dict_conversion_covers_encoder_and_depth_head():
+    source = {
+        "model.backbone.pretrained.cls_token": torch.arange(4.0).reshape(1, 1, 4),
+        "model.backbone.pretrained.pos_embed": torch.arange(20.0).reshape(1, 5, 4),
+        "model.backbone.pretrained.patch_embed.proj.weight": torch.ones(4, 3, 2, 2),
+        "model.backbone.pretrained.blocks.0.norm1.weight": torch.ones(4),
+        "model.head.projects.0.weight": torch.ones(2, 4, 1, 1),
+        "model.head.scratch.output_conv1.weight": torch.ones(2, 2, 3, 3),
+        "model.gs_head.weight": torch.ones(1),
+    }
+
+    converted = convert_dav3_state_dict(
+        source,
+        patch_embed_name="patch_embed_img",
+        backbone_name="vit",
+        dpt_reassemble_name="depth_head.reassemble",
+        dpt_depth_head_name="depth_head.fusion_head",
+        dpt_rays_head_name=None,
+        camera_encoder_name=None,
+    )
+
+    assert set(converted) == {
+        "vit.cls_tokens",
+        "vit.cls_pos_embed",
+        "vit.img_pos_embed",
+        "patch_embed_img.proj.weight",
+        "vit.blocks.0.norm1.weight",
+        "depth_head.reassemble.proj_layers.0.weight",
+        "depth_head.fusion_head.before_conv.weight",
+    }
+    assert converted["vit.img_pos_embed"].shape == (2, 2, 4)
+
+
+def test_progress_scheduler_matches_reference_initial_and_warmup_steps():
+    parameter = torch.nn.Parameter(torch.tensor(1.0))
+    optimizer = torch.optim.Adam([parameter], lr=1.0e-4)
+    scheduler = CosineWithWarmupPBScheduler(optimizer, TrainingSchedulerConfig())
+    assert optimizer.param_groups[0]["lr"] == 1.0e-10
+    scheduler.set_progress(epoch=0, total_epochs=40, local_step=0, total_local_steps=1000)
+    scheduler.step()
+    assert optimizer.param_groups[0]["lr"] == pytest.approx(1.0e-6)
+    scheduler.set_progress(epoch=0, total_epochs=40, local_step=99, total_local_steps=1000)
+    scheduler.step()
+    assert optimizer.param_groups[0]["lr"] == 1.0e-4
+
+
+def test_quantile_reduce_matches_reference_single_value_edge_case():
+    from instant_nurec.training.losses import _quantile_mean
+
+    value = torch.tensor([3.0], requires_grad=True)
+    reduced = _quantile_mean(value, 0.98)
+    torch.testing.assert_close(reduced, torch.tensor(0.0))
+
+
+def test_affine_zero_init_and_delayed_gradient_contract():
+    module = PerCameraAffinePostProcessing(embed_dim=32, init_token_scale=0.02)
+    module.zero_init()
+    latent = torch.randn(1, 2, 32, requires_grad=True)
+    matrix, bias = module.decode_affine(latent)
+    torch.testing.assert_close(matrix, torch.eye(3)[None, None].expand(1, 2, 3, 3))
+    torch.testing.assert_close(bias, torch.zeros(1, 2, 3))
+    assert matrix.requires_grad
+
+    module.set_detach_linear_grad(True)
+    detached_matrix, detached_bias = module.decode_affine(latent)
+    assert not detached_matrix.requires_grad
+    assert not detached_bias.requires_grad
+
+
+def test_no_aux_context_rgb_loss_remains_trainable():
+    rgb = torch.ones(1, 2, 2, 3)
+    labels = CameraFrameLabels(
+        rgb=rgb,
+        flags=torch.full((1, 2, 2, 1), int(RayFlags.RGB_LABEL), dtype=torch.int32),
+    )
+    context = DataAndRenderingBatch(
+        data=DataBatch(camera=DataBatch.Camera(meta=[FrameMeta(unique_sensor_idx=0, unique_frame_idx=0)], labels=labels)),
+        rendering=SimpleNamespace(camera=SimpleNamespace(distance_to_depth_scale=torch.ones(1, 2, 2, 1))),
+    )
+    prediction = torch.zeros_like(rgb, requires_grad=True)
+    pack = SupervisionPack(context_rgb=prediction)
+    config = TrainingLossConfig(
+        primitive_sky_cubemap=0,
+        primitive_rgb=0.1,
+        primitive_distance=0,
+        primitive_distance_gradient=0,
+        primitive_semantics=0,
+        primitive_normal=0,
+        primitive_velocity=0,
+    )
+    result = TrainingLosses(config)(pack, context)
+    torch.testing.assert_close(result.values["primitive_rgb"], torch.tensor(1.0))
+    torch.testing.assert_close(result.total_value, torch.tensor(0.1))
+    result.total_value.backward()
+    assert prediction.grad is not None
+
+
+def _camera_batch(labels: CameraFrameLabels) -> DataAndRenderingBatch:
+    return DataAndRenderingBatch(
+        data=DataBatch(
+            camera=DataBatch.Camera(
+                meta=[FrameMeta(unique_sensor_idx=0, unique_frame_idx=0)],
+                labels=labels,
+            )
+        ),
+        rendering=SimpleNamespace(camera=SimpleNamespace(distance_to_depth_scale=torch.ones_like(labels.flags))),
+    )
+
+
+def _render_only_config(**weights) -> TrainingLossConfig:
+    defaults = {
+        "primitive_sky_cubemap": 0,
+        "primitive_rgb": 0,
+        "primitive_distance": 0,
+        "primitive_distance_gradient": 0,
+        "primitive_semantics": 0,
+        "primitive_normal": 0,
+        "primitive_velocity": 0,
+    }
+    defaults.update(weights)
+    return TrainingLossConfig(**defaults)
+
+
+def test_semantic_targets_use_reference_priority_and_all_pixels():
+    flags = torch.tensor(
+        [[[[int(RayFlags.ROAD_SEMANTIC | RayFlags.SKY_SEMANTIC | RayFlags.VEHICLE_SEMANTIC | RayFlags.EGO_SEMANTIC | RayFlags.INVALID)]]]],
+        dtype=torch.int32,
+    )
+    labels = CameraFrameLabels(flags=flags)
+    logits = torch.tensor([[[[0.0, 8.0, 0.0, 0.0, 0.0]]]], requires_grad=True)
+    config = _render_only_config(primitive_semantics=1.0)
+
+    values, skipped = TrainingLosses(config)._context_losses(
+        SupervisionPack(context_semantic_logits=logits),
+        _camera_batch(labels),
+    )
+
+    expected = torch.nn.functional.cross_entropy(logits.moveaxis(-1, 1), torch.ones((1, 1, 1), dtype=torch.long))
+    torch.testing.assert_close(values["primitive_semantics"], expected)
+    assert not skipped
+
+
+def test_render_rgb_compacts_valid_pixels_before_semantic_weighting(monkeypatch):
+    flags = torch.tensor(
+        [
+            [
+                [
+                    [int(RayFlags.RGB_LABEL)],
+                    [int(RayFlags.RGB_LABEL | RayFlags.SYNTHETIC)],
+                    [int(RayFlags.RGB_LABEL | RayFlags.INVALID)],
+                    [0],
+                ]
+            ]
+        ],
+        dtype=torch.int32,
+    )
+    predicted = torch.tensor(
+        [[[[1.0, 1.0, 1.0], [2.0, 2.0, 2.0], [100.0, 100.0, 100.0], [100.0, 100.0, 100.0]]]],
+        requires_grad=True,
+    )
+    labels = CameraFrameLabels(rgb=torch.zeros_like(predicted), flags=flags)
+    output = RenderOutput(
+        rgb=predicted,
+        opacity=torch.zeros((1, 1, 4, 1)),
+        distance=torch.ones((1, 1, 4, 1)),
+        sky_rgb=torch.zeros((1, 1, 4, 3)),
+    )
+    calls = []
+    original_mse_loss = losses_module.F.mse_loss
+
+    def tracking_mse_loss(actual, target, *, reduction):
+        calls.append((actual.detach().clone(), target.detach().clone(), reduction))
+        return original_mse_loss(actual, target, reduction=reduction)
+
+    monkeypatch.setattr(losses_module.F, "mse_loss", tracking_mse_loss)
+
+    values, skipped = TrainingLosses(_render_only_config(rgb=1.0))._render_losses(output, _camera_batch(labels))
+
+    torch.testing.assert_close(values["rgb"], torch.tensor(1.0))
+    assert len(calls) == 1
+    torch.testing.assert_close(calls[0][0], predicted.detach()[0, 0, :2])
+    torch.testing.assert_close(calls[0][1], torch.zeros((2, 3)))
+    assert calls[0][2] == "none"
+    values["rgb"].backward()
+    assert predicted.grad is not None
+    torch.testing.assert_close(predicted.grad[0, 0, 0], torch.full((3,), 1.0 / 3.0))
+    torch.testing.assert_close(predicted.grad[0, 0, 1], torch.full((3,), 1.0 / 6.0))
+    torch.testing.assert_close(predicted.grad[0, 0, 2:], torch.zeros((2, 3)))
+    assert not skipped
+
+
+def test_render_rgb_empty_valid_set_preserves_nan_and_zero_gradient():
+    predicted = torch.ones((1, 1, 2, 3), requires_grad=True)
+    labels = CameraFrameLabels(
+        rgb=torch.zeros_like(predicted),
+        flags=torch.zeros((1, 1, 2, 1), dtype=torch.int32),
+    )
+    output = RenderOutput(
+        rgb=predicted,
+        opacity=torch.zeros((1, 1, 2, 1)),
+        distance=torch.ones((1, 1, 2, 1)),
+        sky_rgb=torch.zeros((1, 1, 2, 3)),
+    )
+
+    values, skipped = TrainingLosses(_render_only_config(rgb=1.0))._render_losses(output, _camera_batch(labels))
+
+    assert torch.isnan(values["rgb"])
+    values["rgb"].backward()
+    assert predicted.grad is not None
+    torch.testing.assert_close(predicted.grad, torch.zeros_like(predicted))
+    assert not skipped
+
+
+def test_render_psnr_uses_only_valid_rgb_labeled_rays():
+    flags = torch.tensor(
+        [
+            [
+                [
+                    [int(RayFlags.RGB_LABEL)],
+                    [int(RayFlags.RGB_LABEL | RayFlags.INVALID)],
+                    [0],
+                    [int(RayFlags.RGB_LABEL | RayFlags.SYNTHETIC)],
+                    [int(RayFlags.RGB_LABEL | RayFlags.HARMONIZED)],
+                ]
+            ]
+        ],
+        dtype=torch.int32,
+    )
+    labels = CameraFrameLabels(rgb=torch.zeros((1, 1, 5, 3)), flags=flags)
+    output = RenderOutput(
+        rgb=torch.tensor([[[[0.1, 0.1, 0.1], [1.0, 1.0, 1.0], [0.75, 0.75, 0.75], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]]]]),
+        opacity=torch.zeros((1, 1, 5, 1)),
+        distance=torch.zeros((1, 1, 5, 1)),
+        sky_rgb=torch.zeros((1, 1, 5, 3)),
+    )
+
+    predicted, target = TrainingSystem._render_psnr_inputs(output, _camera_batch(labels))
+
+    torch.testing.assert_close(predicted, torch.full((3, 3), 0.1))
+    torch.testing.assert_close(target, torch.zeros((3, 3)))
+    torch.testing.assert_close(PeakSignalNoiseRatio(data_range=1)(predicted, target), torch.tensor(20.0))
+
+
+def test_psnr_accumulates_pixels_globally_and_context_uses_placeholder():
+    logged = []
+    system = SimpleNamespace(
+        train_psnr=PeakSignalNoiseRatio(data_range=1),
+        validation_psnr=PeakSignalNoiseRatio(data_range=1),
+        current_epoch=3,
+        log=lambda *args, **kwargs: logged.append((args, kwargs)),
+    )
+    predicted = [torch.ones((1, 3)), torch.full((9, 3), 0.1)]
+    target = [torch.zeros_like(value) for value in predicted]
+
+    TrainingSystem._log_psnr(system, predicted, target, "val")
+
+    metric = logged[0][0][1]
+    torch.testing.assert_close(
+        metric.compute(), torch.tensor(-10.0 * np.log10(0.109), dtype=torch.float32), rtol=1e-5, atol=1e-5
+    )
+    assert logged[0][0][0] == "val/psnr"
+
+    logged.clear()
+    TrainingSystem._log_psnr(system, [], [], "val")
+    assert logged == [(("val/psnr", pytest.approx(0.3)), {"prog_bar": True})]
+
+
+def test_render_distance_matches_harmonized_and_synthetic_masks():
+    flags = torch.tensor(
+        [
+            [
+                [
+                    [0],
+                    [int(RayFlags.SYNTHETIC)],
+                    [int(RayFlags.HARMONIZED)],
+                    [int(RayFlags.INVALID)],
+                ]
+            ]
+        ],
+        dtype=torch.int32,
+    )
+    labels = CameraFrameLabels(metric_distance=torch.full((1, 1, 4, 1), 2.0), flags=flags)
+    output = RenderOutput(
+        rgb=torch.zeros((1, 1, 4, 3)),
+        opacity=torch.ones((1, 1, 4, 1)),
+        distance=torch.ones((1, 1, 4, 1)),
+        sky_rgb=torch.zeros((1, 1, 4, 3)),
+    )
+
+    values, skipped = TrainingLosses(_render_only_config(distance=1.0))._render_losses(
+        output,
+        _camera_batch(labels),
+    )
+
+    # The synthetic ray is zero weighted but remains in the two-ray denominator.
+    torch.testing.assert_close(values["distance"], torch.tensor(0.125))
+    assert not skipped
+
+
+def test_pinhole_camera_kwargs_match_reference_batch_axes(monkeypatch):
+    class FakeRollingShutterType(Enum):
+        GLOBAL = 0
+
+    fake_rendering = ModuleType("gsplat.rendering")
+    setattr(fake_rendering, "RollingShutterType", FakeRollingShutterType)
+    monkeypatch.setitem(sys.modules, "gsplat.rendering", fake_rendering)
+    monkeypatch.setattr(renderer_module, "_configure_gsplat_build", lambda: None)
+    monkeypatch.setattr(renderer_module, "_external_distortion_gsplat_parameters", lambda parameters: None)
+    parameters = OpenCVPinholeCameraModelParameters(
+        resolution=np.array([2, 2], dtype=np.uint64),
+        shutter_type=ShutterType.GLOBAL,
+        external_distortion_parameters=None,
+        principal_point=np.array([1.0, 1.0], dtype=np.float32),
+        focal_length=np.array([2.0, 3.0], dtype=np.float32),
+        radial_coeffs=np.arange(6, dtype=np.float32),
+        tangential_coeffs=np.arange(2, dtype=np.float32),
+        thin_prism_coeffs=np.ones(4, dtype=np.float32),
+    )
+
+    K, kwargs = renderer_module._camera_kwargs(parameters, torch.device("cpu"))
+
+    torch.testing.assert_close(K, torch.tensor([[2.0, 0.0, 1.0], [0.0, 3.0, 1.0], [0.0, 0.0, 1.0]]))
+    assert kwargs["radial_coeffs"].shape == (1, 1, 6)
+    assert kwargs["tangential_coeffs"].shape == (1, 1, 2)
+    assert "thin_prism_coeffs" not in kwargs
+
+
+def test_renderer_checkpoints_full_frame_and_matches_reference_postprocess_order(monkeypatch):
+    captured = {}
+    checkpoint_calls = []
+    inverse_calls = []
+
+    def fake_rasterization(**kwargs):
+        captured.update(kwargs)
+        rendered = torch.zeros((1, 1, 2, 2, 4))
+        rendered[..., :3] = -0.5
+        rendered[..., 3] = 0.75
+        opacity = torch.full((1, 1, 2, 2, 1), 0.5)
+        return rendered, opacity, {}
+
+    def fake_checkpoint(function, *args, use_reentrant):
+        checkpoint_calls.append((function, args[-1], use_reentrant))
+        return function(*args)
+
+    def fake_inverse(matrix, *, unbatch):
+        inverse_calls.append((matrix.clone(), unbatch))
+        return torch.eye(4, dtype=matrix.dtype)
+
+    monkeypatch.setattr(renderer_module, "require_gsplat", lambda: fake_rasterization)
+    monkeypatch.setattr(renderer_module, "checkpoint", fake_checkpoint)
+    monkeypatch.setattr(renderer_module, "se3_matrix_inverse", fake_inverse)
+    monkeypatch.setattr(renderer_module, "_reference_renderer_config", lambda: object())
+    monkeypatch.setattr(renderer_module, "_reference_ut_parameters", lambda: object())
+    monkeypatch.setattr(
+        renderer_module,
+        "sample_sky_cubemap",
+        lambda cubemap, directions: torch.full_like(directions, 0.5),
+    )
+    monkeypatch.setattr(
+        renderer_module,
+        "_camera_kwargs",
+        lambda parameters, device: (
+            torch.eye(3, device=device),
+            {
+                "camera_model": "pinhole",
+                "rolling_shutter": "global",
+                "_global_shutter": "global",
+            },
+        ),
+    )
+    parameters = OpenCVPinholeCameraModelParameters(
+        resolution=np.array([2, 2], dtype=np.uint64),
+        shutter_type=ShutterType.GLOBAL,
+        external_distortion_parameters=None,
+        principal_point=np.array([1.0, 1.0], dtype=np.float32),
+        focal_length=np.array([1.0, 1.0], dtype=np.float32),
+        radial_coeffs=np.zeros(6, dtype=np.float32),
+        tangential_coeffs=np.zeros(2, dtype=np.float32),
+        thin_prism_coeffs=np.zeros(4, dtype=np.float32),
+    )
+    directions = torch.zeros((1, 2, 2, 3))
+    directions[..., 2] = 1.0
+    rays = torch.cat([torch.zeros_like(directions), directions], dim=-1)
+    tquat = torch.tensor([[[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]]]).expand(1, 2, 7).clone()
+    timestamps = torch.tensor([[0, 1]], dtype=torch.int64)
+    labels = CameraFrameLabels(
+        rgb=torch.zeros((1, 2, 2, 3)),
+        flags=torch.full((1, 2, 2, 1), int(RayFlags.RGB_LABEL), dtype=torch.int32),
+    )
+    supervision = DataAndRenderingBatch(
+        data=DataBatch(
+            camera=DataBatch.Camera(
+                meta=[FrameMeta(unique_sensor_idx=0, unique_frame_idx=0)],
+                labels=labels,
+            )
+        ),
+        rendering=RenderingBatch(
+            camera=RenderingData(
+                rays=rays,
+                sensor_model_parameters=[parameters],
+                poses_tquat_startend=tquat,
+                timestamps_startend_us=timestamps,
+                timestamps_startend_us_cpu=timestamps,
+            )
+        ),
+    )
+    primitive = KelvinInstantNuRecPrimitive(
+        static_layer=KelvinStaticLayer(
+            positions=torch.zeros((1, 3)),
+            rotations=torch.tensor([[1.0, 0.0, 0.0, 0.0]]),
+            scales=torch.ones((1, 3)),
+            densities=torch.ones((1, 1)),
+            rgb=torch.zeros((1, 3)),
+        ),
+        dynamic_layers=[],
+        sky_cubemap=torch.zeros((6, 2, 2, 3)),
+        affine_matrix=torch.tensor([[[2.0, 0.0, 0.0, 0.0], [0.0, 2.0, 0.0, 0.0], [0.0, 0.0, 2.0, 0.0]]]),
+    )
+
+    output = render_supervision(primitive, supervision)
+
+    assert checkpoint_calls == [(renderer_module._render_supervision_frame, 0, False)]
+    assert len(inverse_calls) == 2
+    assert captured["render_mode"] == "RGB-d"
+    assert captured["means"].shape == (1, 1, 3)
+    assert captured["viewmats"].shape == (1, 1, 4, 4)
+    assert captured["Ks"].shape == (1, 1, 3, 3)
+    assert captured["rays"].shape == (2, 2, 6)
+    assert captured["radius_clip"] == 0.0
+    assert captured["eps2d"] == pytest.approx(0.3)
+    assert captured["sparse_grad"] is False
+    assert captured["absgrad"] is False
+    # clamp(-0.5) + (1 - 0.5) * sky(0.5) = 0.25, then affine scale 2 = 0.5.
+    # Clamping only after composition would instead produce zero.
+    torch.testing.assert_close(output.rgb, torch.full((1, 2, 2, 3), 0.5))
+    torch.testing.assert_close(output.distance, torch.full((1, 2, 2, 1), 0.75))
+
+
+def test_background_does_not_require_valid_semantic_flag():
+    flags = torch.tensor([[[[int(RayFlags.SKY_SEMANTIC)], [0]]]], dtype=torch.int32)
+    labels = CameraFrameLabels(flags=flags)
+    output = RenderOutput(
+        rgb=torch.zeros((1, 1, 2, 3)),
+        opacity=torch.tensor([[[[1.0], [0.0]]]]),
+        distance=torch.zeros((1, 1, 2, 1)),
+        sky_rgb=torch.zeros((1, 1, 2, 3)),
+    )
+
+    values, skipped = TrainingLosses(_render_only_config(background=1.0))._render_losses(
+        output,
+        _camera_batch(labels),
+    )
+
+    torch.testing.assert_close(values["background"], torch.tensor(1.0))
+    assert not skipped
+
+
+def test_sky_cubemap_smooth_region_matches_reference_and_backpropagates():
+    predicted = torch.zeros((6, 31, 31, 3), requires_grad=True)
+    with torch.no_grad():
+        predicted[0, 15, 15] = 1.0
+    pack = SupervisionPack(
+        predicted_sky_cubemap=predicted,
+        reference_sky_cubemap=torch.zeros_like(predicted),
+        reference_sky_cubemap_mask=torch.zeros((6, 31, 31, 1), dtype=torch.bool),
+    )
+    labels = CameraFrameLabels(flags=torch.zeros((1, 1, 1, 1), dtype=torch.int32))
+    config = _render_only_config(primitive_sky_cubemap=1.0)
+
+    values, skipped = TrainingLosses(config)._context_losses(pack, _camera_batch(labels))
+
+    expected_target = gaussian_blur(predicted.permute(0, 3, 1, 2), kernel_size=[29, 29]).permute(0, 2, 3, 1)
+    torch.testing.assert_close(values["primitive_sky_cubemap"], (predicted - expected_target).abs().mean())
+    assert not skipped
+    values["primitive_sky_cubemap"].backward()
+    assert predicted.grad is not None

--- a/tests/test_training_data.py
+++ b/tests/test_training_data.py
@@ -1,0 +1,345 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import instant_nurec.datasets.datamodule as predict_datamodule_module
+import instant_nurec.datasets.mixture as mixture_module
+from instant_nurec.config_schema.dataset import NCoreInstantNuRecDatasetConfig
+from instant_nurec.datasets.datamodule import InstantNuRecDataModule
+from instant_nurec.datasets.instantnurec_base import BaseInstantNuRecIndexableDataset, InstantNuRecDataError
+from instant_nurec.datasets.instantnurec_ncore import NCoreInstantNuRecDataset
+from instant_nurec.datasets.mixture import NCoreMixtureDataset
+from instant_nurec.training.data import TrainingDataModule
+
+
+def test_waymo_lowercase_cyclist_is_unconditionally_dynamic() -> None:
+    assert "cyclist" in NCoreInstantNuRecDataset.UNCONDITIONALLY_DYNAMIC_LABELS
+
+
+def test_dataset_rng_matches_reference_sha256_epoch_item_seed(monkeypatch) -> None:
+    dataset = object.__new__(NCoreInstantNuRecDataset)
+    dataset._rng_epoch = 7
+    dataset._epoch = 7
+    monkeypatch.setenv("PL_GLOBAL_SEED", "38")
+
+    actual = dataset._get_rng(11).integers(0, 2**31, size=8)
+    digest = hashlib.sha256(b"7_11_38").digest()
+    expected = np.random.default_rng(int.from_bytes(digest[:8], "big")).integers(0, 2**31, size=8)
+    np.testing.assert_array_equal(actual, expected)
+
+    # Reinitialization makes an item stable; changing the train RNG epoch changes it.
+    np.testing.assert_array_equal(actual, dataset._get_rng(11).integers(0, 2**31, size=8))
+    dataset.set_rng_epoch(8)
+    assert not np.array_equal(actual, dataset._get_rng(11).integers(0, 2**31, size=8))
+
+
+def test_dataset_explicit_seed_works_without_lightning_environment(monkeypatch) -> None:
+    dataset = object.__new__(NCoreInstantNuRecDataset)
+    dataset._rng_epoch = -1
+    dataset._global_seed = 38
+    monkeypatch.delenv("PL_GLOBAL_SEED", raising=False)
+
+    actual = dataset._get_rng(11).integers(0, 2**31, size=8)
+    digest = hashlib.sha256(b"-1_11_38").digest()
+    expected = np.random.default_rng(int.from_bytes(digest[:8], "big")).integers(0, 2**31, size=8)
+
+    np.testing.assert_array_equal(actual, expected)
+
+
+def _bare_ncore_retry_dataset() -> NCoreInstantNuRecDataset:
+    dataset = object.__new__(NCoreInstantNuRecDataset)
+    dataset._global_seed = 38
+    dataset._rng_epoch = 7
+    dataset._epoch = 7
+    dataset._retry_on_error = True
+    dataset.ncore_json_paths = [f"sequence-{index}.json" for index in range(32)]
+    dataset.num_samples_per_sequence = 1
+    return dataset
+
+
+def test_ncore_training_retry_is_deterministic_and_prediction_fails_loud(monkeypatch) -> None:
+    dataset = _bare_ncore_retry_dataset()
+    attempts: list[int] = []
+
+    def fail_one_index(batch_idx: int, rng: np.random.Generator):
+        del rng
+        attempts.append(batch_idx)
+        if batch_idx == 5:
+            raise InstantNuRecDataError("short sequence")
+        return batch_idx
+
+    monkeypatch.setattr(dataset, "getitem_allow_exceptions", fail_one_index)
+    first_result = dataset[5]
+    first_attempts = attempts.copy()
+    attempts.clear()
+    second_result = dataset[5]
+
+    assert first_result == second_result
+    assert attempts == first_attempts
+    assert first_attempts[0] == 5
+    assert len(first_attempts) == len(set(first_attempts)) == 2
+
+    dataset._retry_on_error = False
+    attempts.clear()
+    with pytest.raises(InstantNuRecDataError, match="short sequence"):
+        dataset[5]
+    assert attempts == [5]
+
+
+def test_ncore_training_retry_stops_after_exactly_ten_unique_attempts(monkeypatch) -> None:
+    dataset = _bare_ncore_retry_dataset()
+    attempts: list[int] = []
+
+    def always_fail(batch_idx: int, rng: np.random.Generator):
+        del rng
+        attempts.append(batch_idx)
+        raise InstantNuRecDataError("still broken")
+
+    monkeypatch.setattr(dataset, "getitem_allow_exceptions", always_fail)
+
+    with pytest.raises(InstantNuRecDataError, match="tried out 10 attempts"):
+        dataset[5]
+
+    assert len(attempts) == len(set(attempts)) == 10
+
+
+def test_predict_datamodule_passes_config_seed_without_lightning_environment(monkeypatch) -> None:
+    seen = {}
+
+    class FakeDataset:
+        def __init__(self, config, **kwargs) -> None:
+            del config
+            seen.update(kwargs)
+
+        def __len__(self) -> int:
+            return 1
+
+        def __getitem__(self, index: int):
+            return index
+
+    monkeypatch.delenv("PL_GLOBAL_SEED", raising=False)
+    monkeypatch.setattr(predict_datamodule_module, "NCoreInstantNuRecDataset", FakeDataset)
+    dataset_config = SimpleNamespace(
+        camera_subsampler=SimpleNamespace(frame_width=64, frame_height=48),
+        frame_batch_sampler=SimpleNamespace(n_frames_per_sample=4),
+    )
+    config = SimpleNamespace(
+        seed=38,
+        dataset=SimpleNamespace(predict=dataset_config),
+        system=SimpleNamespace(predict_num_workers=0, predict_batch_size=1),
+    )
+
+    InstantNuRecDataModule(config).predict_dataloader()
+
+    assert seen["global_seed"] == 38
+
+
+def test_training_datamodule_enables_retries_for_direct_and_mixture_datasets(monkeypatch) -> None:
+    seen: list[tuple[str, dict]] = []
+
+    def fake_ncore_init(self, config, **kwargs) -> None:
+        del self, config
+        seen.append(("ncore", kwargs))
+
+    def fake_mixture_init(self, config, **kwargs) -> None:
+        del self, config
+        seen.append(("mixture", kwargs))
+
+    monkeypatch.setattr(NCoreInstantNuRecDataset, "__init__", fake_ncore_init)
+    monkeypatch.setattr(NCoreMixtureDataset, "__init__", fake_mixture_init)
+    datamodule = TrainingDataModule(SimpleNamespace(seed=38))
+
+    direct_config = NCoreInstantNuRecDatasetConfig(ncore_json_paths=["unused.json"])
+    datamodule._make_dataset(direct_config)
+    datamodule._make_dataset(SimpleNamespace())
+
+    assert seen[0][0] == "ncore"
+    assert seen[0][1]["retry_on_error"] is True
+    assert seen[1] == (
+        "mixture",
+        {
+            "global_seed": 38,
+            "retry_on_error": True,
+        },
+    )
+
+
+def test_mixture_matches_reference_length_routing_and_epoch_contract(monkeypatch) -> None:
+    class FakeDataset:
+        created: list["FakeDataset"] = []
+
+        def __init__(self, config, **kwargs) -> None:
+            del kwargs
+            self.name = config.name
+            self.length = config.length
+            self.rng_epochs: list[int] = []
+            self.epochs: list[int] = []
+            self.created.append(self)
+
+        def __len__(self) -> int:
+            return self.length
+
+        def __getitem__(self, index: int):
+            return self.name, index
+
+        def set_rng_epoch(self, value: int) -> None:
+            self.rng_epochs.append(value)
+
+        def set_epoch(self, value: int) -> None:
+            self.epochs.append(value)
+
+    monkeypatch.setattr(mixture_module, "NCoreInstantNuRecDataset", FakeDataset)
+    monkeypatch.setenv("PL_GLOBAL_SEED", "38")
+
+    def component(name: str, length: int, ratio: float):
+        dataset_config = SimpleNamespace(
+            name=name,
+            length=length,
+            camera_subsampler=SimpleNamespace(frame_width=1, frame_height=1),
+            frame_batch_sampler=SimpleNamespace(n_frames_per_sample=1),
+        )
+        return SimpleNamespace(sample_ratio=ratio, config=dataset_config)
+
+    config = SimpleNamespace(
+        mixture={
+            "undersampled": component("under", 4, 0.5),
+            "oversampled": component("over", 3, 2.0),
+            "disabled": component("off", 9, 0.0),
+        }
+    )
+    dataset = NCoreMixtureDataset(config)
+
+    # int(4 * .5) + int(3 * 2) and zero-ratio components are omitted.
+    assert len(dataset) == 8
+    assert [item.name for item in dataset.datasets] == ["undersampled", "oversampled"]
+    assert len(FakeDataset.created) == 2
+
+    dataset.set_rng_epoch(7)
+    dataset.set_epoch(9)
+    assert all(item.rng_epochs == [7] for item in FakeDataset.created)
+    assert all(item.epochs == [9] for item in FakeDataset.created)
+
+    # Oversampling preserves one ordered pass, then draws only the excess.
+    assert [dataset[index] for index in range(2, 5)] == [("over", 0), ("over", 1), ("over", 2)]
+    extra = [dataset[index] for index in range(5, 8)]
+    assert all(name == "over" and 0 <= index < 3 for name, index in extra)
+
+    # SHA-derived per-item RNG makes both undersampling and excess draws stable.
+    assert dataset[0] == dataset[0]
+    assert dataset[7] == dataset[7]
+
+
+class _RetryingFakeNCoreDataset(BaseInstantNuRecIndexableDataset[tuple[str, int]]):
+    created: list["_RetryingFakeNCoreDataset"] = []
+
+    def __init__(self, config, *, global_seed: int | None = None, retry_on_error: bool = False, **kwargs) -> None:
+        del kwargs
+        self.name = config.name
+        self.length = config.length
+        self.fail_indices = config.fail_indices
+        self.fail_all = config.fail_all
+        self._global_seed = 38 if global_seed is None else global_seed
+        self._rng_epoch = -1
+        self._epoch = -1
+        self._retry_on_error = retry_on_error
+        self.attempts: list[int] = []
+        self.created.append(self)
+
+    def __len__(self) -> int:
+        return self.length
+
+    def set_rng_epoch(self, value: int) -> None:
+        self._rng_epoch = value
+
+    def set_epoch(self, value: int) -> None:
+        self._epoch = value
+
+    def _get_rng(self, batch_idx: int) -> np.random.Generator:
+        digest = hashlib.sha256(f"{self._rng_epoch}_{batch_idx}_{self._global_seed}".encode()).digest()
+        return np.random.default_rng(int.from_bytes(digest[:8], "big"))
+
+    def getitem_allow_exceptions(self, batch_idx: int, rng: np.random.Generator) -> tuple[str, int]:
+        del rng
+        self.attempts.append(batch_idx)
+        if self.fail_all or batch_idx in self.fail_indices:
+            raise InstantNuRecDataError(f"bad component item {batch_idx}")
+        return self.name, batch_idx
+
+
+def _retry_mixture_config(*, fail_indices: set[int] | None = None, fail_all: bool = False):
+    dataset_config = SimpleNamespace(
+        name="component",
+        length=32,
+        fail_indices=set() if fail_indices is None else fail_indices,
+        fail_all=fail_all,
+        camera_subsampler=SimpleNamespace(frame_width=1, frame_height=1),
+        frame_batch_sampler=SimpleNamespace(n_frames_per_sample=1),
+    )
+    return SimpleNamespace(
+        mixture={
+            "component": SimpleNamespace(
+                sample_ratio=1.0,
+                config=dataset_config,
+            )
+        }
+    )
+
+
+def test_mixture_component_retries_before_outer_mixture(monkeypatch) -> None:
+    _RetryingFakeNCoreDataset.created.clear()
+    monkeypatch.setattr(mixture_module, "NCoreInstantNuRecDataset", _RetryingFakeNCoreDataset)
+    dataset = NCoreMixtureDataset(
+        _retry_mixture_config(fail_indices={0}),
+        global_seed=38,
+        retry_on_error=True,
+    )
+    outer_attempts: list[int] = []
+    outer_getitem = dataset.getitem_allow_exceptions
+
+    def trace_outer(batch_idx: int, rng: np.random.Generator):
+        outer_attempts.append(batch_idx)
+        return outer_getitem(batch_idx, rng)
+
+    monkeypatch.setattr(dataset, "getitem_allow_exceptions", trace_outer)
+
+    result = dataset[0]
+    component = _RetryingFakeNCoreDataset.created[0]
+
+    assert outer_attempts == [0]
+    assert component._retry_on_error is True
+    assert component.attempts[0] == 0
+    assert len(component.attempts) == len(set(component.attempts)) == 2
+    assert result == ("component", component.attempts[-1])
+
+
+def test_mixture_retries_after_component_exhausts_ten_attempts(monkeypatch, caplog) -> None:
+    caplog.set_level("CRITICAL")
+    _RetryingFakeNCoreDataset.created.clear()
+    monkeypatch.setattr(mixture_module, "NCoreInstantNuRecDataset", _RetryingFakeNCoreDataset)
+    dataset = NCoreMixtureDataset(
+        _retry_mixture_config(fail_all=True),
+        global_seed=38,
+        retry_on_error=True,
+    )
+    outer_attempts: list[int] = []
+    outer_getitem = dataset.getitem_allow_exceptions
+
+    def trace_outer(batch_idx: int, rng: np.random.Generator):
+        outer_attempts.append(batch_idx)
+        return outer_getitem(batch_idx, rng)
+
+    monkeypatch.setattr(dataset, "getitem_allow_exceptions", trace_outer)
+
+    with pytest.raises(InstantNuRecDataError, match="tried out 10 attempts"):
+        dataset[0]
+
+    component = _RetryingFakeNCoreDataset.created[0]
+    assert len(outer_attempts) == len(set(outer_attempts)) == 10
+    assert len(component.attempts) == 100

--- a/tests/test_training_resume.py
+++ b/tests/test_training_resume.py
@@ -1,0 +1,399 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+from lightning_fabric.utilities.data import _replace_dunder_methods, _update_dataloader
+from pytorch_lightning import LightningModule, Trainer
+from pytorch_lightning.callbacks import Callback, ModelCheckpoint
+from torch.utils.data import BatchSampler, DataLoader, Dataset, DistributedSampler, RandomSampler, SequentialSampler
+from torch.utils.data._utils.collate import default_collate
+
+import instant_nurec.training.data as training_data_module
+from instant_nurec.config_schema.train import TrainingSchedulerConfig
+from instant_nurec.training.callbacks import AtomicCheckpointAndExitOnSignalCallback, PreemptionInterrupt
+from instant_nurec.training.data import ResumableDataModuleCallback, SkipBatchSampler, TrainingDataModule
+from instant_nurec.training.optim import CosineWithWarmupPBScheduler
+from instant_nurec.training.run import make_training_callbacks
+from instant_nurec.datasets.mixture import NCoreMixtureDataset
+
+
+class _ToyDataset(Dataset):
+    def __init__(self, size: int = 8) -> None:
+        self.size = size
+        self.rng_epoch = -1
+        self.epoch = -1
+
+    def __len__(self) -> int:
+        return self.size
+
+    def __getitem__(self, index: int) -> torch.Tensor:
+        return torch.tensor(float(index))
+
+    def set_rng_epoch(self, epoch: int) -> None:
+        self.rng_epoch = epoch
+
+    def set_epoch(self, epoch: int) -> None:
+        self.epoch = epoch
+
+
+def _toy_config(*, with_validation: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        seed=38,
+        dataset=SimpleNamespace(train=object(), val=object() if with_validation else None),
+        system=SimpleNamespace(
+            train_batch_size=1,
+            train_num_workers=0,
+            val_batch_size=1,
+            val_num_workers=0,
+        ),
+    )
+
+
+class _ToyTrainingDataModule(TrainingDataModule):
+    def _make_dataset(self, dataset_config):
+        del dataset_config
+        return _ToyDataset()
+
+
+class _ToyMixtureTrainingDataModule(TrainingDataModule):
+    def _make_dataset(self, dataset_config):
+        del dataset_config
+        child = _ToyDataset(size=1)
+        mixture = object.__new__(NCoreMixtureDataset)
+        mixture.datasets = [NCoreMixtureDataset.SubDataset("toy", child, 1.0)]
+        mixture._global_seed = self.config.seed
+        mixture._retry_on_error = True
+        mixture._rng_epoch = -1
+        mixture._epoch = -1
+        return mixture
+
+
+class _ResumeProbe(LightningModule):
+    automatic_optimization = False
+
+    def __init__(self, records: list[dict[str, float | int]]) -> None:
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.tensor(0.0))
+        self.records = records
+
+    def configure_optimizers(self):
+        optimizer = torch.optim.SGD([self.weight], lr=1.0)
+        scheduler = CosineWithWarmupPBScheduler(
+            optimizer,
+            TrainingSchedulerConfig(warmup_factor=0.1, warmup_steps=2, cosine_factor=0.2),
+        )
+        return {"optimizer": optimizer, "lr_scheduler": {"scheduler": scheduler, "interval": "step"}}
+
+    def training_step(self, batch: torch.Tensor, batch_idx: int):
+        global_step_before = int(self.global_step)
+        optimizer = self.optimizers(use_pl_optimizer=True)
+        optimizer.zero_grad()
+        loss = (self.weight - batch.float().mean()).square()
+        self.manual_backward(loss)
+        optimizer.step()
+
+        scheduler = self.lr_schedulers()
+        assert isinstance(scheduler, CosineWithWarmupPBScheduler)
+        scheduler.set_progress(
+            epoch=self.current_epoch,
+            total_epochs=1,
+            local_step=batch_idx,
+            total_local_steps=int(self.trainer.num_training_batches),
+        )
+        scheduler.step()
+        self.records.append(
+            {
+                "sample": int(batch.item()),
+                "batch_idx": batch_idx,
+                "global_step": global_step_before,
+                "lr": optimizer.optimizer.param_groups[0]["lr"],
+            }
+        )
+        return loss.detach()
+
+
+class _EpochPropagationProbe(LightningModule):
+    def __init__(self, records: list[tuple[int, int, int, int, int]]) -> None:
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.tensor(0.0))
+        self.records = records
+
+    def configure_optimizers(self):
+        return torch.optim.SGD([self.weight], lr=0.1)
+
+    def training_step(self, batch: torch.Tensor, batch_idx: int):
+        del batch, batch_idx
+        mixture = self.trainer.datamodule.train_dataset
+        child = mixture.datasets[0].dataset
+        self.records.append(
+            (
+                self.current_epoch,
+                mixture._rng_epoch,
+                child.rng_epoch,
+                mixture.epoch,
+                child.epoch,
+            )
+        )
+        return self.weight.square()
+
+
+class _ValidationResumeProbe(LightningModule):
+    def __init__(
+        self,
+        train_records: list[tuple[int, int, int]],
+        validation_records: list[tuple[int, int, int]],
+    ) -> None:
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.tensor(0.0))
+        self.train_records = train_records
+        self.validation_records = validation_records
+
+    def configure_optimizers(self):
+        return torch.optim.SGD([self.weight], lr=0.1)
+
+    def training_step(self, batch: torch.Tensor, batch_idx: int):
+        self.train_records.append((self.current_epoch, batch_idx, int(batch.item())))
+        return (self.weight - batch.float().mean()).square()
+
+    def validation_step(self, batch: torch.Tensor, batch_idx: int):
+        self.validation_records.append((self.current_epoch, batch_idx, int(batch.item())))
+        self.log("val/probe", batch.float().mean(), on_epoch=True, sync_dist=True)
+
+
+class _TriggerPreemption(Callback):
+    def __init__(self, target: AtomicCheckpointAndExitOnSignalCallback, batch_idx: int) -> None:
+        self.target = target
+        self.batch_idx = batch_idx
+
+    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx: int) -> None:
+        del trainer, pl_module, outputs, batch
+        if batch_idx == self.batch_idx:
+            self.target.preempting = True
+
+
+class _TriggerValidationPreemption(Callback):
+    def __init__(self, target: AtomicCheckpointAndExitOnSignalCallback, batch_idx: int) -> None:
+        self.target = target
+        self.batch_idx = batch_idx
+
+    def on_validation_batch_end(
+        self,
+        trainer,
+        pl_module,
+        outputs,
+        batch,
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> None:
+        del trainer, pl_module, outputs, batch, dataloader_idx
+        if batch_idx == self.batch_idx:
+            self.target.preempting = True
+
+
+def _trainer(callbacks: list[Callback]) -> Trainer:
+    return Trainer(
+        accelerator="cpu",
+        devices=1,
+        max_epochs=1,
+        callbacks=callbacks,
+        logger=False,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+        num_sanity_val_steps=0,
+        limit_val_batches=0,
+        deterministic=True,
+    )
+
+
+def _validation_trainer(callbacks: list[Callback]) -> Trainer:
+    return Trainer(
+        accelerator="cpu",
+        devices=1,
+        max_epochs=1,
+        callbacks=callbacks,
+        logger=False,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+        num_sanity_val_steps=0,
+        deterministic=True,
+        reload_dataloaders_every_n_epochs=1,
+    )
+
+
+def test_skip_batch_sampler_preserves_full_epoch_length() -> None:
+    sampler = SkipBatchSampler(SequentialSampler(range(10)), batch_size=2, first_batch_idx=2)
+
+    assert len(sampler) == 5
+    assert list(sampler) == [[4, 5], [6, 7], [8, 9]]
+
+
+def test_lightning_injects_distributed_sampler_without_losing_resume_cursor() -> None:
+    dataset = _ToyDataset(size=10)
+    generator = torch.Generator().manual_seed(38)
+    with _replace_dunder_methods(DataLoader, "dataset"), _replace_dunder_methods(BatchSampler):
+        dataloader = DataLoader(
+            dataset,
+            batch_sampler=SkipBatchSampler(
+                RandomSampler(dataset, generator=generator),
+                batch_size=2,
+                first_batch_idx=2,
+            ),
+        )
+
+    distributed_sampler = DistributedSampler(dataset, num_replicas=2, rank=0, shuffle=True, seed=38)
+    injected = _update_dataloader(dataloader, distributed_sampler)
+
+    assert isinstance(injected.batch_sampler, SkipBatchSampler)
+    assert injected.batch_sampler.sampler is distributed_sampler
+    assert injected.batch_sampler.first_batch_idx == 2
+    assert len(injected.batch_sampler) == 3
+
+
+def test_resumable_callback_precedes_all_checkpoint_callbacks(tmp_path) -> None:
+    config = SimpleNamespace(
+        system=SimpleNamespace(
+            save_on_preemption=True,
+            save_every_n_train_steps=1,
+        )
+    )
+    datamodule = _ToyTrainingDataModule(_toy_config())
+
+    callbacks = make_training_callbacks(config, tmp_path, datamodule)
+
+    assert isinstance(callbacks[0], ResumableDataModuleCallback)
+    assert isinstance(callbacks[1], AtomicCheckpointAndExitOnSignalCallback)
+    assert isinstance(callbacks[2], ModelCheckpoint)
+    callbacks[1].teardown(None, None, "fit")
+
+
+def test_real_trainer_propagates_each_epoch_to_mixture_and_children(monkeypatch) -> None:
+    monkeypatch.setattr(
+        training_data_module,
+        "InstantNuRecDataBatch",
+        SimpleNamespace(collate_fn=default_collate),
+    )
+    records: list[tuple[int, int, int, int, int]] = []
+    datamodule = _ToyMixtureTrainingDataModule(_toy_config())
+    trainer = Trainer(
+        accelerator="cpu",
+        devices=1,
+        max_epochs=2,
+        reload_dataloaders_every_n_epochs=1,
+        logger=False,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+        num_sanity_val_steps=0,
+        limit_val_batches=0,
+        deterministic=True,
+    )
+
+    trainer.fit(_EpochPropagationProbe(records), datamodule=datamodule)
+
+    assert records == [
+        (0, 0, 0, 0, 0),
+        (1, 1, 1, 1, 1),
+    ]
+
+
+def test_mid_epoch_checkpoint_resume_has_no_replay_and_preserves_schedule(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        training_data_module,
+        "InstantNuRecDataBatch",
+        SimpleNamespace(collate_fn=default_collate),
+    )
+    checkpoint_path = tmp_path / "checkpoints" / "last.ckpt"
+
+    interrupted_records: list[dict[str, float | int]] = []
+    interrupted_datamodule = _ToyTrainingDataModule(_toy_config())
+    resumable = ResumableDataModuleCallback(interrupted_datamodule)
+    preemption = AtomicCheckpointAndExitOnSignalCallback(checkpoint_path, signal_type=None)
+    trigger = _TriggerPreemption(preemption, batch_idx=2)
+    with pytest.raises(PreemptionInterrupt, match="checkpoint saved"):
+        _trainer([resumable, trigger, preemption]).fit(
+            _ResumeProbe(interrupted_records),
+            datamodule=interrupted_datamodule,
+        )
+
+    assert checkpoint_path.is_file()
+    assert not Path(f"{checkpoint_path}.tmp").exists()
+    assert interrupted_datamodule.state_dict() == {"next_train_batch_idx": 3}
+    assert [record["batch_idx"] for record in interrupted_records] == [0, 1, 2]
+    assert [record["global_step"] for record in interrupted_records] == [0, 1, 2]
+
+    resumed_records: list[dict[str, float | int]] = []
+    resumed_datamodule = _ToyTrainingDataModule(_toy_config())
+    _trainer([ResumableDataModuleCallback(resumed_datamodule)]).fit(
+        _ResumeProbe(resumed_records),
+        datamodule=resumed_datamodule,
+        ckpt_path=checkpoint_path,
+    )
+
+    uninterrupted_records: list[dict[str, float | int]] = []
+    uninterrupted_datamodule = _ToyTrainingDataModule(_toy_config())
+    _trainer([ResumableDataModuleCallback(uninterrupted_datamodule)]).fit(
+        _ResumeProbe(uninterrupted_records),
+        datamodule=uninterrupted_datamodule,
+    )
+
+    combined = interrupted_records + resumed_records
+    assert [record["sample"] for record in combined] == [record["sample"] for record in uninterrupted_records]
+    assert len({record["sample"] for record in combined}) == len(combined) == 8
+    assert [record["batch_idx"] for record in resumed_records] == [3, 4, 5, 6, 7]
+    assert [record["global_step"] for record in resumed_records] == [3, 4, 5, 6, 7]
+    assert [record["lr"] for record in combined] == pytest.approx([record["lr"] for record in uninterrupted_records])
+
+
+def test_validation_preemption_restarts_full_validation_without_train_replay(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        training_data_module,
+        "InstantNuRecDataBatch",
+        SimpleNamespace(collate_fn=default_collate),
+    )
+    checkpoint_path = tmp_path / "checkpoints" / "last.ckpt"
+
+    interrupted_train: list[tuple[int, int, int]] = []
+    interrupted_validation: list[tuple[int, int, int]] = []
+    interrupted_datamodule = _ToyTrainingDataModule(_toy_config(with_validation=True))
+    resumable = ResumableDataModuleCallback(interrupted_datamodule)
+    preemption = AtomicCheckpointAndExitOnSignalCallback(checkpoint_path, signal_type=None)
+    trigger = _TriggerValidationPreemption(preemption, batch_idx=2)
+    with pytest.raises(PreemptionInterrupt, match="checkpoint saved"):
+        _validation_trainer([resumable, trigger, preemption]).fit(
+            _ValidationResumeProbe(interrupted_train, interrupted_validation),
+            datamodule=interrupted_datamodule,
+        )
+
+    assert sorted(sample for _, _, sample in interrupted_train) == list(range(8))
+    assert [sample for _, _, sample in interrupted_validation] == [0, 1, 2]
+    assert interrupted_datamodule.state_dict() == {"next_train_batch_idx": 8}
+
+    checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    validation_progress = checkpoint["loops"]["fit_loop"]["epoch_loop.val_loop.batch_progress"]
+    for scope in ("total", "current"):
+        assert validation_progress[scope] == {
+            "ready": 1,
+            "started": 1,
+            "processed": 0,
+            "completed": 0,
+        }
+
+    resumed_train: list[tuple[int, int, int]] = []
+    resumed_validation: list[tuple[int, int, int]] = []
+    resumed_datamodule = _ToyTrainingDataModule(_toy_config(with_validation=True))
+    _validation_trainer([ResumableDataModuleCallback(resumed_datamodule)]).fit(
+        _ValidationResumeProbe(resumed_train, resumed_validation),
+        datamodule=resumed_datamodule,
+        ckpt_path=checkpoint_path,
+    )
+
+    assert resumed_train == []
+    assert [sample for _, _, sample in resumed_validation] == list(range(8))

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,64 @@ revision = 3
 requires-python = "==3.11.*"
 
 [[package]]
+name = "aiohappyeyeballs"
+version = "2.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/f4/eec0465c2f67b2664688d0240b3212d5196fd89e741df67ddb81f8d35658/aiohappyeyeballs-2.7.1.tar.gz", hash = "sha256:065665c041c42a5938ed220bdcd7230f22527fbec085e1853d2402c8a3615d9d", size = 24757, upload-time = "2026-07-01T17:11:55.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl", hash = "sha256:9243213661e29250eb41368e5daa826fc017156c3b8a11440826b2e3ed376472", size = 15038, upload-time = "2026-07-01T17:11:54.055Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "typing-extensions" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/d9/22ce5786ac0c1653ae8b6c23bded02c1686d11f0dbb45b31ce128e0df985/aiohttp-3.14.3.tar.gz", hash = "sha256:9491196535a88924a60afd5b5f434b5b203b6cc616250878dbdb223a8f7844bc", size = 7971213, upload-time = "2026-07-23T01:57:27.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/5c/b3e4ff8ad43a8afef9602c5e90285936da1beaea8b029016b793891f03c3/aiohttp-3.14.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e568e14940c09955aa51f4e645b6daa18a581c5dcfcd73744dcc86a856e3ced3", size = 764250, upload-time = "2026-07-23T01:52:48.525Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/da/f1b384465e51449d844056b75070461da03a9a23e6c1747003695bf4172a/aiohttp-3.14.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:54cfcdee2770dac994417cbb0ee1f3eb0e7cb6b30c79bf44f2c02ff79ec5124a", size = 516281, upload-time = "2026-07-23T01:52:51.047Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/3f/01264f820ee2e3712a827892b1cd6ff80f3300c1fcbffbb45714a915d47a/aiohttp-3.14.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:21c016079415ed3fd676963e9793700a566d85dbbd6bfc564b9b2d209147dcc8", size = 514742, upload-time = "2026-07-23T01:52:53.779Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8d/a71c6f2db52ac1ed142b133f7feddaa6b70539c3f4de24d7e226c95b794c/aiohttp-3.14.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d6088ec9894113802bddb3c09e974929aed2c7b3a8c456219b8aab4481f1a239", size = 1780613, upload-time = "2026-07-23T01:52:56.948Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/11/3dd9b3fb3a170f6ec9011b5291d876a6fab4086714c9e158600edf01b4fd/aiohttp-3.14.3-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:16ea7e24c309fb7c0bbd505d149abe4fe4dccfb8db911db7dbec0921bc889a6f", size = 1737688, upload-time = "2026-07-23T01:52:59.294Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/3e/834c26918be7d88068822b40e0db30fca50b5f4fe79104aa16a93f1d74e6/aiohttp-3.14.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56f355e79f71aef2a85c80305cc915f894b170dba76de5fe84f6351939b83c06", size = 1845742, upload-time = "2026-07-23T01:53:01.641Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c9/49ab8572df7d66bc13d11e31f781292badb04180dd87ba98733066c6aed7/aiohttp-3.14.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:18c441d0a8fca6de8d1f546849b9f0ab20d435993e2c5b59562b2fae6be2f929", size = 1928412, upload-time = "2026-07-23T01:53:04.018Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/2b8f0c0ce09c87a1daf80fd483431b56b1435d3f62789bc86f572e1245de/aiohttp-3.14.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:53e7b4ce82b54a8bcc71b3b67a5cbd177ca1d7f592cbc92cd38b7349f73482db", size = 1786220, upload-time = "2026-07-23T01:53:06.481Z" },
+    { url = "https://files.pythonhosted.org/packages/85/00/9c45f81de11710460edfa1dc81317b6e882703b160926c879a9d20da9fcc/aiohttp-3.14.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f55119f7bf25f49ed210f6096090715da24f2943c62102448915fde3c62877ce", size = 1637231, upload-time = "2026-07-23T01:53:10.258Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ce/967d628e910756f3539c6107cb7844a1b69440dcb3029a5ee7871b09ab63/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9aa6e61fdf20105c4144e755bd586008ff450791d67b1c8146fdc15959c4d51c", size = 1753161, upload-time = "2026-07-23T01:53:13.817Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b2/0c3d4114f0aee4f580f5b3b4eb71b24d7a23b834ea506a4dfebe76513f35/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:ccd4893707b3e2a13e39c90d43cf80edf2e4d0457935bcc103bf2346214c3f15", size = 1756356, upload-time = "2026-07-23T01:53:16.211Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5d/99e7d91c82f1399d1ae2a854e080bd1493fbc31e5e959dbc4ec33dac3bec/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:b2466434105a4e03113c36ec775cc2ebe6676b62eae326fa670bb607ef788c1c", size = 1819846, upload-time = "2026-07-23T01:53:18.289Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/05/d5e1cb6480eeffd3f901d40a2c5e2d1e7effdc797837da3b490272699f13/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:ba59d59aba08ac02fc03b0c8983ccd5ee39a199d0552ce9e6d2b4845b34d59ae", size = 1628531, upload-time = "2026-07-23T01:53:23.86Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/90/b934682bcaefae18a9e04f3dff5b68522ba810906358ae5029b68110ea3b/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:ed099d105449c4f9e84f24af203cd131349d4761d8813fa7e02c32e7128cd910", size = 1832712, upload-time = "2026-07-23T01:53:27.551Z" },
+    { url = "https://files.pythonhosted.org/packages/21/df/6061679faaf81fac746e7307c7adb71e858071a5d34c27583afefc64f543/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:152516815ef926786a0b6ae2b8f1fd2e0c71582dee0b435636865316fd4891b7", size = 1775014, upload-time = "2026-07-23T01:53:30.223Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/1d/f854878bbc69b88faefe924b619a34a6f59ec05fd387c77690667eaa75eb/aiohttp-3.14.3-cp311-cp311-win32.whl", hash = "sha256:a4af35c443e0b1a1bd6a8af3f3485d7fda15c142751a00f3ff8090f0b93346fa", size = 456006, upload-time = "2026-07-23T01:53:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/73/0c/2af9d1674baccd1dbd47282a93d660a22e57ef6167c856deb24b4214fbab/aiohttp-3.14.3-cp311-cp311-win_amd64.whl", hash = "sha256:e1e74298bab6ee0d6e749ed4fd1901c7e604bdda32c03d787a2cc71c46d0433d", size = 481069, upload-time = "2026-07-23T01:53:39.673Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/76/88401ff3fc95e85c5fc38d588f36f55e61ecb64343b2bc8d69326f453cc0/aiohttp-3.14.3-cp311-cp311-win_arm64.whl", hash = "sha256:03cd2bde3d7f085b64e549c985f4bb928cad7e8ecf5323bfca320db548d81b39", size = 453021, upload-time = "2026-07-23T01:53:43.749Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -16,6 +74,15 @@ name = "asciitree"
 version = "0.3.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2d/6a/885bc91484e1aa8f618f6f0228d76d0e67000b0fdd6090673b777e311913/asciitree-0.3.3.tar.gz", hash = "sha256:4aa4b9b649f85e3fcb343363d97564aa1fb62e249677f2e18a96765145cc0f6e", size = 3951, upload-time = "2016-09-05T19:10:42.681Z" }
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
 
 [[package]]
 name = "cbor2"
@@ -64,6 +131,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
     { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
     { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -154,6 +233,31 @@ wheels = [
 ]
 
 [[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/03/077f869d540370db12165c0aa51640a873fb661d8b315d1d4d67b284d7ac/frozenlist-1.8.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:09474e9831bc2b2199fad6da3c14c7b0fbdd377cce9d3d77131be28906cb7d84", size = 86912, upload-time = "2025-10-06T05:35:45.98Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b5/7610b6bd13e4ae77b96ba85abea1c8cb249683217ef09ac9e0ae93f25a91/frozenlist-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:17c883ab0ab67200b5f964d2b9ed6b00971917d5d8a92df149dc2c9779208ee9", size = 50046, upload-time = "2025-10-06T05:35:47.009Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ef/0e8f1fe32f8a53dd26bdd1f9347efe0778b0fddf62789ea683f4cc7d787d/frozenlist-1.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fa47e444b8ba08fffd1c18e8cdb9a75db1b6a27f17507522834ad13ed5922b93", size = 50119, upload-time = "2025-10-06T05:35:48.38Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b1/71a477adc7c36e5fb628245dfbdea2166feae310757dea848d02bd0689fd/frozenlist-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2552f44204b744fba866e573be4c1f9048d6a324dfe14475103fd51613eb1d1f", size = 231067, upload-time = "2025-10-06T05:35:49.97Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7e/afe40eca3a2dc19b9904c0f5d7edfe82b5304cb831391edec0ac04af94c2/frozenlist-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:957e7c38f250991e48a9a73e6423db1bb9dd14e722a10f6b8bb8e16a0f55f695", size = 233160, upload-time = "2025-10-06T05:35:51.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/aa/7416eac95603ce428679d273255ffc7c998d4132cfae200103f164b108aa/frozenlist-1.8.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8585e3bb2cdea02fc88ffa245069c36555557ad3609e83be0ec71f54fd4abb52", size = 228544, upload-time = "2025-10-06T05:35:53.246Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/3d/2a2d1f683d55ac7e3875e4263d28410063e738384d3adc294f5ff3d7105e/frozenlist-1.8.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:edee74874ce20a373d62dc28b0b18b93f645633c2943fd90ee9d898550770581", size = 243797, upload-time = "2025-10-06T05:35:54.497Z" },
+    { url = "https://files.pythonhosted.org/packages/78/1e/2d5565b589e580c296d3bb54da08d206e797d941a83a6fdea42af23be79c/frozenlist-1.8.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c9a63152fe95756b85f31186bddf42e4c02c6321207fd6601a1c89ebac4fe567", size = 247923, upload-time = "2025-10-06T05:35:55.861Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/c3/65872fcf1d326a7f101ad4d86285c403c87be7d832b7470b77f6d2ed5ddc/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b6db2185db9be0a04fecf2f241c70b63b1a242e2805be291855078f2b404dd6b", size = 230886, upload-time = "2025-10-06T05:35:57.399Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/76/ac9ced601d62f6956f03cc794f9e04c81719509f85255abf96e2510f4265/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:f4be2e3d8bc8aabd566f8d5b8ba7ecc09249d74ba3c9ed52e54dc23a293f0b92", size = 245731, upload-time = "2025-10-06T05:35:58.563Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/49/ecccb5f2598daf0b4a1415497eba4c33c1e8ce07495eb07d2860c731b8d5/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:c8d1634419f39ea6f5c427ea2f90ca85126b54b50837f31497f3bf38266e853d", size = 241544, upload-time = "2025-10-06T05:35:59.719Z" },
+    { url = "https://files.pythonhosted.org/packages/53/4b/ddf24113323c0bbcc54cb38c8b8916f1da7165e07b8e24a717b4a12cbf10/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:1a7fa382a4a223773ed64242dbe1c9c326ec09457e6b8428efb4118c685c3dfd", size = 241806, upload-time = "2025-10-06T05:36:00.959Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/fb/9b9a084d73c67175484ba2789a59f8eebebd0827d186a8102005ce41e1ba/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:11847b53d722050808926e785df837353bd4d75f1d494377e59b23594d834967", size = 229382, upload-time = "2025-10-06T05:36:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/95/a3/c8fb25aac55bf5e12dae5c5aa6a98f85d436c1dc658f21c3ac73f9fa95e5/frozenlist-1.8.0-cp311-cp311-win32.whl", hash = "sha256:27c6e8077956cf73eadd514be8fb04d77fc946a7fe9f7fe167648b0b9085cc25", size = 39647, upload-time = "2025-10-06T05:36:03.409Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/f5/603d0d6a02cfd4c8f2a095a54672b3cf967ad688a60fb9faf04fc4887f65/frozenlist-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:ac913f8403b36a2c8610bbfd25b8013488533e71e62b4b4adce9c86c8cea905b", size = 44064, upload-time = "2025-10-06T05:36:04.368Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/16/c2c9ab44e181f043a86f9a8f84d5124b62dbcb3a02c0977ec72b9ac1d3e0/frozenlist-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:d4d3214a0f8394edfa3e303136d0575eece0745ff2b47bd2cb2e66dd92d4351a", size = 39937, upload-time = "2025-10-06T05:36:05.669Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
 name = "fsspec"
 version = "2026.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -162,10 +266,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
 ]
 
+[package.optional-dependencies]
+http = [
+    { name = "aiohttp" },
+]
+
 [[package]]
 name = "gsplat"
 version = "1.5.3"
-source = { git = "https://github.com/nerfstudio-project/gsplat.git?rev=a337c3dcaca733ddc3e16bdc156c536aaf5e19ba#a337c3dcaca733ddc3e16bdc156c536aaf5e19ba" }
+source = { git = "https://github.com/nerfstudio-project/gsplat.git?rev=608e19ad1657815b685a14f1735ac830838c240e#608e19ad1657815b685a14f1735ac830838c240e" }
 dependencies = [
     { name = "jaxtyping" },
     { name = "ninja" },
@@ -257,6 +366,16 @@ dependencies = [
 [package.optional-dependencies]
 render = [
     { name = "gsplat" },
+    { name = "nvdiffrast" },
+]
+training = [
+    { name = "gsplat" },
+    { name = "lpips" },
+    { name = "nvdiffrast" },
+    { name = "pytorch-lightning" },
+    { name = "safetensors" },
+    { name = "torchmetrics" },
+    { name = "wandb" },
 ]
 
 [package.dev-dependencies]
@@ -269,27 +388,35 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "einops", specifier = "==0.8.1" },
-    { name = "gsplat", marker = "extra == 'render'", git = "https://github.com/nerfstudio-project/gsplat.git?rev=a337c3dcaca733ddc3e16bdc156c536aaf5e19ba" },
+    { name = "gsplat", marker = "extra == 'render'", git = "https://github.com/nerfstudio-project/gsplat.git?rev=608e19ad1657815b685a14f1735ac830838c240e" },
+    { name = "gsplat", marker = "extra == 'training'", git = "https://github.com/nerfstudio-project/gsplat.git?rev=608e19ad1657815b685a14f1735ac830838c240e" },
     { name = "huggingface-hub", specifier = "==0.36.2" },
+    { name = "lpips", marker = "extra == 'training'", specifier = "==0.1.4" },
     { name = "numcodecs", specifier = "==0.11.0" },
     { name = "numpy", specifier = "==1.26.4" },
+    { name = "nvdiffrast", marker = "extra == 'render'", git = "https://github.com/NVlabs/nvdiffrast.git?rev=253ac4fcea7de5f396371124af597e6cc957bfae" },
+    { name = "nvdiffrast", marker = "extra == 'training'", git = "https://github.com/NVlabs/nvdiffrast.git?rev=253ac4fcea7de5f396371124af597e6cc957bfae" },
     { name = "nvidia-ncore", specifier = "==18.7.0" },
     { name = "pandas", specifier = "==2.3.3" },
     { name = "pillow", specifier = "==12.2.0" },
     { name = "point-cloud-utils", specifier = "==0.34.0" },
     { name = "pydantic", specifier = "==2.8.2" },
+    { name = "pytorch-lightning", marker = "extra == 'training'", specifier = "==2.6.5" },
     { name = "pyyaml", specifier = "==6.0" },
+    { name = "safetensors", marker = "extra == 'training'", specifier = "==0.6.2" },
     { name = "scipy", specifier = "==1.11.1" },
     { name = "shortuuid", specifier = "==1.0.11" },
     { name = "torch", specifier = "==2.7.0+cu128", index = "https://download.pytorch.org/whl/cu128" },
     { name = "torch-scatter", specifier = "==2.1.2", index = "https://data.pyg.org/whl/torch-2.7.0+cu128.html" },
+    { name = "torchmetrics", marker = "extra == 'training'", specifier = "==1.7.0" },
     { name = "torchvision", specifier = "==0.22.0+cu128", index = "https://download.pytorch.org/whl/cu128" },
     { name = "tqdm", specifier = "==4.66.3" },
     { name = "universal-pathlib", specifier = "==0.3.6" },
     { name = "urllib3", specifier = ">=2.7.0" },
+    { name = "wandb", marker = "extra == 'training'", specifier = "==0.28.2" },
     { name = "zarr", specifier = "==2.18.2" },
 ]
-provides-extras = ["render"]
+provides-extras = ["render", "training"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -320,6 +447,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "lightning-utilities"
+version = "0.15.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/45/7fa8f56b17dc0f0a41ec70dd307ecd6787254483549843bef4c30ab5adce/lightning_utilities-0.15.3.tar.gz", hash = "sha256:792ae0204c79f6859721ac7f386c237a33b0ed06ba775009cb894e010a842033", size = 33553, upload-time = "2026-02-22T14:48:53.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/f4/ead6e0e37209b07c9baa3e984ccdb0348ca370b77cea3aaea8ddbb097e00/lightning_utilities-0.15.3-py3-none-any.whl", hash = "sha256:6c55f1bee70084a1cbeaa41ada96e4b3a0fea5909e844dd335bd80f5a73c5f91", size = 31906, upload-time = "2026-02-22T14:48:52.488Z" },
+]
+
+[[package]]
+name = "lpips"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "torch" },
+    { name = "torchvision" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/2d/4b8148d32f5bd461eb7d5daa54fcc998f86eaa709a57f4ef6aa4c62f024f/lpips-0.1.4.tar.gz", hash = "sha256:3846331df6c69688aec3d300a5eeef6c529435bc8460bd58201c3d62e56188fa", size = 18029, upload-time = "2021-08-25T22:10:32.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/13/1df50c7925d9d2746702719f40e864f51ed66f307b20ad32392f1ad2bb87/lpips-0.1.4-py3-none-any.whl", hash = "sha256:fd537af5828b69d2e6ffc0a397bd506dbc28ca183543617690844c08e102ec5e", size = 53763, upload-time = "2021-08-25T22:10:31.257Z" },
 ]
 
 [[package]]
@@ -381,6 +537,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "multidict"
+version = "6.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/f1/a90635c4f88fb913fbf4ce660b83b7445b7a02615bda034b2f8eb38fd597/multidict-6.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7ff981b266af91d7b4b3793ca3382e53229088d193a85dfad6f5f4c27fc73e5d", size = 76626, upload-time = "2026-01-26T02:43:26.485Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9b/267e64eaf6fc637a15b35f5de31a566634a2740f97d8d094a69d34f524a4/multidict-6.7.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:844c5bca0b5444adb44a623fb0a1310c2f4cd41f402126bb269cd44c9b3f3e1e", size = 44706, upload-time = "2026-01-26T02:43:27.607Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a4/d45caf2b97b035c57267791ecfaafbd59c68212004b3842830954bb4b02e/multidict-6.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f2a0a924d4c2e9afcd7ec64f9de35fcd96915149b2216e1cb2c10a56df483855", size = 44356, upload-time = "2026-01-26T02:43:28.661Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d2/0a36c8473f0cbaeadd5db6c8b72d15bbceeec275807772bfcd059bef487d/multidict-6.7.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8be1802715a8e892c784c0197c2ace276ea52702a0ede98b6310c8f255a5afb3", size = 244355, upload-time = "2026-01-26T02:43:31.165Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/16/8c65be997fd7dd311b7d39c7b6e71a0cb449bad093761481eccbbe4b42a2/multidict-6.7.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e2d2ed645ea29f31c4c7ea1552fcfd7cb7ba656e1eafd4134a6620c9f5fdd9e", size = 246433, upload-time = "2026-01-26T02:43:32.581Z" },
+    { url = "https://files.pythonhosted.org/packages/01/fb/4dbd7e848d2799c6a026ec88ad39cf2b8416aa167fcc903baa55ecaa045c/multidict-6.7.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:95922cee9a778659e91db6497596435777bd25ed116701a4c034f8e46544955a", size = 225376, upload-time = "2026-01-26T02:43:34.417Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8a/4a3a6341eac3830f6053062f8fbc9a9e54407c80755b3f05bc427295c2d0/multidict-6.7.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6b83cabdc375ffaaa15edd97eb7c0c672ad788e2687004990074d7d6c9b140c8", size = 257365, upload-time = "2026-01-26T02:43:35.741Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a2/dd575a69c1aa206e12d27d0770cdf9b92434b48a9ef0cd0d1afdecaa93c4/multidict-6.7.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:38fb49540705369bab8484db0689d86c0a33a0a9f2c1b197f506b71b4b6c19b0", size = 254747, upload-time = "2026-01-26T02:43:36.976Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/56/21b27c560c13822ed93133f08aa6372c53a8e067f11fbed37b4adcdac922/multidict-6.7.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:439cbebd499f92e9aa6793016a8acaa161dfa749ae86d20960189f5398a19144", size = 246293, upload-time = "2026-01-26T02:43:38.258Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/23466059dc3854763423d0ad6c0f3683a379d97673b1b89ec33826e46728/multidict-6.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d3bc717b6fe763b8be3f2bee2701d3c8eb1b2a8ae9f60910f1b2860c82b6c49", size = 242962, upload-time = "2026-01-26T02:43:40.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/67/51dd754a3524d685958001e8fa20a0f5f90a6a856e0a9dcabff69be3dbb7/multidict-6.7.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:619e5a1ac57986dbfec9f0b301d865dddf763696435e2962f6d9cf2fdff2bb71", size = 237360, upload-time = "2026-01-26T02:43:41.752Z" },
+    { url = "https://files.pythonhosted.org/packages/64/3f/036dfc8c174934d4b55d86ff4f978e558b0e585cef70cfc1ad01adc6bf18/multidict-6.7.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0b38ebffd9be37c1170d33bc0f36f4f262e0a09bc1aac1c34c7aa51a7293f0b3", size = 245940, upload-time = "2026-01-26T02:43:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/20/6214d3c105928ebc353a1c644a6ef1408bc5794fcb4f170bb524a3c16311/multidict-6.7.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:10ae39c9cfe6adedcdb764f5e8411d4a92b055e35573a2eaa88d3323289ef93c", size = 253502, upload-time = "2026-01-26T02:43:44.371Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e2/c653bc4ae1be70a0f836b82172d643fcf1dade042ba2676ab08ec08bff0f/multidict-6.7.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:25167cc263257660290fba06b9318d2026e3c910be240a146e1f66dd114af2b0", size = 247065, upload-time = "2026-01-26T02:43:45.745Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/11/a854b4154cd3bd8b1fd375e8a8ca9d73be37610c361543d56f764109509b/multidict-6.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:128441d052254f42989ef98b7b6a6ecb1e6f708aa962c7984235316db59f50fa", size = 241870, upload-time = "2026-01-26T02:43:47.054Z" },
+    { url = "https://files.pythonhosted.org/packages/13/bf/9676c0392309b5fdae322333d22a829715b570edb9baa8016a517b55b558/multidict-6.7.1-cp311-cp311-win32.whl", hash = "sha256:d62b7f64ffde3b99d06b707a280db04fb3855b55f5a06df387236051d0668f4a", size = 41302, upload-time = "2026-01-26T02:43:48.753Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/68/f16a3a8ba6f7b6dc92a1f19669c0810bd2c43fc5a02da13b1cbf8e253845/multidict-6.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:bdbf9f3b332abd0cdb306e7c2113818ab1e922dc84b8f8fd06ec89ed2a19ab8b", size = 45981, upload-time = "2026-01-26T02:43:49.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/9dd5305253fa00cd3c7555dbef69d5bf4133debc53b87ab8d6a44d411665/multidict-6.7.1-cp311-cp311-win_arm64.whl", hash = "sha256:b8c990b037d2fff2f4e33d3f21b9b531c5745b33a49a7d6dbe7a177266af44f6", size = 43159, upload-time = "2026-01-26T02:43:51.635Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
 ]
 
 [[package]]
@@ -456,6 +639,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/df/a0/4e0f14d847cfc2a633a1c8621d00724f3206cfeddeb66d35698c4e2cf3d2/numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a", size = 18093567, upload-time = "2024-02-05T23:54:11.696Z" },
     { url = "https://files.pythonhosted.org/packages/d2/b7/a734c733286e10a7f1a8ad1ae8c90f2d33bf604a96548e0a4a3a6739b468/numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20", size = 5968812, upload-time = "2024-02-05T23:54:26.453Z" },
     { url = "https://files.pythonhosted.org/packages/3f/6b/5610004206cf7f8e7ad91c5a85a8c71b2f2f8051a0c0c4d5916b76d6cbb2/numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2", size = 15811913, upload-time = "2024-02-05T23:54:53.933Z" },
+]
+
+[[package]]
+name = "nvdiffrast"
+version = "0.4.0"
+source = { git = "https://github.com/NVlabs/nvdiffrast.git?rev=253ac4fcea7de5f396371124af597e6cc957bfae#253ac4fcea7de5f396371124af597e6cc957bfae" }
+dependencies = [
+    { name = "numpy" },
 ]
 
 [[package]]
@@ -615,6 +806,18 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -680,6 +883,15 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.11.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/d7/e7bfbc86e9f99ff7807e24de7703f032e9c9ba80bb355cf26e0e9bc5a75e/platformdirs-4.11.3.tar.gz", hash = "sha256:66a73d38a849810252df809a3d8bcbda8e26f6c189920e7535ad608a48dbb5ab", size = 33050, upload-time = "2026-08-13T22:43:27.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/a9/c34aebedd3a4c9afe5101b1b8713710b3fec18087c8a36c35d2f909861bd/platformdirs-4.11.3-py3-none-any.whl", hash = "sha256:5ed065d443751de711da036041a7a214122efc4a4de393b3f4137ba5576540e7", size = 23491, upload-time = "2026-08-13T22:43:26.121Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -702,6 +914,47 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/43/01/5e9b22c025bc556f16cc5ff7d6979e3ed8d04b2784abc19a3c84dd04227b/point_cloud_utils-0.34.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:59cd4591183fd38cc032d43213f4be4fe85f305fa45aea0454db3bf9548df08d", size = 6878205, upload-time = "2025-04-14T23:32:37.27Z" },
     { url = "https://files.pythonhosted.org/packages/ad/42/f46fe08797d3f8cc6e4e91659d3ab83fe531b3eb4eecc9e44cd8756bb0fb/point_cloud_utils-0.34.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1ecef3ef1ce43a332d20da73b34d079a50ae0fd1b51f39b7eef509740f69cf2", size = 9762532, upload-time = "2025-04-14T23:32:39.098Z" },
     { url = "https://files.pythonhosted.org/packages/17/da/b12b2c7b9d6b9611b33c6c9c2f93d74d1b225bcc88c55a7b8494a8162c69/point_cloud_utils-0.34.0-cp311-cp311-win_amd64.whl", hash = "sha256:40469bc373765586e4f18940ccff17f9f90db53e9f5c4d238f2c6932d3ff2544", size = 5424127, upload-time = "2025-04-14T23:32:41.163Z" },
+]
+
+[[package]]
+name = "propcache"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/44/c87281c333769159c50594f22610f77398a47ccbfbbf23074e744e86f87c/propcache-0.5.2.tar.gz", hash = "sha256:01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427", size = 50208, upload-time = "2026-05-08T21:02:12.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/f1/8a8cc1c2c7e7934ab77e0163414f736fadbc0f5e8dd9673b952355ac175b/propcache-0.5.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:74b70780220e2dd89175ca24b81b68b67c83db499ae611e7f2313cb329801c78", size = 90744, upload-time = "2026-05-08T20:59:45.799Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f4/651b1225e976bd1a2ba5cfba0c29d096581c2636b437e3a9a7ab6276270a/propcache-0.5.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a4840ab0ae0216d952f4b53dc6d0b992bfc2bedbfe360bdd9b548bc184c08959", size = 52033, upload-time = "2026-05-08T20:59:47.408Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a8/8ede85d6aa1f79fc7dc2f8fd2c8d65920b8272c3892903c8a1affde48cfb/propcache-0.5.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c6844ba6364fb12f403928a82cfd295ab103a2b315c77c747b2dbe4a41894ea7", size = 52754, upload-time = "2026-05-08T20:59:49.202Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/fe/b3551b41bbc2f5b5bb088fc6920567cd43101253e68fbaa261339eb96fe1/propcache-0.5.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2293949b855ce597f2826452d17c2d545fb5622379c4ea6fdf525e9b8e8a2511", size = 57573, upload-time = "2026-05-08T20:59:50.778Z" },
+    { url = "https://files.pythonhosted.org/packages/83/27/ab851ebd1b7172e3e161f5f8d39e315d54a91bea246f01f4d872d3376aef/propcache-0.5.2-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0fd59b5af35f74da48d905dcbad55449ba13be91823cb05a9bd590bbf5b61660", size = 60645, upload-time = "2026-05-08T20:59:52.227Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/466b3d18022e9897cbda9c735c493c5bd747d7a4c6f5ea1480b4cec434b6/propcache-0.5.2-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:29f9309a2e42b0d273be006fdb4be2d6c39a47f6f57d8fb1cf9f81481df81b66", size = 61563, upload-time = "2026-05-08T20:59:53.866Z" },
+    { url = "https://files.pythonhosted.org/packages/27/1b/16ab7f2cf2041da2f60d156ba64c2484eadf9168075b4ff43c3ef60045af/propcache-0.5.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5aaa2b923c1944ac8febd6609cb373540a5563e7cbcb0fd770f75dace2eb817b", size = 58888, upload-time = "2026-05-08T20:59:55.457Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/67/bb777ffd907633563bf35fd859c4ce97b0512c32f4633cf5d1eb7c33512b/propcache-0.5.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66ea454f095ddf5b6b14f56c064c0941c4788be11e18d2464cf643bf7203ff67", size = 59253, upload-time = "2026-05-08T20:59:57.075Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/42/64f8d90b73fd9cdc1499b48057ff6d9cd2a98a25734c9bb62ecf07e87061/propcache-0.5.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:95f1e3f4760d404b13c9976c0229b2b49a3c8e2c62a9ce92efdd2b11ada75e3f", size = 57558, upload-time = "2026-05-08T20:59:58.602Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/02/dba5bc03c9041f2092ea55a449caf5dfe68352c6654511b29ba0654ddb69/propcache-0.5.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:85341b12b9d55bad0bded24cac341bb34289469e03a11f3f583ea1cc1db0326c", size = 55007, upload-time = "2026-05-08T20:59:59.837Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c0/43f649c7aa2a77a3b100d84e9dea3a483120ecb608bfe36ce49eaff517fe/propcache-0.5.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:26a4dca084132874e639895c3135dfad5eb20bae209f62d1aeb31b03e601c3c0", size = 60355, upload-time = "2026-05-08T21:00:01.144Z" },
+    { url = "https://files.pythonhosted.org/packages/83/c0/435dafd27f1cb4a495381dae60e25883ccfe4020bb72818e8184c1678092/propcache-0.5.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3b199b9b2b3d6a7edf3183ba8a9a137a22b97f7df525feb5ae1eccf026d2a9c6", size = 59057, upload-time = "2026-05-08T21:00:02.401Z" },
+    { url = "https://files.pythonhosted.org/packages/53/ae/6e292df9135d659944e96cb3389258e4a663e5b2b5f6c217ef0ddc8d2f73/propcache-0.5.2-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:e59bc9e66329185b93dab73f210f1a37f81cb40f321501db8017c9aea15dba27", size = 61938, upload-time = "2026-05-08T21:00:03.638Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/42/314ebc50d8159055411fd6b0bda322ff510e4b1f7d2e4927940ad0f6af20/propcache-0.5.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:552ffadf6ad409844bc5919c42a0a83d88314cedddaea0e41e80a8b8fffe881f", size = 59731, upload-time = "2026-05-08T21:00:04.881Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/9b/2da6dee38871c3c8772fabc2758325a5c9077d6d18c597737dc04dd884cd/propcache-0.5.2-cp311-cp311-win32.whl", hash = "sha256:cd416c1de191973c52ff1a12a57446bfc7642797b282d7caf2162d7d1b8aa9a0", size = 38966, upload-time = "2026-05-08T21:00:06.511Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4e/f17363fb58c0afe05b067361cb6d86ed2d29de6506779a27547c4d183075/propcache-0.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:44e488ef40dbb452700b2b1f8188934121f6648f52c295055662d2191959ff82", size = 42135, upload-time = "2026-05-08T21:00:08.088Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/eb/6af6685077d22e8b33358d3c548e3282706a0b3cd85044ffba4e5dd08e3b/propcache-0.5.2-cp311-cp311-win_arm64.whl", hash = "sha256:54adaa85a22078d1e306304a40984dc5be99d599bf3dc0a24dc98f7daeab89ab", size = 38381, upload-time = "2026-05-08T21:00:09.692Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
 ]
 
 [[package]]
@@ -793,6 +1046,25 @@ wheels = [
 ]
 
 [[package]]
+name = "pytorch-lightning"
+version = "2.6.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fsspec", extra = ["http"] },
+    { name = "lightning-utilities" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "torch" },
+    { name = "torchmetrics" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/2c/8e73a3929b4c4bd600cafd38a97aaf7242a8cf518fb9f33d27c274ec898f/pytorch_lightning-2.6.5.tar.gz", hash = "sha256:1c32cefa76a1a9c4c5250338272d961d1e48b180e68396849efe128538ddb28e", size = 661673, upload-time = "2026-05-27T14:33:41.961Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/4d/5740c27110b83634d8491c3b5facf0111b3e554c3164f4fb953be9bddaf6/pytorch_lightning-2.6.5-py3-none-any.whl", hash = "sha256:62d9c8549b2278fedc3364f0a5607a56c6063d18635008f8cf3fae8d802b0d76", size = 852407, upload-time = "2026-05-27T14:33:39.856Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2026.2"
 source = { registry = "https://pypi.org/simple" }
@@ -870,6 +1142,28 @@ wheels = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/cc/738f3011628920e027a11754d9cae9abec1aed00f7ae860abbf843755233/safetensors-0.6.2.tar.gz", hash = "sha256:43ff2aa0e6fa2dc3ea5524ac7ad93a9839256b8703761e76e2d0b2a3fa4f15d9", size = 197968, upload-time = "2025-08-08T13:13:58.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/b1/3f5fd73c039fc87dba3ff8b5d528bfc5a32b597fea8e7a6a4800343a17c7/safetensors-0.6.2-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9c85ede8ec58f120bad982ec47746981e210492a6db876882aa021446af8ffba", size = 454797, upload-time = "2025-08-08T13:13:52.066Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c9/bb114c158540ee17907ec470d01980957fdaf87b4aa07914c24eba87b9c6/safetensors-0.6.2-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:d6675cf4b39c98dbd7d940598028f3742e0375a6b4d4277e76beb0c35f4b843b", size = 432206, upload-time = "2025-08-08T13:13:50.931Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8e/f70c34e47df3110e8e0bb268d90db8d4be8958a54ab0336c9be4fe86dac8/safetensors-0.6.2-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d2d2b3ce1e2509c68932ca03ab8f20570920cd9754b05063d4368ee52833ecd", size = 473261, upload-time = "2025-08-08T13:13:41.259Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/f5/be9c6a7c7ef773e1996dc214e73485286df1836dbd063e8085ee1976f9cb/safetensors-0.6.2-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:93de35a18f46b0f5a6a1f9e26d91b442094f2df02e9fd7acf224cfec4238821a", size = 485117, upload-time = "2025-08-08T13:13:43.506Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/55/23f2d0a2c96ed8665bf17a30ab4ce5270413f4d74b6d87dd663258b9af31/safetensors-0.6.2-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:89a89b505f335640f9120fac65ddeb83e40f1fd081cb8ed88b505bdccec8d0a1", size = 616154, upload-time = "2025-08-08T13:13:45.096Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c6/affb0bd9ce02aa46e7acddbe087912a04d953d7a4d74b708c91b5806ef3f/safetensors-0.6.2-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fc4d0d0b937e04bdf2ae6f70cd3ad51328635fe0e6214aa1fc811f3b576b3bda", size = 520713, upload-time = "2025-08-08T13:13:46.25Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/5d/5a514d7b88e310c8b146e2404e0dc161282e78634d9358975fd56dfd14be/safetensors-0.6.2-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8045db2c872db8f4cbe3faa0495932d89c38c899c603f21e9b6486951a5ecb8f", size = 485835, upload-time = "2025-08-08T13:13:49.373Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/7b/4fc3b2ba62c352b2071bea9cfbad330fadda70579f617506ae1a2f129cab/safetensors-0.6.2-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:81e67e8bab9878bb568cffbc5f5e655adb38d2418351dc0859ccac158f753e19", size = 521503, upload-time = "2025-08-08T13:13:47.651Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/50/0057e11fe1f3cead9254315a6c106a16dd4b1a19cd247f7cc6414f6b7866/safetensors-0.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b0e4d029ab0a0e0e4fdf142b194514695b1d7d3735503ba700cf36d0fc7136ce", size = 652256, upload-time = "2025-08-08T13:13:53.167Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/29/473f789e4ac242593ac1656fbece6e1ecd860bb289e635e963667807afe3/safetensors-0.6.2-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:fa48268185c52bfe8771e46325a1e21d317207bcabcb72e65c6e28e9ffeb29c7", size = 747281, upload-time = "2025-08-08T13:13:54.656Z" },
+    { url = "https://files.pythonhosted.org/packages/68/52/f7324aad7f2df99e05525c84d352dc217e0fa637a4f603e9f2eedfbe2c67/safetensors-0.6.2-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:d83c20c12c2d2f465997c51b7ecb00e407e5f94d7dec3ea0cc11d86f60d3fde5", size = 692286, upload-time = "2025-08-08T13:13:55.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/cad1d9762868c7c5dc70c8620074df28ebb1a8e4c17d4c0cb031889c457e/safetensors-0.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d944cea65fad0ead848b6ec2c37cc0b197194bec228f8020054742190e9312ac", size = 655957, upload-time = "2025-08-08T13:13:57.029Z" },
+    { url = "https://files.pythonhosted.org/packages/59/a7/e2158e17bbe57d104f0abbd95dff60dda916cf277c9f9663b4bf9bad8b6e/safetensors-0.6.2-cp38-abi3-win32.whl", hash = "sha256:cab75ca7c064d3911411461151cb69380c9225798a20e712b102edda2542ddb1", size = 308926, upload-time = "2025-08-08T13:14:01.095Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c3/c0be1135726618dc1e28d181b8c442403d8dbb9e273fd791de2d4384bcdd/safetensors-0.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:c7b214870df923cbc1593c3faee16bec59ea462758699bd3fee399d00aac072c", size = 320192, upload-time = "2025-08-08T13:13:59.467Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.11.1"
 source = { registry = "https://pypi.org/simple" }
@@ -884,6 +1178,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/46/1d255bb55e63de02f7b2f3a2f71b59b840db21d61ff7cd41edbfc2da448a/scipy-1.11.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b4bb943010203465ac81efa392e4645265077b4d9e99b66cf3ed33ae12254173", size = 36242335, upload-time = "2023-06-28T21:59:45.937Z" },
     { url = "https://files.pythonhosted.org/packages/6c/b2/137a6596e8169baa80404cd5b39f0a2e0f2854cb325b1ed4e53646c4f904/scipy-1.11.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:249cfa465c379c9bb2c20123001e151ff5e29b351cbb7f9c91587260602c58d0", size = 36466412, upload-time = "2023-06-28T22:01:32.643Z" },
     { url = "https://files.pythonhosted.org/packages/04/b8/947f40706ee2e316fd1a191688f690c4c2b351c2d043fe9deb9b7940e36e/scipy-1.11.1-cp311-cp311-win_amd64.whl", hash = "sha256:ffb28e3fa31b9c376d0fb1f74c1f13911c8c154a760312fbee87a21eb21efe31", size = 43950897, upload-time = "2023-06-28T22:03:50.053Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.68.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/94/23b7dd072acb9628907bd3f4fbf61794a7b12a9db8f33c1276f70ae5ac92/sentry_sdk-2.68.0.tar.gz", hash = "sha256:648c58e9887311a03470a41539e24bdbbf64a30ca4f5336f7e3dcc87276400b3", size = 1008854, upload-time = "2026-08-13T09:06:21.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/9b/e2421d08956d0bc4691d995393d835e563886bff499d8fb10fdefae85a8d/sentry_sdk-2.68.0-py3-none-any.whl", hash = "sha256:538e56c2d03679d42f7c0cb5f1af73a7a510b00abc7e296c13ac49b107b713a4", size = 518670, upload-time = "2026-08-13T09:06:19.735Z" },
 ]
 
 [[package]]
@@ -986,6 +1293,21 @@ wheels = [
 ]
 
 [[package]]
+name = "torchmetrics"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lightning-utilities" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/99/3a28bc2be4f562b9aae5b3557ec4c6cbcfcdd0a7d2a6fcb1ab44e7c55334/torchmetrics-1.7.0.tar.gz", hash = "sha256:7a26d5cb73a6ae51ab5cb514aa4dc0543af7287a507719986a06e15df12ea68b", size = 564173, upload-time = "2025-03-20T19:12:01.289Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/1d/dbbb54743865bad58a9adc7ac2c9bedd28bc76253cb8ec4b69765ccc8190/torchmetrics-1.7.0-py3-none-any.whl", hash = "sha256:39a72cf40c8452e041f5315b997ef811c2baaae01478131cf6ed9813f553a668", size = 960916, upload-time = "2025-03-20T19:11:58.841Z" },
+]
+
+[[package]]
 name = "torchvision"
 version = "0.22.0+cu128"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
@@ -1082,6 +1404,65 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1e/67/cbae4bf7683a64755c2c1778c418fea96d00e34395bb91743f08bd951571/wadler_lindig-0.1.7.tar.gz", hash = "sha256:81d14d3fe77d441acf3ebd7f4aefac20c74128bf460e84b512806dccf7b2cd55", size = 15842, upload-time = "2025-06-18T07:00:42.843Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl", hash = "sha256:e3ec83835570fd0a9509f969162aeb9c65618f998b1f42918cfc8d45122fe953", size = 20516, upload-time = "2025-06-18T07:00:41.684Z" },
+]
+
+[[package]]
+name = "wandb"
+version = "0.28.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sentry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/41/c2eb0e25e0504287442f0829a5dc380669b683f78068c79220acc626383f/wandb-0.28.2.tar.gz", hash = "sha256:9dba560ce076f96a0033a0d2898d97cba651fc95fec7274fd09920bae8aec5cf", size = 41011367, upload-time = "2026-08-12T01:34:20.484Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/d9/8fb47c6c0b6e70378fc2b5da6dfba5d1d3178366a06bd7e672c3249964c3/wandb-0.28.2-py3-none-macosx_12_0_arm64.whl", hash = "sha256:f9aa4037d18168dd4e804ff8213100c4a3ebe3e52b5f29463bbc7fadcaadff75", size = 26716653, upload-time = "2026-08-12T01:33:58.338Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/a7/6690491966e46409bfe770b73bdb1952fb6a59988b9e8c72c748f4ca080c/wandb-0.28.2-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:b3830781cb93a29ad91a736d3bc5763312e782467432ee432fd731f408708991", size = 28649923, upload-time = "2026-08-12T01:34:01.22Z" },
+    { url = "https://files.pythonhosted.org/packages/03/46/e69c813d88f37f77da92cfd9c63e1e9b5ce70834b0f420f876c66590353f/wandb-0.28.2-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:0c475c6b93d57e0455f3d1323e323927696502e6af7ee15e389a552114edacff", size = 27385453, upload-time = "2026-08-12T01:34:03.876Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/7f/f3e23a2ff01848d7a5adab9f307992b92ef99c5e6bff2bd89cd46d651e3a/wandb-0.28.2-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:1db698d107871c66b2dcbb0cf4dc2af1ddb159ba94e957e890158ec60ab2de54", size = 29622780, upload-time = "2026-08-12T01:34:06.621Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1d/e087f71898ebfa86f68264e91f44ee5b8106823f09e2644043e3f1d5fe49/wandb-0.28.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:86e017d3f38bb99374de4d991a2ea0e6e71722164918585b3dea66190b28d0eb", size = 27425107, upload-time = "2026-08-12T01:34:09.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/58/3f7a624c880d7b9e60b4a000b0bb751c20244d0bcc002d3ff683cf828651/wandb-0.28.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:81468f5c00b5453a2a1d3c7ca7a18056c52a85fa4df60299052cb96829d81b11", size = 29851453, upload-time = "2026-08-12T01:34:12.133Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a3/b680c7518b0dc7eb236e7ef3bcc0994d0fabc67bbef1b73878dee196fc1e/wandb-0.28.2-py3-none-win_amd64.whl", hash = "sha256:ae5c2591214565be9f085c3b7838ee4a89344ae0c8dc06030425def08b6191aa", size = 26800272, upload-time = "2026-08-12T01:34:14.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/5a/a323653c6989c565b2138ddd7421ef30b47ea2849a62d0181534772b56da/wandb-0.28.2-py3-none-win_arm64.whl", hash = "sha256:23a4b9ac74f211836b71b27ba33bb217977a6b4cdc927e33eb5b12de143dd727", size = 24484327, upload-time = "2026-08-12T01:34:17.46Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.24.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/33/ebe9e3d1f86c7a0b51094c0a146392045ca1631d2664889539dec8088a33/yarl-1.24.5.tar.gz", hash = "sha256:e81b83143bee16329c23db3c1b2d82b29892fcbcb849186d2f6e98a5abe9a57f", size = 228679, upload-time = "2026-07-20T02:07:45.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/db/3cb5df059756a45761cc3dee8fd25ec82b83a6585ea3542b969fda850f99/yarl-1.24.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2c1fe720934a16ea8e7146175cba2126f87f54912c8c5435e7f7c7a51ef808d3", size = 135043, upload-time = "2026-07-20T02:04:52.39Z" },
+    { url = "https://files.pythonhosted.org/packages/44/f8/767d6bd5a03db63bc467df2fb56d6fafeae9667d74aea92cd6af399f828b/yarl-1.24.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c687ed078e145f5fd53a14854beff320e1d2ab76df03e2009c98f39a0f68f39a", size = 96942, upload-time = "2026-07-20T02:04:54.26Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/97/10b939c44d7b28d1dbc389cfc7012306d1ea8dba01eaef44b39fffaee52a/yarl-1.24.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:709f1efed56c4a145793c046cd4939f9959bcd818979a787b77d8e09c57a0840", size = 97046, upload-time = "2026-07-20T02:04:56.638Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7a/b410dbe39b6255c55fb2a2bcee96eb844d0789235ddc381a889a90dc72d6/yarl-1.24.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:874019bd513008b009f58657134e5d0c5e030b3559bd0553976837adf52fe966", size = 110512, upload-time = "2026-07-20T02:04:58.955Z" },
+    { url = "https://files.pythonhosted.org/packages/83/c7/da591971f78a5617e1f21f5699858ebccd836fe181a6493788ffc91ba69b/yarl-1.24.5-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a4582acf7ef76482f6f511ebaf1946dae7f2e85ec4728b81a678c01df63bd723", size = 102454, upload-time = "2026-07-20T02:05:00.623Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8e/73b0ed4de47289a78a96045d76d1cfe5e41848bf0da59ce25b2ec87ee05d/yarl-1.24.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2cabe6546e41dabe439999a23fcb5246e0c3b595b4315b96ef755252be90caeb", size = 117617, upload-time = "2026-07-20T02:05:02.325Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/14/b744747bc4f57a8d55bd744df463457524583e1e9f7538b5ace0346ab92e/yarl-1.24.5-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:17f57620f5475b3c69109376cc87e42a7af5db13c9398e4292772a706ff10780", size = 116135, upload-time = "2026-07-20T02:05:04.05Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ca/95aa4d0e5b7ea4f20e4d577c42d001ed9df207569fdb063cc5ed4ebb496b/yarl-1.24.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:570fec8fbd22b032733625f03f10b7ff023bc399213db15e72a7acaef28c2f4e", size = 111935, upload-time = "2026-07-20T02:05:05.738Z" },
+    { url = "https://files.pythonhosted.org/packages/72/0d/d2ad8d6b147832d177a4e720ba1962fe686eb0913b74503b3eca094b8bba/yarl-1.24.5-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5fede79c6f73ff2c3ef822864cb1ada23196e62756df53bc6231d351a49516a2", size = 110010, upload-time = "2026-07-20T02:05:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/50/18/eb335e4120903903f4865041355ae46256a2406eb2865bc24827f4f27b61/yarl-1.24.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8ccf9aca873b767977c73df497a85dbedee4ee086ae9ae49dc461333b9b79f58", size = 110058, upload-time = "2026-07-20T02:05:09.246Z" },
+    { url = "https://files.pythonhosted.org/packages/44/70/97353add32c62ad6f206d948ac5a5ee84398225e534dc6ed6433d1b335b6/yarl-1.24.5-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:ad5d8201d310b031e6cd839d9bac2d4e5a01533ce5d3d5b50b7de1ef3af1de61", size = 103308, upload-time = "2026-07-20T02:05:11.31Z" },
+    { url = "https://files.pythonhosted.org/packages/68/39/5e7398d4b6f6b3c9062823ebc60802df5b272e3fe9e788f9734c6ee46c85/yarl-1.24.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:841f0852f48fefea3b12c9dfec00704dfa3aef5215d0e3ce564bb3d7cd8d57c6", size = 116898, upload-time = "2026-07-20T02:05:13.099Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c9/09e52f2239e8b96357eccca05915382e4ba5405ebfb623b6036040d99654/yarl-1.24.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:9baafc71b04f8f4bb0703b21d6fc9f0c30b346c636a532ff16ec8491a5ea4b1f", size = 109400, upload-time = "2026-07-20T02:05:14.821Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6a/e94133d4c2d1a14d2384310bf3e79d9cf32c9d1eae1c6f034fb80d098fa1/yarl-1.24.5-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d897129df1a22b12aeed2c2c98df0785a2e8e6e0bde87b389491d0025c187077", size = 115934, upload-time = "2026-07-20T02:05:17.78Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/3c/34955ed967b976fc38edcbb6d538dee79dbda4cb7fc7f72a0907a7c78e0f/yarl-1.24.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:dd625535328fd9882374356269227670189adfcc6a2d90284f323c05862eecbd", size = 112178, upload-time = "2026-07-20T02:05:19.675Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/46/d7bd3a8859d47dcfaffd7127af7076032a7da278a9a02e17b5f37bfb6712/yarl-1.24.5-cp311-cp311-win_amd64.whl", hash = "sha256:f4239bbec5a3577ddb49e4b50aeb32d8e5792098262ae2f63723f916a29b1a25", size = 97544, upload-time = "2026-07-20T02:05:21.523Z" },
+    { url = "https://files.pythonhosted.org/packages/01/69/c1bfd21e32c638974ea2c542a0b8c53ef1fa9eff336020f5d014f9503ff2/yarl-1.24.5-cp311-cp311-win_arm64.whl", hash = "sha256:3ac6aff147deb9c09461b2d4bbdf6256831198f5d8a23f5d37138213090b6d8a", size = 93359, upload-time = "2026-07-20T02:05:23.493Z" },
+    { url = "https://files.pythonhosted.org/packages/61/02/962c1cbfc401a30c1d034dc67ff395f64b52302c6d62de556c1fca99acc0/yarl-1.24.5-py3-none-any.whl", hash = "sha256:a33700d13d9b7d84fd10947b09ff69fb9a792e519c8cb9764a3ca70baa6c23a7", size = 58612, upload-time = "2026-07-20T02:07:43.461Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add a standalone two-phase training pipeline for calibrated NCore V4 data, including example configurations, supervision, losses, differentiable rendering, optimizer scheduling, and documentation
- add deterministic invalid-sample retry, distributed-safe experiment logging, and exact checkpoint/resume and preemption handling
- add regression coverage for normalization, seeded sampling, renderer tensor contracts and post-processing order, and masked RGB loss

## Validation

- `uv lock --check`
- `ruff check --no-cache .`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q tests` — 616 passed
- completed one local single-GPU context step and one rendering step

## Scope

This change supports the dense front-camera two-phase path. Other model
families and variable-camera curricula remain unsupported. The GPU smoke test
covers one step only; it does not establish renderer-kernel bitwise
equivalence, distributed convergence, or final model quality.
